### PR TITLE
Fix found MIO, MState and VarDefsCache errors

### DIFF
--- a/hearth-micro-fp/src/main/scala/hearth/fp/DirectStyle.scala
+++ b/hearth-micro-fp/src/main/scala/hearth/fp/DirectStyle.scala
@@ -58,6 +58,10 @@ object DirectStyle {
   final class RunSafe[F[_]](directStyle: DirectStyle[F]) {
     def apply[A](value: => F[A]): A = directStyle.runUnsafe(this.asOwner)(value)
     private[DirectStyle] def asOwner: ScopeOwner[F] = this.asInstanceOf[ScopeOwner[F]]
+
+    // For debugging purposes
+    private lazy val id = counter.getAndIncrement()
+    override def toString: String = s"RunSafe($id)"
   }
 
   /** When we use nested direct style operations, we need a way to distinct who is the managing which `runSafe`. Scope
@@ -133,4 +137,6 @@ object DirectStyle {
         case Success(value) => value
       }
   }
+
+  private val counter = new java.util.concurrent.atomic.AtomicLong(1L)
 }

--- a/hearth-micro-fp/src/main/scala/hearth/fp/effect/DirectStyleExecutor.scala
+++ b/hearth-micro-fp/src/main/scala/hearth/fp/effect/DirectStyleExecutor.scala
@@ -12,14 +12,22 @@ private[fp] object DirectStyleExecutor {
     * @since 0.1.0
     */
   def apply[A](thunk: => A): A =
-    Await.result(
-      scala.concurrent.Future {
-        scala.concurrent.blocking {
-          thunk
-        }
-      },
-      duration.Duration.Inf
-    )
+    Await
+      .result(
+        scala.concurrent.Future {
+          scala.concurrent.blocking {
+            try
+              Right(thunk)
+            catch {
+              // Catch _everything_ including fatal errors to rethrow them outside,
+              // to prevent hanging infinitely on e.g. DirectStyle's `PassError` OR `hearthRequirementFailed`.
+              case e: Throwable => Left(e)
+            }
+          }
+        },
+        duration.Duration.Inf
+      )
+      .fold(throw _, identity)
 
   /** Virtual threads are only avilable on JVM and only from JDK 17+.
     *
@@ -28,61 +36,66 @@ private[fp] object DirectStyleExecutor {
     * @since 0.1.0
     */
   implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService {
-    try {
+    try
       //  Use virtual thread from JDK 17+ if available
-      val method = classOf[java.util.concurrent.Executors].getDeclaredMethod("newVirtualThreadPerTaskExecutor")
-      method.setAccessible(true)
-      method.invoke(null).asInstanceOf[java.util.concurrent.ExecutorService]
-    } catch {
-      case _: Throwable =>
-        // Fallback to normal thread if virtual threads are not available
-        new AbstractExecutorService with AutoCloseable {
-
-          private val factory = new ThreadFactory {
-            override def newThread(r: Runnable): Thread = new Thread(r, "Hearth MIO direct-style runner")
-          }
-          private val shutdownFlag = new java.util.concurrent.atomic.AtomicBoolean(false)
-          private val phaser = new Phaser(1) // self
-
-          override def execute(command: Runnable): Unit = {
-            if (isShutdown) throw new RejectedExecutionException("Executor is shut down")
-            phaser.register()
-            val wrapped = new Runnable {
-              override def run(): Unit =
-                try command.run()
-                finally ignore(phaser.arriveAndDeregister())
-            }
-            val t = factory.newThread(wrapped)
-            t.start()
-          }
-
-          // ---- lifecycle ----
-          override def shutdown(): Unit =
-            if (shutdownFlag.compareAndSet(false, true))
-              ignore(phaser.arriveAndDeregister())
-
-          override def shutdownNow(): java.util.List[Runnable] = {
-            shutdown()
-            java.util.Collections.emptyList()
-          }
-
-          override def isShutdown: Boolean = shutdownFlag.get()
-          override def isTerminated: Boolean = isShutdown && phaser.isTerminated
-
-          override def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = {
-            if (!isShutdown) return false
-            val phase = phaser.getPhase
-            try {
-              phaser.awaitAdvanceInterruptibly(phase, timeout, unit)
-              true
-            } catch {
-              case _: TimeoutException     => false
-              case e: InterruptedException => throw e
-            }
-          }
-
-          override def close(): Unit = shutdown()
-        }
+      newVirtualThreadPerTaskExecutor()
+    catch {
+      // Fallback to normal thread if virtual threads are not available
+      case _: Throwable => new FallbackExecutor
     }
+  }
+
+  private def newVirtualThreadPerTaskExecutor(): ExecutorService = {
+    val method = classOf[java.util.concurrent.Executors].getDeclaredMethod("newVirtualThreadPerTaskExecutor")
+    method.setAccessible(true)
+    method.invoke(null).asInstanceOf[java.util.concurrent.ExecutorService]
+  }
+
+  private class FallbackExecutor extends AbstractExecutorService with AutoCloseable {
+
+    private val factory = new ThreadFactory {
+      override def newThread(r: Runnable): Thread = new Thread(r, "Hearth MIO direct-style runner")
+    }
+    private val shutdownFlag = new java.util.concurrent.atomic.AtomicBoolean(false)
+    private val phaser = new Phaser(1) // self
+
+    override def execute(command: Runnable): Unit = {
+      if (isShutdown) throw new RejectedExecutionException("Executor is shut down")
+      phaser.register()
+      val wrapped = new Runnable {
+        override def run(): Unit =
+          try command.run()
+          finally ignore(phaser.arriveAndDeregister())
+      }
+      val t = factory.newThread(wrapped)
+      t.start()
+    }
+
+    // ---- lifecycle ----
+    override def shutdown(): Unit =
+      if (shutdownFlag.compareAndSet(false, true))
+        ignore(phaser.arriveAndDeregister())
+
+    override def shutdownNow(): java.util.List[Runnable] = {
+      shutdown()
+      java.util.Collections.emptyList()
+    }
+
+    override def isShutdown: Boolean = shutdownFlag.get()
+    override def isTerminated: Boolean = isShutdown && phaser.isTerminated
+
+    override def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = {
+      if (!isShutdown) return false
+      val phase = phaser.getPhase
+      try {
+        phaser.awaitAdvanceInterruptibly(phase, timeout, unit)
+        true
+      } catch {
+        case _: TimeoutException     => false
+        case e: InterruptedException => throw e
+      }
+    }
+
+    override def close(): Unit = shutdown()
   }
 }

--- a/hearth-micro-fp/src/main/scala/hearth/fp/effect/MLocal.scala
+++ b/hearth-micro-fp/src/main/scala/hearth/fp/effect/MLocal.scala
@@ -23,6 +23,9 @@ final class MLocal[A] private (
   def get: MIO[A] = MIO.get(this)
 
   def set(a: A): MIO[Unit] = MIO.set(this, a)
+
+  private val version = new java.util.concurrent.atomic.AtomicLong(1L)
+  private[effect] def nextVersion: Long = version.getAndIncrement()
 }
 
 object MLocal {

--- a/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
@@ -53,6 +53,8 @@ final private class ExprsFixtures(val c: blackbox.Context) extends MacroCommonsS
 
   def testValDefBuilderBuildCachedVarGetterSetterImpl: c.Expr[Data] = testValDefBuilderBuildCachedVarGetterSetter
 
+  def testValDefsCacheMergeImpl: c.Expr[Unit] = testValDefsCacheMerge
+
   def testLambdaBuilderOfNAndBuildImpl: c.Expr[Data] = testLambdaBuilderOfNAndBuild
 
   def testLambdaBuilderBuildWithImpl: c.Expr[Data] = testLambdaBuilderBuildWith
@@ -107,6 +109,8 @@ object ExprsFixtures {
 
   def testValDefBuilderBuildCachedVarGetterSetter: Data =
     macro ExprsFixtures.testValDefBuilderBuildCachedVarGetterSetterImpl
+
+  def testValDefsCacheMerge: Unit = macro ExprsFixtures.testValDefsCacheMergeImpl
 
   def testLambdaBuilderOfNAndBuild: Data = macro ExprsFixtures.testLambdaBuilderOfNAndBuildImpl
 

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
@@ -89,6 +89,10 @@ object ExprsFixtures {
   private def testValDefBuilderBuildCachedVarGetterSetterImpl(using q: Quotes): Expr[Data] =
     new ExprsFixtures(q).testValDefBuilderBuildCachedVarGetterSetter
 
+  inline def testValDefsCacheMerge: Unit = ${ testValDefsCacheMergeImpl }
+  private def testValDefsCacheMergeImpl(using q: Quotes): Expr[Unit] =
+    new ExprsFixtures(q).testValDefsCacheMerge
+
   inline def testLambdaBuilderOfNAndBuild: Data = ${ testLambdaBuilderOfNAndBuildImpl }
   private def testLambdaBuilderOfNAndBuildImpl(using q: Quotes): Expr[Data] =
     new ExprsFixtures(q).testLambdaBuilderOfNAndBuild

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -287,6 +287,14 @@ final class ExprsSpec extends MacroSuite {
           "setterExists" -> Data(true)
         )
       }
+
+      test("methods ValDefsCache.merge should allow merging ValDefsCache") {
+        import ExprsFixtures.testValDefsCacheMerge
+
+        @scala.annotation.nowarn // suppress "unused method" errors - we want to check whethere these compile, not use them
+        val result = testValDefsCacheMerge
+        result ==> ()
+      }
     }
 
     group("type LambdaBuilder") {

--- a/hearth-tests/src/test/scalajvm/hearth/fp/effect/MioSpec.scala
+++ b/hearth-tests/src/test/scalajvm/hearth/fp/effect/MioSpec.scala
@@ -296,6 +296,18 @@ final class MioSpec extends ScalaCheckSuite with Laws {
 
       countdown(n) === MIO.void
     }
+
+    test("should not hang infinitely on FatalErrors") {
+      val error = new OutOfMemoryError("Out of memory")
+
+      MIO
+        .scoped { runSafe =>
+          runSafe(MIO.fail(error).as(10))
+        }
+        .unsafe
+        .runSync
+        ._2 === Left(NonEmptyVector(error))
+    }
   }
 
   group("Instances for MIO") {

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -1637,7 +1637,21 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
               )
             }
             // $COVERAGE-ON$
-            (key, value1)
+            (value1.definition, value2.definition) match {
+              // Forwarding after declaration should be a safe no-op
+              case (Some(_), None) => (key, value1)
+              // Declaration after forwarding should keep declaration
+              case (None, Some(_)) => (key, value2)
+              case _               =>
+                // $COVERAGE-OFF$
+                if (value1.definition != value2.definition) {
+                  hearthRequirementFailed(
+                    s"Def with key $key already exists with different definition, you probably created it twice in 2 branches, without noticing"
+                  )
+                }
+                // $COVERAGE-ON$
+                (key, value1)
+            }
           case (Some(value), None) => (key, value)
           case (None, Some(value)) => (key, value)
           // $COVERAGE-OFF$

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -3056,7 +3056,21 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
               )
             }
             // $COVERAGE-ON$
