### PR TITLE
Update newest Scala 3 to 3.8.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This document provides guidelines for AI agents (like Claude Code, GitHub Copilo
 **Hearth** is the first Scala macros' standard library, designed to make macro development easier and more maintainable across Scala 2.13 and Scala 3.
 
 - **Language**: Scala (pure Scala library)
-- **Scala Versions**: 2.13.16, 3.3.7 (primary); 2.13.18, 3.8.0-RC3 (regression testing)
+- **Scala Versions**: 2.13.16, 3.3.7 (primary); 2.13.18, 3.8.1 (regression testing)
 - **Platforms**: JVM, Scala.js, Scala Native
 - **Build Tool**: SBT (but see restrictions below)
 - **License**: Apache 2.0

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ val versions = new {
 
   // Versions we can compile tests against if needed, to check for regressions.
   val scala213Newest = "2.13.18"
-  val scala3Newest = "3.8.0-RC5"
+  val scala3Newest = "3.8.1"
 
   // Which versions should be cross-compiled for publishing.
   val scalas = List(scala213, scala3)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -95,7 +95,7 @@ extra:
     2_13: "2.13.16"
     3:    "3.3.7"
     newest_2_13: "2.13.18"
-    newest_3:    "3.7.4"
+    newest_3:    "3.8.1"
   libraries:
     kindProjector:    "0.13.4"
     munit:            "1.2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the "newest" Scala 3 reference used for regression testing and documentation.
> 
> - Set `versions.scala3Newest` to `3.8.1` in `build.sbt`
> - Update `newest_3` to `"3.8.1"` in `docs/mkdocs.yml`
> - Refresh `AGENTS.md` project overview to list `3.8.1` for regression testing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e3ae7c42408820be01ecc436c45998f7f10dcfe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->