### PR TITLE
Update newest Scala 2.13 to 2.13.18 and 3 to 3.7.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,8 +23,8 @@ val versions = new {
   val scala3 = "3.3.7"
 
   // Versions we can compile tests against if needed, to check for regressions.
-  val scala213Newest = "2.13.17"
-  val scala3Newest = "3.7.3"
+  val scala213Newest = "2.13.18"
+  val scala3Newest = "3.7.4"
 
   // Which versions should be cross-compiled for publishing.
   val scalas = List(scala213, scala3)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -93,8 +93,8 @@ extra:
   scala:
     2_13: "2.13.16"
     3:    "3.3.7"
-    newest_2_13: "2.13.17"
-    newest_3:    "3.7.3"
+    newest_2_13: "2.13.18"
+    newest_3:    "3.7.4"
   libraries:
     kindProjector:    "0.13.4"
     munit:            "1.2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the "newest" Scala versions to 2.13.18 and 3.7.4 in build config and docs.
> 
> - **Build**:
>   - Update `versions.scala213Newest` to `2.13.18` and `versions.scala3Newest` to `3.7.4` in `build.sbt`.
> - **Docs**:
>   - Sync `extra.scala.newest_2_13` and `extra.scala.newest_3` in `docs/mkdocs.yml` to `2.13.18` and `3.7.4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7e9dcd407933d37dd8a1eefb8a047314a5d7d37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->