-            (key, value1)
+            (value1.definition, value2.definition) match {
+              // Forwarding after declaration should be a safe no-op
+              case (Some(_), None) => (key, value1)
+              // Declaration after forwarding should keep declaration
+              case (None, Some(_)) => (key, value2)
+              case _               =>
+                // $COVERAGE-OFF$
+                if value1.definition != value2.definition then {
+                  hearthRequirementFailed(
+                    s"Def with key $key already exists with different definition, you probably created it twice in 2 branches, without noticing"
+                  )
+                }
+                // $COVERAGE-ON$
+                (key, value1)
+            }
           case (Some(value), None) => (key, value)
           case (None, Some(value)) => (key, value)
           case (None, None)        => ??? // impossible


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core effect/state-merging logic (`MIO` direct style and `MLocal` versioning), which can subtly affect macro execution semantics; changes are covered by new targeted tests for hangs, nested scopes, and cache merging.
> 
> **Overview**
> Fixes `MIO` direct-style execution so failures (including *fatal* `Throwable`s) are surfaced instead of hanging, and so nested `MIO.scoped` calls correctly preserve/merge `MState`/`MLocal` updates.
> 
> Switches `MState`’s local conflict resolution from time-based `System.nanoTime` ordering to per-`MLocal` versioning, and adds small performance guards for `empty` state merges.
> 
> Adjusts `ValDefsCache.merge` (Scala 2/3) to treat “forward-declared” vs defined entries as a safe merge (keep the defined one), and adds compile-time tests covering cache merge behavior and nested `scoped` state handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1955482dfd12c8e3447240052b15e77e15a89e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->