### PR TITLE
Fixing Expr/Type ownership on Scala 3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ log.cross-quotes = false
     git log
     git branch
     git show
+    sbt --client "..."
     ```
 
  - ❌ **forbidden operations**:
@@ -100,10 +101,10 @@ log.cross-quotes = false
     git rebase
     git merge
     git reset --hard
-    sbt
-    ``` 
+    sbt          # bare sbt without --client is forbidden
+    ```
 
- - **prefer working with MCP server**, it allows for:
+ - **prefer working with MCP server** when available, it allows for:
 
     - **Compilation**: Request compilation through MCP tools
     - **Testing**: Run tests through MCP tools
@@ -111,9 +112,10 @@ log.cross-quotes = false
     - **Code navigation**: Find definitions, references, implementations
     - **Type information**: Query types at specific positions
 
- - **only if MCP server is inaccessible OR it would not be enough** (the task requires implementation of both Scala 2 and Scala 3 code, while MCP exposes only 1 of them)
-   **ask user for permission to use `sbt --client`** - always call it with `--client` as sbt startup is expensive and kills the feedback loop, **never run it without it**
- - **do not modify `dev.properties`** - it's primarly used by the developer to focus on working on one platform in their IDE without the issues related to shared sources
+ - **use `sbt --client` when MCP is insufficient** — e.g. when the task requires both Scala 2 and Scala 3
+   (MCP exposes only 1 version at a time), or when MCP is down. Always use `--client` flag as sbt startup
+   is expensive and kills the feedback loop — **never run bare `sbt` without `--client`**
+ - **do not modify `dev.properties`** - it's primarily used by the developer to focus on working on one platform in their IDE without the issues related to shared sources
    (IDE not being able to identify whether source file should be treated as a part of Scala 2 project or Scala 3 project, JVM or JS or Native)
 
 ### Finding the MCP Server Address
@@ -204,6 +206,26 @@ but an agent was not able to run the compilation and tests (e.g. because GitHub 
 prevents downloading artifacts), it should inform user that any PR they would attempt to make
 will be closed immediatelly.
 
+## Bug Fix Workflow
+
+For the complete bug-fix workflow (reproduce → fix → verify), see [Instruction for fixing a bug](docs/contributing/instruction-for-fixing-a-bug.md).
+
+**Quick reference — clean commands by changed module** (all using `sbt --client`):
+
+| What changed | Clean commands |
+|---|---|
+| `hearth-better-printers` | `hearthBetterPrinters/clean ; hearthBetterPrinters3/clean ; hearthCrossQuotes/clean ; hearthCrossQuotes3/clean ; hearth/clean ; hearth3/clean ; quick-clean` |
+| `hearth-cross-quotes` | `hearthCrossQuotes/clean ; hearthCrossQuotes3/clean ; hearth/clean ; hearth3/clean ; quick-clean` |
+| `hearth` | `hearth/clean ; hearth3/clean ; quick-clean` |
+| `hearth-tests` only | `quick-clean` |
+
+**Key reminders:**
+- Always clean after macro changes — incremental compilation does NOT re-expand macros
+- `quick-clean` then `quick-test` is the standard verify cycle
+- MCP supports only 1 Scala version at a time — use `sbt --client` for the other version
+
 ## Skills
 
 Are available in [contributing documentation](docs/contributing/_index.md).
+
+The bug fix workflow is documented in [instruction for fixing a bug](docs/contributing/instruction-for-fixing-a-bug.md).

--- a/docs/contributing/_index.md
+++ b/docs/contributing/_index.md
@@ -34,7 +34,14 @@ Ideally, each such example should be a snippet (or a group of snippets) that can
 [Instruction for testing documentation snippets](instruction-for-testing-documentation-snippets.md).
 
 
-## Instructions for fixing compilation errors
+## Instructions for fixing bugs and compilation errors
+
+### Instruction for fixing a bug (end-to-end workflow)
+
+Complete workflow for reproducing bugs with failing tests, applying fixes, and verifying them.
+Covers clean/compile/test cycles, incremental compilation gotchas, and MCP limitations.
+
+[Instruction for fixing a bug](instruction-for-fixing-a-bug.md).
 
 ### Instruction for fixing `':' expected but identifier found.`
 

--- a/docs/contributing/_index.md
+++ b/docs/contributing/_index.md
@@ -111,3 +111,23 @@ forward reference to value ... defined on line ... extends over definition of va
 ```
 
 [Instruction for fixing `forward reference to value` caused by implicit](instruction-for-fixing-forward-reference-to-value.md).
+
+### Instruction for fixing ScopeException in Scala 3 caused by raw quotes
+
+When code in Scala 3 platform-specific files uses raw `'{ ... }` or `${ ... }` (as opposed to `Expr.quote` / `Expr.splice`)
+inside a closure that may execute in a nested Quotes context, the expansion fails with a `ScopeException`.
+
+**Example error:**
+```
+[error] .../SomeFile.scala:42:9: Cannot call `asTerm` on an `Expr` that was defined in a different `Quotes` context.
+```
+or
+```
+scala.quoted.runtime.impl.ScopeException:
+  Cannot call `asTerm` on an `Expr` that was defined in a different `Quotes` context.
+```
+
+The fix is to wrap the closure body with `withQuotes { ... }`, which provides `CrossQuotes.ctx[Quotes]` (the
+dynamically current Quotes) as the implicit, replacing the stale class-level one.
+
+[Instruction for fixing ScopeException in Scala 3 caused by raw quotes](instruction-for-fixing-scope-exception-in-scala-3-caused-by-raw-quotes.md).

--- a/docs/contributing/instruction-for-fixing-a-bug.md
+++ b/docs/contributing/instruction-for-fixing-a-bug.md
@@ -20,6 +20,7 @@ Use `compileErrors(...)` to test compilation failures, or standard assertions (`
    - Type names like `someValue.Underlying` in generated code (Scala 3) → [Cross-Quotes undetected implicit (Scala 3)](instruction-for-fixing-cross-quotes-errors-on-scala-3-caused-by-undetected-implicit.md)
    - `':' expected but identifier found.` → [Colon expected error](instruction-for-fixing-colon-expected-but-identifier-found.md)
    - `forward reference to value` → [Forward reference error](instruction-for-fixing-forward-reference-to-value.md)
+   - `ScopeException: Cannot call ... on an Expr that was defined in a different Quotes context` → [ScopeException from raw quotes](instruction-for-fixing-scope-exception-in-scala-3-caused-by-raw-quotes.md) (`ScopeException` might be hidden)
 
 
 ## Step 2 — Reproduce with a failing test

--- a/docs/contributing/instruction-for-fixing-a-bug.md
+++ b/docs/contributing/instruction-for-fixing-a-bug.md
@@ -1,0 +1,184 @@
+# Instruction for fixing a bug (end-to-end workflow)
+
+This instruction covers the complete cycle of reproducing a bug with a failing test, applying a fix, and verifying the fix works.
+
+**Key principle:** A "failing test" may mean either a runtime assertion failure OR code that does not compile.
+Use `compileErrors(...)` to test compilation failures, or standard assertions (`<==>`) for incorrect behavior.
+
+## Step 1 — Understand the bug
+
+1. **Read the GitHub issue** carefully, including all comments — the root cause is sometimes different from the initial description
+2. **Identify the affected module(s):**
+   - `hearth-better-printers` — AST printing / quasiquote generation
+   - `hearth-cross-quotes` — `Expr.quote`/`Expr.splice`/`Type.of` cross-platform macro support
+   - `hearth` — main library utilities
+   - `hearth-micro-fp` — FP utilities (rarely buggy)
+3. **Identify the affected Scala version(s):** 2.13, 3, or both
+4. **Check if the issue matches a known error pattern** — if so, use the dedicated instruction:
+   - Compilation error with path `hearth/<macro>:...` → [Cross-Quotes errors caused by Better-Printers](instruction-for-fixing-cross-quotes-errors-on-scala-2-caused-by-better-printers.md)
+   - Type names like `someValue.Underlying` in generated code (Scala 2) → [Cross-Quotes undetected implicit (Scala 2)](instruction-for-fixing-cross-quotes-errors-on-scala-2-caused-by-undetected-implicit.md)
+   - Type names like `someValue.Underlying` in generated code (Scala 3) → [Cross-Quotes undetected implicit (Scala 3)](instruction-for-fixing-cross-quotes-errors-on-scala-3-caused-by-undetected-implicit.md)
+   - `':' expected but identifier found.` → [Colon expected error](instruction-for-fixing-colon-expected-but-identifier-found.md)
+   - `forward reference to value` → [Forward reference error](instruction-for-fixing-forward-reference-to-value.md)
+
+
+## Step 2 — Reproduce with a failing test
+
+### Where to place the test
+
+Follow the rules from [guidelines for tests](guidelines-for-tests.md):
+
+ - Shared (both Scala versions, all platforms): `hearth-tests/src/test/scala/`
+ - Scala 2 only: `hearth-tests/src/test/scala-2/`
+ - Scala 3 only: `hearth-tests/src/test/scala-3/`
+ - JVM only: `hearth-tests/src/test/scalajvm/`
+
+### Writing the test
+
+**Prefer extending an existing fixture** over creating a new one when the bug relates to existing functionality.
+For example, if the bug is about `Expr.quote` behavior, extend `CrossExprsFixturesImpl.scala` rather than creating a new fixture.
+
+**If a new fixture IS needed**, follow the 3-level pattern:
+
+1. `*FixturesImpl.scala` in `hearth-tests/src/main/scala/` — cross-compiled macro logic using `hearth.data.Data`
+2. `*Fixtures.scala` in `hearth-tests/src/main/scala-2/` — Scala 2 macro adapter
+3. `*Fixtures.scala` in `hearth-tests/src/main/scala-3/` — Scala 3 inline macro adapter
+
+**For bugs where code does not compile** (the bug IS a compilation error):
+
+```scala
+compileErrors(
+  """
+  // code that triggers the bug
+  """
+).arePresent() // confirms the bug exists
+```
+
+or to verify a specific error message:
+
+```scala
+compileErrors(
+  """
+  // code that triggers the bug
+  """
+).check(
+  "expected error text"
+)
+```
+
+**For bugs where code compiles but produces wrong output:**
+
+```scala
+SomeFixtures.testSomething(...) <==> Data.map(
+  "expected" -> Data("value")
+)
+```
+
+### New test classes
+
+If a new test file is needed, place example types and fixture data in `hearth-tests/src/main/` (not `src/test/`),
+and the test spec in `hearth-tests/src/test/`. Ask the user if you are unsure about whether a new test class is needed.
+
+
+## Step 3 — Clean and verify the test fails
+
+**Always clean after writing a test that exercises macros** — incremental compilation does NOT re-expand macros
+when their implementation changes, and it may not detect new test fixtures either.
+
+### Clean commands by changed module
+
+All commands use `sbt --client`:
+
+| What changed | Minimum clean commands (Scala 2.13 + 3) |
+|---|---|
+| `hearth-better-printers` | `hearthBetterPrinters/clean ; hearthBetterPrinters3/clean ; hearthCrossQuotes/clean ; hearthCrossQuotes3/clean ; hearth/clean ; hearth3/clean ; quick-clean` |
+| `hearth-cross-quotes` | `hearthCrossQuotes/clean ; hearthCrossQuotes3/clean ; hearth/clean ; hearth3/clean ; quick-clean` |
+| `hearth` | `hearth/clean ; hearth3/clean ; quick-clean` |
+| `hearth-tests` only (new test/fixture) | `quick-clean` |
+
+Note: `quick-clean` cleans `hearthTests`, `hearthTests3`, `hearthSandwichTests`, `hearthSandwichTests3`.
+
+Then run tests for the affected Scala version:
+
+```bash
+sbt --client "hearthTests/test"    # Scala 2.13
+sbt --client "hearthTests3/test"   # Scala 3
+```
+
+**Confirm the new test fails as expected** before moving to the fix.
+
+
+## Step 4 — Apply the fix
+
+ - Make the fix in the appropriate module
+ - Follow the dedicated instruction docs if the error pattern matches one of the known cases (see Step 1)
+ - If working on `hearth-better-printers` or `hearth-cross-quotes`, remember the dependency chain:
+   `hearth-better-printers` → `hearth-cross-quotes` → `hearth` → `hearth-tests`
+
+
+## Step 5 — Clean and verify the fix works
+
+Apply the **same clean commands** from Step 3 (the module chain is the same or larger if you changed additional modules).
+
+Run the **full quick-test** to verify nothing is broken:
+
+```bash
+sbt --client "quick-clean"
+sbt --client "quick-test"
+```
+
+This runs `hearthTests/test ; hearthTests3/test ; hearthSandwichTests/test ; hearthSandwichTests3/test` after cleaning all JVM test modules.
+
+If only one Scala version is affected, you may test just that version first for a faster feedback loop, but **always
+run `quick-test` as the final check** before considering the work done.
+
+
+## Incremental compilation gotchas
+
+ - **Always clean after macro changes** — incremental compilation does NOT re-expand macros when their
+   implementation changes. You WILL get stale results if you skip cleaning.
+
+ - **Dual cleaning is often needed:** hearth itself expands macros from `hearth-cross-quotes`. If you change
+   `cross-quotes`, you must clean `hearth` (to re-expand macros in the library code) AND `hearth-tests`
+   (to re-expand macros that consume the library).
+
+ - **When in doubt:** `quick-clean` then `quick-test` — this cleans all JVM test modules and runs all JVM tests.
+
+ - **Nuclear option** (if behavior seems wrong despite clean):
+
+   ```bash
+   sbt --client "hearthBetterPrinters/clean ; hearthBetterPrinters3/clean ; hearthCrossQuotes/clean ; hearthCrossQuotes3/clean ; hearthMicroFp/clean ; hearthMicroFp3/clean ; hearth/clean ; hearth3/clean ; quick-clean"
+   sbt --client "quick-test"
+   ```
+
+
+## MCP limitations
+
+ - The MCP server exposes only **one Scala version** at a time (controlled by `dev.properties`)
+ - For bugs affecting one version: use MCP for that version when possible, then verify with `sbt --client` for the other
+ - For testing both versions: use `sbt --client` directly — it compiles and tests both Scala 2.13 and 3
+ - **Never change `dev.properties` yourself** — ask the user if a MCP version switch is needed
+
+
+## Cross-quotes and macro-agnostic APIs
+
+Code in hearth uses `Expr`, `Type`, etc. from **hearth's own API**, NOT `scala.quoted.Expr` or `c.Expr`.
+Specifically:
+
+ - `Expr.quote { ... Expr.splice { ... } }` is hearth's cross-platform alternative to Scala 3 quotes/splices
+   and Scala 2 quasiquotes
+ - When writing test fixtures, use hearth's API (traits from `hearth.typed`, `hearth.crossquotes`, etc.)
+ - The implementation traits mix in `MacroTypedCommons` or similar base traits that provide the cross-platform API
+
+
+## Cross-quotes / better-printers specific gotchas
+
+ - On Scala 2, `cross-quotes` uses `better-printers` to generate quasiquotes — bugs in printing result
+   in invalid generated code
+ - Errors with path `hearth/<macro>:...` indicate generated quasiquote issues
+   (see [instruction for fixing Cross-Quotes errors caused by Better-Printers](instruction-for-fixing-cross-quotes-errors-on-scala-2-caused-by-better-printers.md))
+ - The full dependency chain for cross-quotes fixes is:
+   `hearth-better-printers` → `hearth-cross-quotes` → `hearth` → `hearth-tests`
+ - Debug logging: ask the user to set `log.cross-quotes = true` in `dev.properties`,
+   or use the `isOurCulprit` pattern in `CrossQuotesMacros.scala`
+   (see [instruction for debugging a macro](instruction-for-debugging-a-macro.md))

--- a/docs/contributing/instruction-for-fixing-scope-exception-in-scala-3-caused-by-raw-quotes.md
+++ b/docs/contributing/instruction-for-fixing-scope-exception-in-scala-3-caused-by-raw-quotes.md
@@ -1,0 +1,192 @@
+# Instruction for fixing ScopeException in Scala 3 caused by raw quotes
+
+When code in `ExprsScala3.scala` uses raw Scala 3 quotation syntax (`'{ ... }` or `${ ... }`) inside a closure
+that may execute in a **nested Quotes context**, the expansion fails at compile time with a `ScopeException`.
+
+## Recognizing the issue
+
+**Error message (at the call site that expands the macro):**
+```
+[error] .../SomeFile.scala:42:9: Cannot call `asTerm` on an `Expr` that was defined in a different `Quotes` context.
+```
+or
+```
+scala.quoted.runtime.impl.ScopeException:
+  Cannot call `asTerm` on an `Expr` that was defined in a different `Quotes` context.
+```
+
+**Key symptom:**
+- The error comes from Scala 3 macro expansion (not Scala 2)
+- It references a `Quotes` scope mismatch
+- It occurs in code that uses raw `'{ ... }` or `${ ... }` (as opposed to `Expr.quote { ... }` / `Expr.splice { ... }`)
+- It typically appears inside a **closure** that is stored and invoked later, when the `Quotes` context has changed
+
+**Not this issue if:**
+- The error is on Scala 2 (Scala 2 does not have `Quotes` scoping)
+- The code only uses `Expr.quote` / `Expr.splice` / `Type.of` (these go through `CrossQuotes` and handle scope automatically)
+- The raw quote is used at top level (not inside a closure)
+
+
+## What causes it
+
+Hearth manages Quotes contexts through `CrossQuotes`. The flow is:
+
+1. The class-level implicit `Quotes` (Q0) comes from `MacroCommonsScala3`
+2. `Expr.splice` calls `CrossQuotes.nestedCtx`, which pushes a new Quotes context (Q1) onto a stack
+3. Code inside the splice runs with Q1 as the "current" context
+4. `CrossQuotes.ctx[Quotes]` retrieves the current context from the stack
+
+**`Expr.quote` / `Expr.splice`** are transformed by the `CrossQuotesPlugin` compiler plugin to automatically
+use `CrossQuotes.ctx` and wrap splices with `CrossQuotes.nestedCtx`. They are scope-safe.
+
+**Raw `'{ ... }` / `${ ... }`** are NOT transformed by the plugin. They resolve `Quotes` through normal
+implicit resolution, which finds Q0 (the class-level implicit). If the raw quote executes inside a nested context
+(Q1), the `Expr`/`Term` values it produces belong to Q0, but the surrounding code expects Q1. This mismatch
+causes `ScopeException`.
+
+**Why closures trigger this:** The `buildValDef` closure in `ValDefBuilder.ofDefN` (or any similar closure)
+captures the raw `'{ ... }` expression at definition time, when Q0 is in scope. But MIO's lazy evaluation and
+`Expr.splice` → `CrossQuotes.nestedCtx` means the closure executes in a nested context (Q1). At execution time:
+- `body.asTerm` uses Q1 (correct — `body` was created in Q1's context)
+- `'{ val _ = $aExpr }.asTerm` uses Q0 (wrong — it should use Q1)
+
+This Q0/Q1 mismatch is the `ScopeException`.
+
+
+## Confirming the issue
+
+### Step 1: Identify the raw quote
+
+Look for `'{ ... }` or `${ ... }` in the suspected method. If the method only uses `Expr.quote` / `Expr.splice`,
+this is not the issue (those are already scope-safe).
+
+Common locations:
+- `ExprsScala3.scala` in `ValDefBuilder.ofDefN` — the `buildValDef` closure's case body
+- `ExprsScala3.scala` in `LambdaBuilder.ofN` — similar closure pattern
+- Any closure in a Scala 3 platform-specific file that uses raw quotes and is invoked lazily
+
+### Step 2: Write a reproduction test
+
+The test must force the closure to execute in a nested Quotes context. The pattern is:
+
+```scala
+Expr.quote {
+  val x: Int = Expr.splice {
+    // This creates a nested Quotes context (Q1)
+    // Inside here, any closures from builders will run with Q1
+    someBuilder
+      .traverse[MIO, Expr[Int]] { ... }
+      .map(_.build.close)
+      // MIO.scoped forces lazy evaluation
+  }
+  x
+}
+```
+
+The key ingredients:
+- `Expr.splice` (or `Expr.quote` inside `Expr.splice`) creates the nested Q1 context
+- `MIO.scoped { runSafe => runSafe { ... } }` safely extracts the result from MIO, forcing lazy evaluation
+- `.traverse` maps over the builder, which internally invokes the `buildValDef` closure in the current context
+
+If the raw quote lacks `withQuotes`, this test will fail to compile with `ScopeException`.
+
+### Step 3: Verify by temporarily removing `withQuotes`
+
+If `withQuotes` is already present, temporarily remove it and verify the test fails.
+If it is absent, verify the test already fails.
+
+
+## Fixing the issue
+
+Wrap the closure body that contains the raw quote with `withQuotes { ... }`:
+
+**Before (broken):**
+```scala
+buildValDef = (body: Expr[Returned]) =>
+  DefDef(
+    name,
+    {
+      case List(List(a: Term)) =>
+        Some {
+          Block(
+            List(
+              ValDef(a1, Some(a)),
+              '{ val _ = $aExpr }.asTerm  // ← uses Q0 (stale)
+            ),
+            body.asTerm.changeOwner(name)
+          )
+        }
+    }
+  )
+```
+
+**After (fixed):**
+```scala
+buildValDef = (body: Expr[Returned]) =>
+  DefDef(
+    name,
+    {
+      case List(List(a: Term)) => withQuotes {  // ← provides current Quotes
+        Some {
+          Block(
+            List(
+              ValDef(a1, Some(a)),
+              '{ val _ = $aExpr }.asTerm  // ← now uses CrossQuotes.ctx (current)
+            ),
+            body.asTerm.changeOwner(name)
+          )
+        }
+      }
+    }
+  )
+```
+
+`withQuotes` is defined in `Expr.platformSpecific` (imported via `import Expr.platformSpecific.*`):
+
+```scala
+def withQuotes[A](thunk: scala.quoted.Quotes ?=> A): A =
+  thunk(using CrossQuotes.ctx[Quotes])
+```
+
+It replaces the implicit `Quotes` inside the thunk with `CrossQuotes.ctx[Quotes]` — the dynamically current
+Quotes context — instead of whatever the lexical scope provides (typically the stale class-level Q0).
+
+
+## When is `withQuotes` NOT needed?
+
+Methods that do NOT use raw `'{ ... }` or `${ ... }` do not need `withQuotes`. For example:
+
+- `ValDefBuilder.ofVal` — its `buildValDef` is `body.asTerm.changeOwner(name)` (no raw quotes)
+- `ValDefBuilder.ofVar` — its `buildVar` is `body.asTerm.changeOwner(name)` (no raw quotes)
+- `ValDefBuilder.ofLazy` — same pattern, no raw quotes
+- `ValDefBuilder.ofDef0` — same pattern, no raw quotes
+
+These only use `body.asTerm` which correctly belongs to the current context (since `body` was created there).
+The raw quotes (`'{ val _ = $aExpr }`) are what introduce the scope mismatch, because they capture a `Quotes`
+from lexical scope rather than from `CrossQuotes.ctx`.
+
+
+## Historical context
+
+| Commit                                     | What was fixed                                                           |
+|--------------------------------------------|--------------------------------------------------------------------------|
+| `113c2deaacd24b819c4bb0eb3b1a61fdde9ec9ac` | quick fix in `LambdaBuilder.of1` — temporary workaround for one arity    | 
+| `1b8340404ccbf65543825a3c836150de0fdf3c01` | reproduction and fix for every `LambdaBuilder.ofN`                       |
+| `1c01e680431ef8178ea38901d99ae500e439bd70` | quick fix in `ValDefBuilder.ofDef4` — temporary workaround for one arity |
+| `655e1251a349c229c11227e82570d534a29ed69e` | reproduction and fix for every `ValDefBuilder.ofDefN`                    |
+
+
+## Checklist for future occurrences
+
+When adding new code in `ExprsScala3.scala` (or any Scala 3 platform-specific file):
+
+1. **Does it use raw `'{ ... }` or `${ ... }`?**
+   - If no → no action needed
+   - If yes → continue to step 2
+
+2. **Is the raw quote inside a closure that might execute in a different Quotes context?**
+   - If it is directly in a macro body (not inside a closure) → typically safe
+   - If it is inside `buildValDef`, `buildVar`, or any closure stored in a builder → needs `withQuotes`
+
+3. **Wrap with `withQuotes { ... }`** and write a test that exercises the builder through
+   `Expr.splice` → `MIO.scoped` → `traverse` to confirm it works in a nested context.

--- a/docs/user-guide/cross-quotes.md
+++ b/docs/user-guide/cross-quotes.md
@@ -46,6 +46,13 @@ Cross Quotes provides a unified API that gets transformed into the appropriate n
 Additionally, under the hood, it passes around and sets some local copy of `blackbox.Context`/`scala.quoted.Quotes`,
 that makes the whole process possible.
 
+!!! note "Automatic `Quotes` management"
+
+    Because Cross Quotes handle `scala.quoted.Quotes` passing automatically, you do **not** need to use
+    `passQuotes` or `withQuotes` when building expressions with `Expr.quote` / `Expr.splice`. These utilities
+    are only needed when using native Scala 3 `'{ ... }` / `${ ... }` syntax — see
+    [`passQuotes` and `withQuotes`](basic-utilities.md#pass-quotes-and-with-quotes) for details.
+
 ## Usage
 
 ### Basic Type Operations

--- a/hearth-tests/src/main/scala-2/hearth/demo/simple/ShowCompanionCompat.scala
+++ b/hearth-tests/src/main/scala-2/hearth/demo/simple/ShowCompanionCompat.scala
@@ -1,26 +1,25 @@
 // We've put things into a separate package and do not use:
 //   package hearth
-//   package demo_sanely_automatic
+//   package demo
+//   package simple
 // here, because we want to show all the imports normal users would have to do.
-package hearth.demo_sanely_automatic
+package hearth.demo.simple
 
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
-private[demo_sanely_automatic] trait ShowCompanionCompat { this: Show.type =>
+private[demo] trait ShowCompanionCompat { this: Show.type =>
 
-  implicit def derived[A]: Show[A] = macro ShowMacros.deriveTypeClassImpl[A]
+  implicit def derived[A]: Show.AutoDerived[A] = macro ShowMacros.deriveTypeClassImpl[A]
 
   def show[A](value: A): String = macro ShowMacros.deriveShowStringImpl[A]
 }
 
-private[demo_sanely_automatic] class ShowMacros(val c: blackbox.Context)
-    extends hearth.MacroCommonsScala2
-    with ShowMacrosImpl {
+private[demo] class ShowMacros(val c: blackbox.Context) extends hearth.MacroCommonsScala2 with ShowMacrosImpl {
 
   // TODO: create macro annotation which would allow to do the following
 
-  def deriveTypeClassImpl[A: c.WeakTypeTag]: c.Expr[Show[A]] = deriveTypeClass[A]
+  def deriveTypeClassImpl[A: c.WeakTypeTag]: c.Expr[Show.AutoDerived[A]] = deriveTypeClass[A]
 
   def deriveShowStringImpl[A: c.WeakTypeTag](value: c.Expr[A]): c.Expr[String] = deriveShowString[A](value)
 }

--- a/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
@@ -65,6 +65,32 @@ final private class ExprsFixtures(val c: blackbox.Context) extends MacroCommonsS
   def testLambdaBuilderTraverseImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[Data] =
     testLambdaBuilderTraverse[A](expr)
 
+  def testLambdaBuilderOf1ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf1ScopeIssue
+
+  def testLambdaBuilderOf2ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf2ScopeIssue
+
+  def testLambdaBuilderOf3ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf3ScopeIssue
+
+  def testLambdaBuilderOf4ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf4ScopeIssue
+  def testLambdaBuilderOf5ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf5ScopeIssue
+  def testLambdaBuilderOf6ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf6ScopeIssue
+  def testLambdaBuilderOf7ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf7ScopeIssue
+  def testLambdaBuilderOf8ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf8ScopeIssue
+  def testLambdaBuilderOf9ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf9ScopeIssue
+  def testLambdaBuilderOf10ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf10ScopeIssue
+  def testLambdaBuilderOf11ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf11ScopeIssue
+  def testLambdaBuilderOf12ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf12ScopeIssue
+  def testLambdaBuilderOf13ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf13ScopeIssue
+  def testLambdaBuilderOf14ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf14ScopeIssue
+  def testLambdaBuilderOf15ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf15ScopeIssue
+  def testLambdaBuilderOf16ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf16ScopeIssue
+  def testLambdaBuilderOf17ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf17ScopeIssue
+  def testLambdaBuilderOf18ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf18ScopeIssue
+  def testLambdaBuilderOf19ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf19ScopeIssue
+  def testLambdaBuilderOf20ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf20ScopeIssue
+  def testLambdaBuilderOf21ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf21ScopeIssue
+  def testLambdaBuilderOf22ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf22ScopeIssue
+
   def testBidirectionalCodecsImpl: c.Expr[Data] = testBidirectionalCodecs
 
   def testOneWayCodecsImpl: c.Expr[Data] = testOneWayCodecs
@@ -119,6 +145,32 @@ object ExprsFixtures {
   def testLambdaBuilderPartition[A](expr: A): Data = macro ExprsFixtures.testLambdaBuilderPartitionImpl[A]
 
   def testLambdaBuilderTraverse[A](expr: A): Data = macro ExprsFixtures.testLambdaBuilderTraverseImpl[A]
+
+  def testLambdaBuilderOf1ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf1ScopeIssueImpl
+
+  def testLambdaBuilderOf2ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf2ScopeIssueImpl
+
+  def testLambdaBuilderOf3ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf3ScopeIssueImpl
+
+  def testLambdaBuilderOf4ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf4ScopeIssueImpl
+  def testLambdaBuilderOf5ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf5ScopeIssueImpl
+  def testLambdaBuilderOf6ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf6ScopeIssueImpl
+  def testLambdaBuilderOf7ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf7ScopeIssueImpl
+  def testLambdaBuilderOf8ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf8ScopeIssueImpl
+  def testLambdaBuilderOf9ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf9ScopeIssueImpl
+  def testLambdaBuilderOf10ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf10ScopeIssueImpl
+  def testLambdaBuilderOf11ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf11ScopeIssueImpl
+  def testLambdaBuilderOf12ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf12ScopeIssueImpl
+  def testLambdaBuilderOf13ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf13ScopeIssueImpl
+  def testLambdaBuilderOf14ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf14ScopeIssueImpl
+  def testLambdaBuilderOf15ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf15ScopeIssueImpl
+  def testLambdaBuilderOf16ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf16ScopeIssueImpl
+  def testLambdaBuilderOf17ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf17ScopeIssueImpl
+  def testLambdaBuilderOf18ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf18ScopeIssueImpl
+  def testLambdaBuilderOf19ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf19ScopeIssueImpl
+  def testLambdaBuilderOf20ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf20ScopeIssueImpl
+  def testLambdaBuilderOf21ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf21ScopeIssueImpl
+  def testLambdaBuilderOf22ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf22ScopeIssueImpl
 
   def testBidirectionalCodecs: Data = macro ExprsFixtures.testBidirectionalCodecsImpl
 

--- a/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
@@ -91,6 +91,33 @@ final private class ExprsFixtures(val c: blackbox.Context) extends MacroCommonsS
   def testLambdaBuilderOf21ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf21ScopeIssue
   def testLambdaBuilderOf22ScopeIssueImpl: c.Expr[Data] = testLambdaBuilderOf22ScopeIssue
 
+  def testValDefBuilderOfValScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfValScopeIssue
+  def testValDefBuilderOfVarScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfVarScopeIssue
+  def testValDefBuilderOfLazyScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfLazyScopeIssue
+  def testValDefBuilderOfDef0ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef0ScopeIssue
+  def testValDefBuilderOfDef1ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef1ScopeIssue
+  def testValDefBuilderOfDef2ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef2ScopeIssue
+  def testValDefBuilderOfDef3ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef3ScopeIssue
+  def testValDefBuilderOfDef4ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef4ScopeIssue
+  def testValDefBuilderOfDef5ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef5ScopeIssue
+  def testValDefBuilderOfDef6ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef6ScopeIssue
+  def testValDefBuilderOfDef7ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef7ScopeIssue
+  def testValDefBuilderOfDef8ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef8ScopeIssue
+  def testValDefBuilderOfDef9ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef9ScopeIssue
+  def testValDefBuilderOfDef10ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef10ScopeIssue
+  def testValDefBuilderOfDef11ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef11ScopeIssue
+  def testValDefBuilderOfDef12ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef12ScopeIssue
+  def testValDefBuilderOfDef13ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef13ScopeIssue
+  def testValDefBuilderOfDef14ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef14ScopeIssue
+  def testValDefBuilderOfDef15ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef15ScopeIssue
+  def testValDefBuilderOfDef16ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef16ScopeIssue
+  def testValDefBuilderOfDef17ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef17ScopeIssue
+  def testValDefBuilderOfDef18ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef18ScopeIssue
+  def testValDefBuilderOfDef19ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef19ScopeIssue
+  def testValDefBuilderOfDef20ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef20ScopeIssue
+  def testValDefBuilderOfDef21ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef21ScopeIssue
+  def testValDefBuilderOfDef22ScopeIssueImpl: c.Expr[Data] = testValDefBuilderOfDef22ScopeIssue
+
   def testBidirectionalCodecsImpl: c.Expr[Data] = testBidirectionalCodecs
 
   def testOneWayCodecsImpl: c.Expr[Data] = testOneWayCodecs
@@ -171,6 +198,33 @@ object ExprsFixtures {
   def testLambdaBuilderOf20ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf20ScopeIssueImpl
   def testLambdaBuilderOf21ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf21ScopeIssueImpl
   def testLambdaBuilderOf22ScopeIssue: Data = macro ExprsFixtures.testLambdaBuilderOf22ScopeIssueImpl
+
+  def testValDefBuilderOfValScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfValScopeIssueImpl
+  def testValDefBuilderOfVarScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfVarScopeIssueImpl
+  def testValDefBuilderOfLazyScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfLazyScopeIssueImpl
+  def testValDefBuilderOfDef0ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef0ScopeIssueImpl
+  def testValDefBuilderOfDef1ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef1ScopeIssueImpl
+  def testValDefBuilderOfDef2ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef2ScopeIssueImpl
+  def testValDefBuilderOfDef3ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef3ScopeIssueImpl
+  def testValDefBuilderOfDef4ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef4ScopeIssueImpl
+  def testValDefBuilderOfDef5ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef5ScopeIssueImpl
+  def testValDefBuilderOfDef6ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef6ScopeIssueImpl
+  def testValDefBuilderOfDef7ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef7ScopeIssueImpl
+  def testValDefBuilderOfDef8ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef8ScopeIssueImpl
+  def testValDefBuilderOfDef9ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef9ScopeIssueImpl
+  def testValDefBuilderOfDef10ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef10ScopeIssueImpl
+  def testValDefBuilderOfDef11ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef11ScopeIssueImpl
+  def testValDefBuilderOfDef12ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef12ScopeIssueImpl
+  def testValDefBuilderOfDef13ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef13ScopeIssueImpl
+  def testValDefBuilderOfDef14ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef14ScopeIssueImpl
+  def testValDefBuilderOfDef15ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef15ScopeIssueImpl
+  def testValDefBuilderOfDef16ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef16ScopeIssueImpl
+  def testValDefBuilderOfDef17ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef17ScopeIssueImpl
+  def testValDefBuilderOfDef18ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef18ScopeIssueImpl
+  def testValDefBuilderOfDef19ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef19ScopeIssueImpl
+  def testValDefBuilderOfDef20ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef20ScopeIssueImpl
+  def testValDefBuilderOfDef21ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef21ScopeIssueImpl
+  def testValDefBuilderOfDef22ScopeIssue: Data = macro ExprsFixtures.testValDefBuilderOfDef22ScopeIssueImpl
 
   def testBidirectionalCodecs: Data = macro ExprsFixtures.testBidirectionalCodecsImpl
 

--- a/hearth-tests/src/main/scala-3/hearth/demo/simple/ShowCompanionCompat.scala
+++ b/hearth-tests/src/main/scala-3/hearth/demo/simple/ShowCompanionCompat.scala
@@ -1,8 +1,9 @@
 // We've put things into a separate package and do not use:
 //   package hearth
 //   package demo
+//   package simple
 // here, because we want to show all the imports normal users would have to do.
-package hearth.demo
+package hearth.demo.simple
 
 import scala.quoted.*
 

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
@@ -197,6 +197,110 @@ object ExprsFixtures {
   private def testLambdaBuilderOf22ScopeIssueImpl(using q: Quotes): Expr[Data] =
     new ExprsFixtures(q).testLambdaBuilderOf22ScopeIssue
 
+  inline def testValDefBuilderOfValScopeIssue: Data = ${ testValDefBuilderOfValScopeIssueImpl }
+  private def testValDefBuilderOfValScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfValScopeIssue
+
+  inline def testValDefBuilderOfVarScopeIssue: Data = ${ testValDefBuilderOfVarScopeIssueImpl }
+  private def testValDefBuilderOfVarScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfVarScopeIssue
+
+  inline def testValDefBuilderOfLazyScopeIssue: Data = ${ testValDefBuilderOfLazyScopeIssueImpl }
+  private def testValDefBuilderOfLazyScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfLazyScopeIssue
+
+  inline def testValDefBuilderOfDef0ScopeIssue: Data = ${ testValDefBuilderOfDef0ScopeIssueImpl }
+  private def testValDefBuilderOfDef0ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef0ScopeIssue
+
+  inline def testValDefBuilderOfDef1ScopeIssue: Data = ${ testValDefBuilderOfDef1ScopeIssueImpl }
+  private def testValDefBuilderOfDef1ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef1ScopeIssue
+
+  inline def testValDefBuilderOfDef2ScopeIssue: Data = ${ testValDefBuilderOfDef2ScopeIssueImpl }
+  private def testValDefBuilderOfDef2ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef2ScopeIssue
+
+  inline def testValDefBuilderOfDef3ScopeIssue: Data = ${ testValDefBuilderOfDef3ScopeIssueImpl }
+  private def testValDefBuilderOfDef3ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef3ScopeIssue
+
+  inline def testValDefBuilderOfDef4ScopeIssue: Data = ${ testValDefBuilderOfDef4ScopeIssueImpl }
+  private def testValDefBuilderOfDef4ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef4ScopeIssue
+
+  inline def testValDefBuilderOfDef5ScopeIssue: Data = ${ testValDefBuilderOfDef5ScopeIssueImpl }
+  private def testValDefBuilderOfDef5ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef5ScopeIssue
+
+  inline def testValDefBuilderOfDef6ScopeIssue: Data = ${ testValDefBuilderOfDef6ScopeIssueImpl }
+  private def testValDefBuilderOfDef6ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef6ScopeIssue
+
+  inline def testValDefBuilderOfDef7ScopeIssue: Data = ${ testValDefBuilderOfDef7ScopeIssueImpl }
+  private def testValDefBuilderOfDef7ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef7ScopeIssue
+
+  inline def testValDefBuilderOfDef8ScopeIssue: Data = ${ testValDefBuilderOfDef8ScopeIssueImpl }
+  private def testValDefBuilderOfDef8ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef8ScopeIssue
+
+  inline def testValDefBuilderOfDef9ScopeIssue: Data = ${ testValDefBuilderOfDef9ScopeIssueImpl }
+  private def testValDefBuilderOfDef9ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef9ScopeIssue
+
+  inline def testValDefBuilderOfDef10ScopeIssue: Data = ${ testValDefBuilderOfDef10ScopeIssueImpl }
+  private def testValDefBuilderOfDef10ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef10ScopeIssue
+
+  inline def testValDefBuilderOfDef11ScopeIssue: Data = ${ testValDefBuilderOfDef11ScopeIssueImpl }
+  private def testValDefBuilderOfDef11ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef11ScopeIssue
+
+  inline def testValDefBuilderOfDef12ScopeIssue: Data = ${ testValDefBuilderOfDef12ScopeIssueImpl }
+  private def testValDefBuilderOfDef12ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef12ScopeIssue
+
+  inline def testValDefBuilderOfDef13ScopeIssue: Data = ${ testValDefBuilderOfDef13ScopeIssueImpl }
+  private def testValDefBuilderOfDef13ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef13ScopeIssue
+
+  inline def testValDefBuilderOfDef14ScopeIssue: Data = ${ testValDefBuilderOfDef14ScopeIssueImpl }
+  private def testValDefBuilderOfDef14ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef14ScopeIssue
+
+  inline def testValDefBuilderOfDef15ScopeIssue: Data = ${ testValDefBuilderOfDef15ScopeIssueImpl }
+  private def testValDefBuilderOfDef15ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef15ScopeIssue
+
+  inline def testValDefBuilderOfDef16ScopeIssue: Data = ${ testValDefBuilderOfDef16ScopeIssueImpl }
+  private def testValDefBuilderOfDef16ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef16ScopeIssue
+
+  inline def testValDefBuilderOfDef17ScopeIssue: Data = ${ testValDefBuilderOfDef17ScopeIssueImpl }
+  private def testValDefBuilderOfDef17ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef17ScopeIssue
+
+  inline def testValDefBuilderOfDef18ScopeIssue: Data = ${ testValDefBuilderOfDef18ScopeIssueImpl }
+  private def testValDefBuilderOfDef18ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef18ScopeIssue
+
+  inline def testValDefBuilderOfDef19ScopeIssue: Data = ${ testValDefBuilderOfDef19ScopeIssueImpl }
+  private def testValDefBuilderOfDef19ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef19ScopeIssue
+
+  inline def testValDefBuilderOfDef20ScopeIssue: Data = ${ testValDefBuilderOfDef20ScopeIssueImpl }
+  private def testValDefBuilderOfDef20ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef20ScopeIssue
+
+  inline def testValDefBuilderOfDef21ScopeIssue: Data = ${ testValDefBuilderOfDef21ScopeIssueImpl }
+  private def testValDefBuilderOfDef21ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef21ScopeIssue
+
+  inline def testValDefBuilderOfDef22ScopeIssue: Data = ${ testValDefBuilderOfDef22ScopeIssueImpl }
+  private def testValDefBuilderOfDef22ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefBuilderOfDef22ScopeIssue
+
   inline def testBidirectionalCodecs: Data = ${ testBidirectionalCodecsImpl }
   private def testBidirectionalCodecsImpl(using q: Quotes): Expr[Data] =
     new ExprsFixtures(q).testBidirectionalCodecs

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
@@ -109,6 +109,94 @@ object ExprsFixtures {
   private def testLambdaBuilderTraverseImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[Data] =
     new ExprsFixtures(q).testLambdaBuilderTraverse[A](expr)
 
+  inline def testLambdaBuilderOf1ScopeIssue: Data = ${ testLambdaBuilderOf1ScopeIssueImpl }
+  private def testLambdaBuilderOf1ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf1ScopeIssue
+
+  inline def testLambdaBuilderOf2ScopeIssue: Data = ${ testLambdaBuilderOf2ScopeIssueImpl }
+  private def testLambdaBuilderOf2ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf2ScopeIssue
+
+  inline def testLambdaBuilderOf3ScopeIssue: Data = ${ testLambdaBuilderOf3ScopeIssueImpl }
+  private def testLambdaBuilderOf3ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf3ScopeIssue
+
+  inline def testLambdaBuilderOf4ScopeIssue: Data = ${ testLambdaBuilderOf4ScopeIssueImpl }
+  private def testLambdaBuilderOf4ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf4ScopeIssue
+
+  inline def testLambdaBuilderOf5ScopeIssue: Data = ${ testLambdaBuilderOf5ScopeIssueImpl }
+  private def testLambdaBuilderOf5ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf5ScopeIssue
+
+  inline def testLambdaBuilderOf6ScopeIssue: Data = ${ testLambdaBuilderOf6ScopeIssueImpl }
+  private def testLambdaBuilderOf6ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf6ScopeIssue
+
+  inline def testLambdaBuilderOf7ScopeIssue: Data = ${ testLambdaBuilderOf7ScopeIssueImpl }
+  private def testLambdaBuilderOf7ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf7ScopeIssue
+
+  inline def testLambdaBuilderOf8ScopeIssue: Data = ${ testLambdaBuilderOf8ScopeIssueImpl }
+  private def testLambdaBuilderOf8ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf8ScopeIssue
+
+  inline def testLambdaBuilderOf9ScopeIssue: Data = ${ testLambdaBuilderOf9ScopeIssueImpl }
+  private def testLambdaBuilderOf9ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf9ScopeIssue
+
+  inline def testLambdaBuilderOf10ScopeIssue: Data = ${ testLambdaBuilderOf10ScopeIssueImpl }
+  private def testLambdaBuilderOf10ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf10ScopeIssue
+
+  inline def testLambdaBuilderOf11ScopeIssue: Data = ${ testLambdaBuilderOf11ScopeIssueImpl }
+  private def testLambdaBuilderOf11ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf11ScopeIssue
+
+  inline def testLambdaBuilderOf12ScopeIssue: Data = ${ testLambdaBuilderOf12ScopeIssueImpl }
+  private def testLambdaBuilderOf12ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf12ScopeIssue
+
+  inline def testLambdaBuilderOf13ScopeIssue: Data = ${ testLambdaBuilderOf13ScopeIssueImpl }
+  private def testLambdaBuilderOf13ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf13ScopeIssue
+
+  inline def testLambdaBuilderOf14ScopeIssue: Data = ${ testLambdaBuilderOf14ScopeIssueImpl }
+  private def testLambdaBuilderOf14ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf14ScopeIssue
+
+  inline def testLambdaBuilderOf15ScopeIssue: Data = ${ testLambdaBuilderOf15ScopeIssueImpl }
+  private def testLambdaBuilderOf15ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf15ScopeIssue
+
+  inline def testLambdaBuilderOf16ScopeIssue: Data = ${ testLambdaBuilderOf16ScopeIssueImpl }
+  private def testLambdaBuilderOf16ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf16ScopeIssue
+
+  inline def testLambdaBuilderOf17ScopeIssue: Data = ${ testLambdaBuilderOf17ScopeIssueImpl }
+  private def testLambdaBuilderOf17ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf17ScopeIssue
+
+  inline def testLambdaBuilderOf18ScopeIssue: Data = ${ testLambdaBuilderOf18ScopeIssueImpl }
+  private def testLambdaBuilderOf18ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf18ScopeIssue
+
+  inline def testLambdaBuilderOf19ScopeIssue: Data = ${ testLambdaBuilderOf19ScopeIssueImpl }
+  private def testLambdaBuilderOf19ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf19ScopeIssue
+
+  inline def testLambdaBuilderOf20ScopeIssue: Data = ${ testLambdaBuilderOf20ScopeIssueImpl }
+  private def testLambdaBuilderOf20ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf20ScopeIssue
+
+  inline def testLambdaBuilderOf21ScopeIssue: Data = ${ testLambdaBuilderOf21ScopeIssueImpl }
+  private def testLambdaBuilderOf21ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf21ScopeIssue
+
+  inline def testLambdaBuilderOf22ScopeIssue: Data = ${ testLambdaBuilderOf22ScopeIssueImpl }
+  private def testLambdaBuilderOf22ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testLambdaBuilderOf22ScopeIssue
+
   inline def testBidirectionalCodecs: Data = ${ testBidirectionalCodecsImpl }
   private def testBidirectionalCodecsImpl(using q: Quotes): Expr[Data] =
     new ExprsFixtures(q).testBidirectionalCodecs

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprsScala3Fixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprsScala3Fixtures.scala
@@ -1,0 +1,271 @@
+package hearth
+package typed
+
+import hearth.data.Data
+import hearth.fp.effect.MIO
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
+
+import scala.quoted.*
+
+/** Scala 3-only fixtures for testing [[passQuotes]] and [[withQuotes]] utilities with native Scala 3 quoting syntax.
+  *
+  * Unlike [[ExprsFixtures]] which uses cross-quotes ([[Expr.quote]] and [[Expr.splice]]), these fixtures use native
+  * Scala 3 `'{...}` and `${...}` syntax, which requires explicit [[passQuotes]] and [[withQuotes]] calls to manage the
+  * [[Quotes]] context.
+  *
+  * These are used in [[ExprsScala3Spec]] to verify that [[passQuotes]]/[[withQuotes]] correctly handle the scope issue
+  * when building expressions with [[LambdaBuilder]] and [[ValDefBuilder]] in a Scala-3-only codebase.
+  */
+// format: off
+final private class ExprsScala3Fixtures(q: Quotes) extends MacroCommonsScala3(using q) {
+
+  // Cannot use Type[Int] in any annotations (parameter types, local vals) in scala-3 source files because the
+  // cross-quotes plugin transforms these into self-referencing code, causing infinite loop errors.
+  // Instead, pass the type as Any and cast to the expected type within a helper that delegates to a method
+  // accepting Type[Int] implicitly in the shared source.
+
+  /** Provides an implicit Type[Int] within a thunk by obtaining it from Type.of[Int] inside a passQuotes block. */
+  private inline def withIntType[A](thunk: Type[Int] ?=> A): A =
+    thunk(using Type.of[Int])
+
+  // LambdaBuilder scope issue tests using passQuotes/withQuotes
+
+  def testLambdaBuilderOf1ScopeIssue: Expr[Data] = {
+    def lambda: Expr[Int => Int] = withQuotes {
+      '{
+        val x: Int => Int = ${ passQuotes {
+          withIntType {
+            MIO
+              .scoped { runSafe =>
+                runSafe {
+                  LambdaBuilder
+                    .of1[Int]("a")
+                    .traverse[MIO, Expr[Int]] { a =>
+                      MIO.pure(Expr.quote(Expr.splice(a) + 1))
+                    }
+                    .map(_.build[Int])
+                }
+              }
+              .unsafe.runSync._2.fold(es => throw es.head, identity)
+          }
+        } }
+        x
+      }
+    }
+    withQuotes{'{ Data(${ passQuotes{lambda} }(2)) }}
+  }
+
+  def testLambdaBuilderOf2ScopeIssue: Expr[Data] = {
+    def lambda: Expr[(Int, Int) => Int] = withQuotes {
+      '{
+        val x: (Int, Int) => Int = ${ passQuotes {
+          withIntType {
+            MIO
+              .scoped { runSafe =>
+                runSafe {
+                  LambdaBuilder
+                    .of2[Int, Int]("a", "b")
+                    .traverse[MIO, Expr[Int]] { case ((a, b)) =>
+                      MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) + 1))
+                    }
+                    .map(_.build[Int])
+                }
+              }
+              .unsafe.runSync._2.fold(es => throw es.head, identity)
+          }
+        } }
+        x
+      }
+    }
+    withQuotes{'{ Data(${ passQuotes{lambda} }(2, 3)) }}
+  }
+
+  def testLambdaBuilderOf3ScopeIssue: Expr[Data] = {
+    def lambda: Expr[(Int, Int, Int) => Int] = withQuotes {
+      '{
+        val x: (Int, Int, Int) => Int = ${ passQuotes {
+          withIntType {
+            MIO
+              .scoped { runSafe =>
+                runSafe {
+                  LambdaBuilder
+                    .of3[Int, Int, Int]("a", "b", "c")
+                    .traverse[MIO, Expr[Int]] { case ((a, b, c)) =>
+                      MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) + 1))
+                    }
+                    .map(_.build[Int])
+                }
+              }
+              .unsafe.runSync._2.fold(es => throw es.head, identity)
+          }
+        } }
+        x
+      }
+    }
+    withQuotes{'{ Data(${ passQuotes{lambda} }(2, 3, 5)) }}
+  }
+
+  // ValDefBuilder scope issue tests using passQuotes/withQuotes
+
+  def testValDefBuilderOfValScopeIssue: Expr[Data] = {
+    def result: Expr[Int] = withQuotes {
+      '{
+        val x: Int = ${ passQuotes {
+          withIntType {
+            MIO
+              .scoped { runSafe =>
+                runSafe {
+                  ValDefBuilder
+                    .ofVal[Int]("v")
+                    .traverse[MIO, Expr[Int]] { _ =>
+                      MIO.pure(Expr.quote(42))
+                    }
+                    .map(_.build.close)
+                }
+              }
+              .unsafe.runSync._2.fold(es => throw es.head, identity)
+          }
+        } }
+        x
+      }
+    }
+    withQuotes{'{ Data(${ passQuotes{result} }) }}
+  }
+
+  def testValDefBuilderOfVarScopeIssue: Expr[Data] = {
+    def result: Expr[Int] = withQuotes {
+      '{
+        val x: Int = ${ passQuotes {
+          withIntType {
+            MIO
+              .scoped { runSafe =>
+                runSafe {
+                  ValDefBuilder
+                    .ofVar[Int]("v")
+                    .traverse[MIO, Expr[Int]] { _ =>
+                      MIO.pure(Expr.quote(42))
+                    }
+                    .map(_.build.close)
+                }
+              }
+              .unsafe.runSync._2.fold(es => throw es.head, identity)
+          }
+        } }
+        x
+      }
+    }
+    withQuotes{'{ Data(${ passQuotes{result} }) }}
+  }
+
+  def testValDefBuilderOfLazyScopeIssue: Expr[Data] = {
+    def result: Expr[Int] = withQuotes {
+      '{
+        val x: Int = ${ passQuotes {
+          withIntType {
+            MIO
+              .scoped { runSafe =>
+                runSafe {
+                  ValDefBuilder
+                    .ofLazy[Int]("v")
+                    .traverse[MIO, Expr[Int]] { _ =>
+                      MIO.pure(Expr.quote(42))
+                    }
+                    .map(_.build.close)
+                }
+              }
+              .unsafe.runSync._2.fold(es => throw es.head, identity)
+          }
+        } }
+        x
+      }
+    }
+    withQuotes{'{ Data(${ passQuotes{result} }) }}
+  }
+
+  def testValDefBuilderOfDef0ScopeIssue: Expr[Data] = {
+    def result: Expr[Int] = withQuotes {
+      '{
+        val x: Int = ${ passQuotes {
+          withIntType {
+            MIO
+              .scoped { runSafe =>
+                runSafe {
+                  ValDefBuilder
+                    .ofDef0[Int]("d")
+                    .traverse[MIO, Expr[Int]] { _ =>
+                      MIO.pure(Expr.quote(42))
+                    }
+                    .map(_.build.close)
+                }
+              }
+              .unsafe.runSync._2.fold(es => throw es.head, identity)
+          }
+        } }
+        x
+      }
+    }
+    withQuotes{'{ Data(${ passQuotes{result} }) }}
+  }
+
+  def testValDefBuilderOfDef1ScopeIssue: Expr[Data] = {
+    def result: Expr[Int] = withQuotes {
+      '{
+        val x: Int = ${ passQuotes {
+          withIntType {
+            MIO
+              .scoped { runSafe =>
+                runSafe {
+                  ValDefBuilder
+                    .ofDef1[Int, Int]("d", "a")
+                    .traverse[MIO, Expr[Int]] { case (_, a) =>
+                      MIO.pure(Expr.quote(Expr.splice(a) + 1))
+                    }
+                    .map(_.build.use(_(Expr.quote(2))))
+                }
+              }
+              .unsafe.runSync._2.fold(es => throw es.head, identity)
+          }
+        } }
+        x
+      }
+    }
+    withQuotes{'{ Data(${ passQuotes{result} }) }}
+  }
+}
+// format: on
+
+object ExprsScala3Fixtures {
+
+  inline def testLambdaBuilderOf1ScopeIssue: Data = ${ testLambdaBuilderOf1ScopeIssueImpl }
+  private def testLambdaBuilderOf1ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsScala3Fixtures(q).testLambdaBuilderOf1ScopeIssue
+
+  inline def testLambdaBuilderOf2ScopeIssue: Data = ${ testLambdaBuilderOf2ScopeIssueImpl }
+  private def testLambdaBuilderOf2ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsScala3Fixtures(q).testLambdaBuilderOf2ScopeIssue
+
+  inline def testLambdaBuilderOf3ScopeIssue: Data = ${ testLambdaBuilderOf3ScopeIssueImpl }
+  private def testLambdaBuilderOf3ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsScala3Fixtures(q).testLambdaBuilderOf3ScopeIssue
+
+  inline def testValDefBuilderOfValScopeIssue: Data = ${ testValDefBuilderOfValScopeIssueImpl }
+  private def testValDefBuilderOfValScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsScala3Fixtures(q).testValDefBuilderOfValScopeIssue
+
+  inline def testValDefBuilderOfVarScopeIssue: Data = ${ testValDefBuilderOfVarScopeIssueImpl }
+  private def testValDefBuilderOfVarScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsScala3Fixtures(q).testValDefBuilderOfVarScopeIssue
+
+  inline def testValDefBuilderOfLazyScopeIssue: Data = ${ testValDefBuilderOfLazyScopeIssueImpl }
+  private def testValDefBuilderOfLazyScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsScala3Fixtures(q).testValDefBuilderOfLazyScopeIssue
+
+  inline def testValDefBuilderOfDef0ScopeIssue: Data = ${ testValDefBuilderOfDef0ScopeIssueImpl }
+  private def testValDefBuilderOfDef0ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsScala3Fixtures(q).testValDefBuilderOfDef0ScopeIssue
+
+  inline def testValDefBuilderOfDef1ScopeIssue: Data = ${ testValDefBuilderOfDef1ScopeIssueImpl }
+  private def testValDefBuilderOfDef1ScopeIssueImpl(using q: Quotes): Expr[Data] =
+    new ExprsScala3Fixtures(q).testValDefBuilderOfDef1ScopeIssue
+}

--- a/hearth-tests/src/main/scala-newest-2/hearth/demo/allfeatures/FastShowPrettyCompanionCompat.scala
+++ b/hearth-tests/src/main/scala-newest-2/hearth/demo/allfeatures/FastShowPrettyCompanionCompat.scala
@@ -1,0 +1,12 @@
+package hearth.demo.allfeatures
+
+import scala.language.experimental.macros
+
+private[allfeatures] trait FastShowPrettyCompanionCompat { this: FastShowPretty.type =>
+
+  /** Renders a value to a String with custom indentation configuration. */
+  def render[A](value: A, config: RenderConfig): String =
+    macro internal.compiletime.FastShowPrettyMacros.deriveInlineWithConfigImpl[A]
+
+  implicit def derived[A]: FastShowPretty[A] = macro internal.compiletime.FastShowPrettyMacros.deriveTypeClassImpl[A]
+}

--- a/hearth-tests/src/main/scala-newest-2/hearth/demo/allfeatures/internal/compiletime/FastShowPrettyMacros.scala
+++ b/hearth-tests/src/main/scala-newest-2/hearth/demo/allfeatures/internal/compiletime/FastShowPrettyMacros.scala
@@ -1,0 +1,22 @@
+package hearth.demo.allfeatures
+package internal.compiletime
+
+import hearth.MacroCommonsScala2
+import scala.reflect.macros.blackbox
+
+final private[allfeatures] class FastShowPrettyMacros(val c: blackbox.Context)
+    extends MacroCommonsScala2
+    with FastShowPrettyMacrosImpl {
+
+  import c.universe.*
+
+  def deriveInlineWithConfigImpl[A: c.WeakTypeTag](
+      value: c.Expr[A],
+      config: c.Expr[RenderConfig]
+  ): c.Expr[String] = {
+    val levelExpr = c.Expr[Int](q"$config.startLevel")
+    deriveInline[A](value, config, levelExpr)
+  }
+
+  def deriveTypeClassImpl[A: c.WeakTypeTag]: c.Expr[FastShowPretty[A]] = deriveTypeClass[A]
+}

--- a/hearth-tests/src/main/scala-newest-2/hearth/demo/sanely_automatic/ShowCompanionCompat.scala
+++ b/hearth-tests/src/main/scala-newest-2/hearth/demo/sanely_automatic/ShowCompanionCompat.scala
@@ -1,24 +1,27 @@
 // We've put things into a separate package and do not use:
 //   package hearth
 //   package demo
+//   package sanely_automatic
 // here, because we want to show all the imports normal users would have to do.
-package hearth.demo
+package hearth.demo.sanely_automatic
 
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
-private[demo] trait ShowCompanionCompat { this: Show.type =>
+private[sanely_automatic] trait ShowCompanionCompat { this: Show.type =>
 
-  implicit def derived[A]: Show.AutoDerived[A] = macro ShowMacros.deriveTypeClassImpl[A]
+  implicit def derived[A]: Show[A] = macro ShowMacros.deriveTypeClassImpl[A]
 
   def show[A](value: A): String = macro ShowMacros.deriveShowStringImpl[A]
 }
 
-private[demo] class ShowMacros(val c: blackbox.Context) extends hearth.MacroCommonsScala2 with ShowMacrosImpl {
+private[sanely_automatic] class ShowMacros(val c: blackbox.Context)
+    extends hearth.MacroCommonsScala2
+    with ShowMacrosImpl {
 
   // TODO: create macro annotation which would allow to do the following
 
-  def deriveTypeClassImpl[A: c.WeakTypeTag]: c.Expr[Show.AutoDerived[A]] = deriveTypeClass[A]
+  def deriveTypeClassImpl[A: c.WeakTypeTag]: c.Expr[Show[A]] = deriveTypeClass[A]
 
   def deriveShowStringImpl[A: c.WeakTypeTag](value: c.Expr[A]): c.Expr[String] = deriveShowString[A](value)
 }

--- a/hearth-tests/src/main/scala-newest-3/hearth/demo/allfeatures/FastShowPrettyCompanionCompat.scala
+++ b/hearth-tests/src/main/scala-newest-3/hearth/demo/allfeatures/FastShowPrettyCompanionCompat.scala
@@ -1,0 +1,11 @@
+package hearth.demo.allfeatures
+
+private[allfeatures] trait FastShowPrettyCompanionCompat { this: FastShowPretty.type =>
+
+  /** Renders a value to a String with custom indentation configuration. */
+  inline def render[A](inline value: A, config: RenderConfig): String = ${
+    internal.compiletime.FastShowPrettyMacros.deriveInlineImpl[A]('value, 'config, '{ config.startLevel })
+  }
+
+  inline given derived[A]: FastShowPretty[A] = ${ internal.compiletime.FastShowPrettyMacros.deriveTypeClassImpl[A] }
+}

--- a/hearth-tests/src/main/scala-newest-3/hearth/demo/allfeatures/internal/compiletime/FastShowPrettyMacros.scala
+++ b/hearth-tests/src/main/scala-newest-3/hearth/demo/allfeatures/internal/compiletime/FastShowPrettyMacros.scala
@@ -1,0 +1,21 @@
+package hearth.demo.allfeatures
+package internal.compiletime
+
+import hearth.MacroCommonsScala3
+import scala.quoted.*
+
+final private[allfeatures] class FastShowPrettyMacros(q: Quotes)
+    extends MacroCommonsScala3(using q),
+      FastShowPrettyMacrosImpl
+private[allfeatures] object FastShowPrettyMacros {
+
+  def deriveInlineImpl[A: Type](
+      value: Expr[A],
+      config: Expr[RenderConfig],
+      level: Expr[Int]
+  )(using q: Quotes): Expr[String] =
+    new FastShowPrettyMacros(q).deriveInline[A](value, config, level)
+
+  def deriveTypeClassImpl[A: Type](using q: Quotes): Expr[FastShowPretty[A]] =
+    new FastShowPrettyMacros(q).deriveTypeClass[A]
+}

--- a/hearth-tests/src/main/scala-newest-3/hearth/demo/sanely_automatic/ShowCompanionCompat.scala
+++ b/hearth-tests/src/main/scala-newest-3/hearth/demo/sanely_automatic/ShowCompanionCompat.scala
@@ -1,21 +1,22 @@
 // We've put things into a separate package and do not use:
 //   package hearth
-//   package demo_sanely_automatic
+//   package demo
+//   package sanely_automatic
 // here, because we want to show all the imports normal users would have to do.
-package hearth.demo_sanely_automatic
+package hearth.demo.sanely_automatic
 
 import scala.quoted.*
 
-private[demo_sanely_automatic] trait ShowCompanionCompat { this: Show.type =>
+private[sanely_automatic] trait ShowCompanionCompat { this: Show.type =>
 
   inline given derived[A]: Show[A] = ${ ShowMacros.deriveTypeClass[A] }
 
   inline def show[A](value: A): String = ${ ShowMacros.deriveShowString[A]('value) }
 }
 
-private[demo_sanely_automatic] class ShowMacros(q: Quotes) extends hearth.MacroCommonsScala3(using q), ShowMacrosImpl
+private[sanely_automatic] class ShowMacros(q: Quotes) extends hearth.MacroCommonsScala3(using q), ShowMacrosImpl
 
-private[demo_sanely_automatic] object ShowMacros {
+private[sanely_automatic] object ShowMacros {
 
   def deriveTypeClass[A: Type](using q: Quotes): Expr[Show[A]] = new ShowMacros(q).deriveTypeClass[A]
 

--- a/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/FastShowPretty.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/FastShowPretty.scala
@@ -1,0 +1,20 @@
+package hearth.demo.allfeatures
+
+/** Configuration for rendering with indentation support. */
+final case class RenderConfig(
+    indentString: String = "  ", // 2 spaces default
+    startLevel: Int = 0
+)
+object RenderConfig {
+  val Default: RenderConfig = RenderConfig()
+  val Compact: RenderConfig = RenderConfig(indentString = "") // No indent
+  val Tabs: RenderConfig = RenderConfig(indentString = "\t")
+  val FourSpaces: RenderConfig = RenderConfig(indentString = "    ")
+}
+
+trait FastShowPretty[A] {
+
+  /** Renders a value to a StringBuilder with indentation support. */
+  def render(sb: StringBuilder, config: RenderConfig, level: Int)(value: A): StringBuilder
+}
+object FastShowPretty extends FastShowPrettyCompanionCompat

--- a/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/compiletime/FastShowPrettyMacrosImpl.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/compiletime/FastShowPrettyMacrosImpl.scala
@@ -1,0 +1,573 @@
+package hearth.demo.allfeatures.internal.compiletime
+
+import hearth.MacroCommons
+import hearth.fp.data.NonEmptyList
+import hearth.fp.effect.*
+import hearth.fp.syntax.*
+import hearth.std.*
+
+import hearth.demo.allfeatures.{FastShowPretty, RenderConfig}
+import hearth.demo.allfeatures.internal.runtime.FastShowPrettyUtils
+
+@scala.annotation.nowarn
+trait FastShowPrettyMacrosImpl { this: MacroCommons & StdExtensions =>
+
+  // Entrypoints to the macro
+
+  def deriveInline[A: Type](value: Expr[A], config: Expr[RenderConfig], level: Expr[Int]): Expr[String] = {
+    implicit val StringBuilder: Type[StringBuilder] = Types.StringBuilder
+    implicit val String: Type[String] = Types.String
+
+    deriveFromCtxAndAdaptForEntrypoint[A, String]("FastShowPretty.render") { fromCtx =>
+      ValDefs.createVal[StringBuilder](Expr.quote(new StringBuilder)).use { sb =>
+        Expr.quote {
+          Expr.splice(fromCtx(DerivationCtx.from(sb, value, config, level))).toString
+        }
+      }
+    }
+  }
+
+  def deriveTypeClass[A: Type]: Expr[FastShowPretty[A]] = {
+    implicit val FastShowPretty: Type[FastShowPretty[A]] = Types.FastShowPretty[A]
+    implicit val RenderConfigType: Type[RenderConfig] = Types.RenderConfig
+
+    deriveFromCtxAndAdaptForEntrypoint[A, FastShowPretty[A]]("FastShowPretty.derived") { fromCtx =>
+      Expr.quote {
+        new FastShowPretty[A] {
+
+          def render(sb: StringBuilder, config: RenderConfig, level: Int)(value: A): StringBuilder = Expr.splice {
+            fromCtx(
+              DerivationCtx.from(
+                Expr.quote(sb),
+                Expr.quote(value),
+                Expr.quote(config),
+                Expr.quote(level)
+              )
+            )
+          }
+        }
+      }
+    }
+  }
+
+  // Handles logging, error reporting and prepending "cached" defs and vals to the result.
+  // We used a continuation passing style, to allow sharing the same code between:
+  //  - the case that inlines the whole logic to return a String, and
+  //  - the case that returns a FastShowPretty instance.
+
+  def deriveFromCtxAndAdaptForEntrypoint[A: Type, Out: Type](macroName: String)(
+      provideCtxAndAdapt: (DerivationCtx[A] => Expr[StringBuilder]) => Expr[Out]
+  ): Expr[Out] = Log
+    .namedScope(
+      s"Deriving the value ${Type[A].prettyPrint} for ${Type[Out].prettyPrint} at: ${Environment.currentPosition.prettyPrint}"
+    ) {
+      MIO.scoped { runSafe =>
+        val fromCtx: (DerivationCtx[A] => Expr[StringBuilder]) = (ctx: DerivationCtx[A]) =>
+          runSafe {
+            for {
+              // Enables usage of IsCollection, IsMap, etc.
+              _ <- Environment.loadStandardExtensions().toMIO(allowFailures = false)
+              result <- deriveResultRecursively[A](using ctx)
+              cache <- ctx.cache.get
+            } yield cache.toValDefs.use(_ => result)
+          }
+
+        provideCtxAndAdapt(fromCtx)
+      }
+    }
+    .flatTap { result =>
+      Log.info(s"Derived final result for: ${result.prettyPrint}")
+    }
+    .runToExprOrFail(
+      macroName,
+      infoRendering =
+        if (Environment.isExpandedAt("FastShowPrettySpec.scala:358"))
+          hearth.fp.effect.RenderFrom(hearth.fp.effect.Log.Level.Info)
+        else hearth.fp.effect.DontRender,
+      warnRendering = hearth.fp.effect.DontRender,
+      errorRendering = hearth.fp.effect.RenderFrom(hearth.fp.effect.Log.Level.Info)
+    ) { (errorLogs, errors) =>
+      s"""Macro derivation failed with the following errors:
+         |${errors.map(e => s"  - ${e.getMessage()}").mkString("\n")}
+         |and the following logs:
+         |$errorLogs""".stripMargin
+    }
+
+  // Context utilities - instead of passing around multiple types, expressions, helpers,
+  // maybe some config options in the future - we can just pass around a single context object.
+  // If we would have to pass more things, we can just modify it instead of changing every single method signature.
+
+  final case class DerivationCtx[A](
+      tpe: Type[A],
+      sb: Expr[StringBuilder],
+      value: Expr[A],
+      config: Expr[RenderConfig],
+      level: Expr[Int],
+      cache: MLocal[ValDefsCache]
+  ) {
+
+    def nest[B: Type](newValue: Expr[B]): DerivationCtx[B] = copy[B](
+      tpe = Type[B],
+      value = newValue
+    )
+
+    def nestInCache(
+        newSb: Expr[StringBuilder],
+        newValue: Expr[A],
+        newConfig: Expr[RenderConfig],
+        newLevel: Expr[Int]
+    ): DerivationCtx[A] = copy(
+      sb = newSb,
+      value = newValue,
+      config = newConfig,
+      level = newLevel
+    )
+
+    def incrementLevel: DerivationCtx[A] = copy(
+      level = Expr.quote(Expr.splice(level) + 1)
+    )
+
+    // Let us reuse type class instance by "caching" it in a lazy val.
+    def getInstance[B: Type]: MIO[Option[Expr[FastShowPretty[B]]]] = {
+      implicit val FastShowPrettyB: Type[FastShowPretty[B]] = Types.FastShowPretty[B]
+      cache.get0Ary[FastShowPretty[B]]("cached-fast-show-pretty-instance")
+    }
+    def setInstance[B: Type](instance: Expr[FastShowPretty[B]]): MIO[Unit] = {
+      implicit val FastShowPrettyB: Type[FastShowPretty[B]] = Types.FastShowPretty[B]
+      cache.buildCachedWith(
+        "cached-fast-show-pretty-instance",
+        ValDefBuilder.ofLazy[FastShowPretty[B]](s"instance_${Type[B].shortName}")
+      )(_ => instance)
+    }
+
+    // Let us reuse code derived for some type, by putting all: case class handling or enum handling into a local def.
+    def getHelper[B: Type]
+        : MIO[Option[(Expr[StringBuilder], Expr[RenderConfig], Expr[Int], Expr[B]) => Expr[StringBuilder]]] = {
+      implicit val StringBuilderT: Type[StringBuilder] = Types.StringBuilder
+      implicit val RenderConfigT: Type[RenderConfig] = Types.RenderConfig
+      implicit val IntT: Type[Int] = Types.Int
+      cache.get4Ary[StringBuilder, RenderConfig, Int, B, StringBuilder]("cached-render-method")
+    }
+    def setHelper[B: Type](
+        helper: (Expr[StringBuilder], Expr[RenderConfig], Expr[Int], Expr[B]) => MIO[Expr[StringBuilder]]
+    ): MIO[Unit] = {
+      implicit val StringBuilderT: Type[StringBuilder] = Types.StringBuilder
+      implicit val RenderConfigT: Type[RenderConfig] = Types.RenderConfig
+      implicit val IntT: Type[Int] = Types.Int
+      val defBuilder =
+        ValDefBuilder.ofDef4[StringBuilder, RenderConfig, Int, B, StringBuilder](s"render_${Type[B].shortName}")
+      for {
+        _ <- cache.forwardDeclare("cached-render-method", defBuilder)
+        _ <- MIO.scoped { runSafe =>
+          runSafe(cache.buildCachedWith("cached-render-method", defBuilder) { case (_, (sb, config, level, value)) =>
+            runSafe(helper(sb, config, level, value))
+          })
+        }
+      } yield ()
+    }
+
+    override def toString: String =
+      s"render[${tpe.prettyPrint}](sb = ${sb.prettyPrint}, config = ${config.prettyPrint}, level = ${level.prettyPrint})(value = ${value.prettyPrint})"
+  }
+  object DerivationCtx {
+
+    def from[A: Type](
+        sb: Expr[StringBuilder],
+        value: Expr[A],
+        config: Expr[RenderConfig],
+        level: Expr[Int]
+    ): DerivationCtx[A] = DerivationCtx(
+      tpe = Type[A],
+      sb = sb,
+      value = value,
+      config = config,
+      level = level,
+      cache = ValDefsCache.mlocal
+    )
+
+    type Helper[B, R, V] =
+      ValDefBuilder[(Expr[StringBuilder], Expr[RenderConfig], Expr[Int], Expr[B]) => Expr[StringBuilder], R, V]
+  }
+
+  def ctx[A](implicit A: DerivationCtx[A]): DerivationCtx[A] = A
+
+  implicit def currentValueType[A: DerivationCtx]: Type[A] = ctx.tpe
+
+  abstract class DerivationRule(val name: String) extends Rule {
+
+    def apply[A: DerivationCtx]: MIO[Rule.Applicability[Expr[StringBuilder]]]
+  }
+
+  // Reusable components
+
+  private object Types {
+
+    def FastShowPretty: Type.Ctor1[FastShowPretty] = Type.Ctor1.of[FastShowPretty]
+    val StringBuilder: Type[StringBuilder] = Type.of[StringBuilder]
+    val RenderConfig: Type[RenderConfig] = Type.of[RenderConfig]
+
+    val Boolean: Type[Boolean] = Type.of[Boolean]
+    val Byte: Type[Byte] = Type.of[Byte]
+    val Short: Type[Short] = Type.of[Short]
+    val Int: Type[Int] = Type.of[Int]
+    val Long: Type[Long] = Type.of[Long]
+    val Float: Type[Float] = Type.of[Float]
+    val Double: Type[Double] = Type.of[Double]
+    val Char: Type[Char] = Type.of[Char]
+    val String: Type[String] = Type.of[String]
+  }
+
+  // The actual derivation logic in the form of DerivationCtx[A] ?=> MIO[Expr[StringBuilder]].
+
+  def deriveResultRecursively[A: DerivationCtx]: MIO[Expr[StringBuilder]] =
+    Log.namedScope(s"Deriving for type ${Type[A].prettyPrint}") {
+      Rules(
+        UseCachedDefWhenAvailableRule,
+        UseImplicitWhenAvailableRule,
+        UseBuiltInSupportRule,
+        HandleAsCollectionRule,
+        HandleAsCaseClassRule,
+        HandleAsEnumRule
+      )(_[A]).flatMap {
+        case Right(result) =>
+          Log.info(s"Derived result for ${Type[A].prettyPrint}: ${result.prettyPrint}") >>
+            MIO.pure(result)
+        case Left(reasons) =>
+          val reasonsStrings = reasons.toListMap
+            .removed(UseCachedDefWhenAvailableRule)
+            .view
+            .map { case (rule, reasons) =>
+              if (reasons.isEmpty) s"The rule ${rule.name} was not applicable"
+              else s" - The rule ${rule.name} was not applicable, for the following reasons: ${reasons.mkString(", ")}"
+            }
+            .toList
+          Log.info(s"Failed to derive result for ${Type[A].prettyPrint}:\n${reasonsStrings.mkString("\n")}") >>
+            MIO.fail(DerivationError.UnsupportedType(Type[A].prettyPrint, reasonsStrings))
+      }
+    }
+
+  // Particular derivation rules - the first one that applies (succeeding OR failing) is used.
+
+  object UseCachedDefWhenAvailableRule extends DerivationRule("use cached def when available") {
+
+    def apply[A: DerivationCtx]: MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      Log.info(s"Attempting to use cached definition for ${Type[A].prettyPrint}") >>
+        ctx.getInstance[A].flatMap {
+          case Some(instance) => callCachedInstance[A](instance)
+          case None           =>
+            ctx.getHelper[A].flatMap {
+              case Some(helperCall) => callCachedHelper[A](helperCall)
+              case None             => yieldUnsupportedType[A]
+            }
+        }
+
+    private def callCachedInstance[A: DerivationCtx](
+        instance: Expr[FastShowPretty[A]]
+    ): MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      Log.info(s"Found cached instance for ${Type[A].prettyPrint}, using it") >> MIO.pure(Rule.matched(Expr.quote {
+        Expr
+          .splice(instance)
+          .render(Expr.splice(ctx.sb), Expr.splice(ctx.config), Expr.splice(ctx.level))(Expr.splice(ctx.value))
+      }))
+
+    private def callCachedHelper[A: DerivationCtx](
+        helperCall: (Expr[StringBuilder], Expr[RenderConfig], Expr[Int], Expr[A]) => Expr[StringBuilder]
+    ): MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      Log.info(s"Found cached helper call for ${Type[A].prettyPrint}, using it") >> MIO.pure(
+        Rule.matched(helperCall(ctx.sb, ctx.config, ctx.level, ctx.value))
+      )
+
+    private def yieldUnsupportedType[A: DerivationCtx]: MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} does not have a cached definition"))
+
+  }
+
+  object UseImplicitWhenAvailableRule extends DerivationRule("use implicit when available") {
+
+    lazy val ignoredImplicits = Type.of[FastShowPretty.type].methods.collect {
+      case method if method.value.name == "derived" => method.value.asUntyped
+    }
+
+    def apply[A: DerivationCtx]: MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      Log.info(s"Attempting to use implicit support for ${Type[A].prettyPrint}") >> {
+        Types.FastShowPretty[A].summonExprIgnoring(ignoredImplicits*).toEither match {
+          case Right(instanceExpr) => cacheImplicitAndUseIt[A](instanceExpr)
+          case Left(reason)        => yieldUnsupportedType[A](reason)
+        }
+      }
+
+    private def cacheImplicitAndUseIt[A: DerivationCtx](
+        instanceExpr: Expr[FastShowPretty[A]]
+    ): MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      Log.info(s"Found implicit ${instanceExpr.prettyPrint}, caching it and using a cached value") >>
+        ctx.setInstance[A](instanceExpr) >> UseCachedDefWhenAvailableRule[A]
+
+    private def yieldUnsupportedType[A: DerivationCtx](reason: String): MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      MIO.pure(
+        Rule.yielded(
+          s"The type ${Type[A].prettyPrint} does not have an implicit FastShowPretty instance: $reason"
+        )
+      )
+  }
+
+  object UseBuiltInSupportRule extends DerivationRule("use built-in support when handling primitive types") {
+
+    implicit val Boolean: Type[Boolean] = Types.Boolean
+    implicit val Byte: Type[Byte] = Types.Byte
+    implicit val Short: Type[Short] = Types.Short
+    implicit val Int: Type[Int] = Types.Int
+    implicit val Long: Type[Long] = Types.Long
+    implicit val Float: Type[Float] = Types.Float
+    implicit val Double: Type[Double] = Types.Double
+    implicit val Char: Type[Char] = Types.Char
+    implicit val String: Type[String] = Types.String
+
+    def apply[A: DerivationCtx]: MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      Log.info(s"Attempting to use built-in support for ${Type[A].prettyPrint}") >> MIO {
+        if (Type[A] <:< Type[Boolean]) Rule.matched(Expr.quote {
+          FastShowPrettyUtils.renderBoolean(Expr.splice(ctx.sb))(Expr.splice(ctx.value.upcast[Boolean]))
+        })
+        else if (Type[A] <:< Type[Byte]) Rule.matched(Expr.quote {
+          FastShowPrettyUtils.renderByte(Expr.splice(ctx.sb))(Expr.splice(ctx.value.upcast[Byte]))
+        })
+        else if (Type[A] <:< Type[Short]) Rule.matched(Expr.quote {
+          FastShowPrettyUtils.renderShort(Expr.splice(ctx.sb))(Expr.splice(ctx.value.upcast[Short]))
+        })
+        else if (Type[A] <:< Type[Int]) Rule.matched(Expr.quote {
+          FastShowPrettyUtils.renderInt(Expr.splice(ctx.sb))(Expr.splice(ctx.value.upcast[Int]))
+        })
+        else if (Type[A] <:< Type[Long]) Rule.matched(Expr.quote {
+          FastShowPrettyUtils.renderLong(Expr.splice(ctx.sb))(Expr.splice(ctx.value.upcast[Long]))
+        })
+        else if (Type[A] <:< Type[Float]) Rule.matched(Expr.quote {
+          FastShowPrettyUtils.renderFloat(Expr.splice(ctx.sb))(Expr.splice(ctx.value.upcast[Float]))
+        })
+        else if (Type[A] <:< Type[Double]) Rule.matched(Expr.quote {
+          FastShowPrettyUtils.renderDouble(Expr.splice(ctx.sb))(Expr.splice(ctx.value.upcast[Double]))
+        })
+        else if (Type[A] <:< Type[Char]) Rule.matched(Expr.quote {
+          FastShowPrettyUtils.renderChar(Expr.splice(ctx.sb))(Expr.splice(ctx.value.upcast[Char]))
+        })
+        else if (Type[A] <:< Type[String]) Rule.matched(Expr.quote {
+          FastShowPrettyUtils.renderString(Expr.splice(ctx.sb))(Expr.splice(ctx.value.upcast[String]))
+        })
+        else Rule.yielded(s"The type ${Type[A].prettyPrint} is not considered to be a built-in type")
+      }
+  }
+
+  object HandleAsCollectionRule extends DerivationRule("handle as collection when possible") {
+    implicit val StringBuilder: Type[StringBuilder] = Types.StringBuilder
+
+    def apply[A: DerivationCtx]: MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+        Type[A] match {
+          case IsCollection(isCollection) =>
+            import isCollection.Underlying as Item
+            deriveCollectionItems(isCollection.value)
+
+          case _ =>
+            yieldUnsupportedType[A]
+        }
+      }
+
+    private def deriveCollectionItems[A: DerivationCtx, Item: Type](
+        isCollection: IsCollectionOf[A, Item]
+    ): MIO[Rule.Applicability[Expr[StringBuilder]]] = {
+      val name = Expr(Type[A].shortName)
+      val iterableExpr = isCollection.asIterable(ctx.value)
+
+      LambdaBuilder
+        .of1[Item]("item")
+        .traverse { itemExpr =>
+          // TODO: possible .incrementLevel
+          deriveResultRecursively[Item](using ctx.nest(itemExpr))
+        }
+        .map { builder =>
+          // TODO: this creates error on Scala 3:
+          val lambda =
+            try
+              // the solution we want
+              builder.build[StringBuilder]
+            catch {
+              case e: Throwable =>
+                e.printStackTrace()
+                // workaround to no fight unrelated compilation errors end stuff
+                Expr.quote((_: Item) => Expr.splice(ctx.sb))
+            }
+          Rule.matched(Expr.quote {
+            FastShowPrettyUtils.openCollection(Expr.splice(ctx.sb), Expr.splice(name))
+            FastShowPrettyUtils.fillCollection(Expr.splice(ctx.sb), Expr.splice(iterableExpr))(Expr.splice(lambda))
+            FastShowPrettyUtils
+              .appendIndent(Expr.splice(ctx.sb), Expr.splice(ctx.config).indentString, Expr.splice(ctx.level))
+            FastShowPrettyUtils.closeCollection(Expr.splice(ctx.sb))
+          })
+        }
+    }
+
+    private def yieldUnsupportedType[A: DerivationCtx]: MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not considered to be a collection"))
+  }
+
+  object HandleAsCaseClassRule extends DerivationRule("handle as case class when possible") {
+
+    def apply[A: DerivationCtx]: MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a case class") >> {
+        CaseClass.parse[A] match {
+          case Some(caseClass) =>
+            for {
+              _ <- ctx.setHelper[A] { (sb, config, level, value) =>
+                deriveCaseClassFields[A](caseClass)(using ctx.nestInCache(sb, value, config, level))
+              }
+              result <- ctx.getHelper[A].flatMap {
+                case Some(helperCall) => MIO.pure(Rule.matched(helperCall(ctx.sb, ctx.config, ctx.level, ctx.value)))
+                case None             => yieldUnsupportedType[A]
+              }
+            } yield result
+
+          case None =>
+            yieldUnsupportedType[A]
+        }
+      }
+
+    private def deriveCaseClassFields[A: DerivationCtx](
+        caseClass: CaseClass[A]
+    ): MIO[Expr[StringBuilder]] = {
+      val name = Expr(Type[A].shortName)
+
+      NonEmptyList.fromList(caseClass.caseFieldValuesAt(ctx.value).toList) match {
+        case Some(fieldValues) =>
+          fieldValues
+            .parTraverse { case (fieldName, fieldValue) =>
+              import fieldValue.{Underlying as Field, value as fieldExpr}
+              Log.namedScope(s"Deriving the value ${ctx.value.prettyPrint}.$fieldName: ${Field.prettyPrint}") {
+                // Use incrementLevel so nested case classes are indented properly
+                deriveResultRecursively[Field](using ctx.incrementLevel.nest(fieldExpr)).map { fieldResult =>
+                  (fieldName, fieldResult)
+                }
+              }
+            }
+            .map { toAppend =>
+              val renderLeftParenthesisAndHeadField = toAppend.head match {
+                case (fieldName, fieldResult) =>
+                  // TODO: fix in cross-quotes on Scala 2!!!
+                  // private[this] val x$$4 - is generated by val _ = ... !!!
+                  Expr.quote {
+                    Expr
+                      .splice(ctx.sb)
+                      .append(Expr.splice(name))
+                      .append("(\n")
+                    FastShowPrettyUtils
+                      .appendIndent(
+                        Expr.splice(ctx.sb),
+                        Expr.splice(ctx.config).indentString,
+                        Expr.splice(ctx.level) + 1
+                      )
+                      .append(Expr.splice(Expr(fieldName)))
+                      .append(" = ")
+                    Expr.splice(fieldResult)
+                  }
+              }
+              val renderAllFields = toAppend.tail.foldLeft(renderLeftParenthesisAndHeadField) {
+                case (renderPreviousFields, (fieldName, fieldResult)) =>
+                  Expr.quote {
+                    Expr
+                      .splice(renderPreviousFields)
+                      .append(",\n")
+                    FastShowPrettyUtils
+                      .appendIndent(
+                        Expr.splice(ctx.sb),
+                        Expr.splice(ctx.config).indentString,
+                        Expr.splice(ctx.level) + 1
+                      )
+                      .append(Expr.splice(Expr(fieldName)))
+                      .append(" = ")
+                    Expr.splice(fieldResult)
+                  }
+              }
+
+              Expr.quote {
+                Expr.splice(renderAllFields).append("\n")
+                FastShowPrettyUtils
+                  .appendIndent(
+                    Expr.splice(ctx.sb),
+                    Expr.splice(ctx.config).indentString,
+                    Expr.splice(ctx.level)
+                  )
+                  .append(")")
+              }
+            }
+        case None =>
+          MIO.pure {
+            Expr.quote {
+              Expr.splice(ctx.sb).append(Expr.splice(name)).append("()")
+            }
+          }
+      }
+    }
+
+    private def yieldUnsupportedType[A: DerivationCtx]: MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not considered to be a case class"))
+  }
+
+  object HandleAsEnumRule extends DerivationRule("handle as enum when possible") {
+
+    def apply[A: DerivationCtx]: MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as an enum") >> {
+        Enum.parse[A] match {
+          case Some(enumm) =>
+            for {
+              _ <- ctx.setHelper[A] { (sb, config, level, value) =>
+                deriveEnumCases[A](enumm)(using ctx.nestInCache(sb, value, config, level))
+              }
+              result <- ctx.getHelper[A].flatMap {
+                case Some(helperCall) => MIO.pure(Rule.matched(helperCall(ctx.sb, ctx.config, ctx.level, ctx.value)))
+                case None             => yieldUnsupportedType[A]
+              }
+            } yield result
+          case None =>
+            yieldUnsupportedType[A]
+        }
+      }
+
+    private def deriveEnumCases[A: DerivationCtx](
+        enumm: Enum[A]
+    ): MIO[Expr[StringBuilder]] = {
+      val name = Expr(Type[A].shortName)
+
+      implicit val StringBuilder: Type[StringBuilder] = Types.StringBuilder
+
+      enumm
+        .parMatchOn[MIO, StringBuilder](ctx.value) { matched =>
+          import matched.{value as enumCaseValue, Underlying as EnumCase}
+          Log.namedScope(s"Deriving the value ${enumCaseValue.prettyPrint}: ${EnumCase.prettyPrint}") {
+            // Use incrementLevel so nested case classes in enum cases are indented properly
+            deriveResultRecursively[EnumCase](using ctx.incrementLevel.nest(enumCaseValue)).map { enumCaseResult =>
+              Expr.quote {
+                Expr.splice(ctx.sb).append("(")
+                Expr.splice(enumCaseResult).append("): ").append(Expr.splice(name))
+              }
+            }
+          }
+        }
+        .flatMap {
+          case Some(result) =>
+            MIO.pure(result)
+          case None =>
+            MIO.fail(new RuntimeException(s"The type ${Type[A].prettyPrint} does not have any children!"))
+        }
+    }
+
+    private def yieldUnsupportedType[A: DerivationCtx]: MIO[Rule.Applicability[Expr[StringBuilder]]] =
+      MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not considered to be an enum"))
+  }
+}
+
+sealed private[compiletime] trait DerivationError extends util.control.NoStackTrace with Product with Serializable {
+  def message: String
+  override def getMessage(): String = message
+}
+private[compiletime] object DerivationError {
+  final case class UnsupportedType(tpeName: String, reasons: List[String]) extends DerivationError {
+    override def message: String = s"The type $tpeName was "
+  }
+}

--- a/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/compiletime/FastShowPrettyMacrosImpl.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/compiletime/FastShowPrettyMacrosImpl.scala
@@ -253,13 +253,6 @@ trait FastShowPrettyMacrosImpl { this: MacroCommons & StdExtensions =>
               MIO.fail(DerivationError.UnsupportedType(Type[A].prettyPrint, reasonsStrings))
         }
       }
-      .attemptTap {
-        case Right(result) =>
-        case Left(errors)  =>
-          if (Environment.isExpandedAt("FastShowPrettySpec.scala")) {
-            errors.toList.foreach(e => e.printStackTrace())
-          }
-      }
 
   // Particular derivation rules - the first one that applies (succeeding OR failing) is used.
 

--- a/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/runtime/FastShowPrettyUtils.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/runtime/FastShowPrettyUtils.scala
@@ -71,7 +71,9 @@ object FastShowPrettyUtils {
       sb.append("\n")
       val _ = renderItem(item)
       if (iterator.hasNext) {
-        sb.append(", ")
+        sb.append(",")
+      } else {
+        sb.append("\n")
       }
     }
     sb
@@ -87,13 +89,13 @@ object FastShowPrettyUtils {
 
   /** Opens a map entry rendering. */
   def openMapEntry(sb: StringBuilder): StringBuilder =
-    sb
+    sb.append("(")
 
-  /** Appends the arrow separator between key and value in a map entry. */
+  /** Appends the separator between key and value in a map entry. */
   def appendMapArrow(sb: StringBuilder): StringBuilder =
-    sb.append(" -> ")
+    sb.append(", ")
 
   /** Closes a map entry rendering. */
   def closeMapEntry(sb: StringBuilder): StringBuilder =
-    sb
+    sb.append(")")
 }

--- a/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/runtime/FastShowPrettyUtils.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/runtime/FastShowPrettyUtils.scala
@@ -26,7 +26,7 @@ object FastShowPrettyUtils {
     val result = value.toString
     sb.append(result)
     // Workaround for https://www.scala-js.org/doc/semantics.html#tostring-of-float-double-and-unit
-    if (result.contains(".")) {
+    if (!result.contains(".")) {
       sb.append(".0")
     }
     sb.append('f')
@@ -35,7 +35,7 @@ object FastShowPrettyUtils {
     val result = value.toString
     sb.append(result)
     // Workaround for https://www.scala-js.org/doc/semantics.html#tostring-of-float-double-and-unit
-    if (result.contains(".")) {
+    if (!result.contains(".")) {
       sb.append(".0")
     }
     sb.append('d')

--- a/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/runtime/FastShowPrettyUtils.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/runtime/FastShowPrettyUtils.scala
@@ -1,0 +1,99 @@
+package hearth.demo.allfeatures.internal.runtime
+
+object FastShowPrettyUtils {
+
+  /** Appends indentation (indentString repeated level times) to the StringBuilder. */
+  def appendIndent(sb: StringBuilder, indentString: String, level: Int): StringBuilder = {
+    var i = 0
+    while (i < level) {
+      sb.append(indentString)
+      i += 1
+    }
+    sb
+  }
+
+  def renderBoolean(sb: StringBuilder)(value: Boolean): StringBuilder =
+    if (value) sb.append("true") else sb.append("false")
+  def renderByte(sb: StringBuilder)(value: Byte): StringBuilder =
+    sb.append(value.toString).append(".toByte")
+  def renderShort(sb: StringBuilder)(value: Short): StringBuilder =
+    sb.append(value.toString).append(".toShort")
+  def renderInt(sb: StringBuilder)(value: Int): StringBuilder =
+    sb.append(value.toString)
+  def renderLong(sb: StringBuilder)(value: Long): StringBuilder =
+    sb.append(value.toString).append('L')
+  def renderFloat(sb: StringBuilder)(value: Float): StringBuilder = {
+    val result = value.toString
+    sb.append(result)
+    // Workaround for https://www.scala-js.org/doc/semantics.html#tostring-of-float-double-and-unit
+    if (result.contains(".")) {
+      sb.append(".0")
+    }
+    sb.append('f')
+  }
+  def renderDouble(sb: StringBuilder)(value: Double): StringBuilder = {
+    val result = value.toString
+    sb.append(result)
+    // Workaround for https://www.scala-js.org/doc/semantics.html#tostring-of-float-double-and-unit
+    if (result.contains(".")) {
+      sb.append(".0")
+    }
+    sb.append('d')
+  }
+  def renderChar(sb: StringBuilder)(value: Char): StringBuilder =
+    sb.append("'").append(value.toString).append("'")
+  def renderString(sb: StringBuilder)(value: String): StringBuilder = {
+    sb.append('"')
+    var i = 0
+    while (i < value.length) {
+      val c = value.charAt(i)
+      c match {
+        case '"'  => sb.append("\\\"")
+        case '\\' => sb.append("\\\\")
+        case '\n' => sb.append("\\n")
+        case '\r' => sb.append("\\r")
+        case '\t' => sb.append("\\t")
+        case _    => sb.append(c)
+      }
+      i += 1
+    }
+    sb.append('"')
+  }
+
+  /** Opens a collection rendering with the collection type name and opening bracket. */
+  def openCollection(sb: StringBuilder, typeName: String): StringBuilder =
+    sb.append(typeName).append("(")
+
+  def fillCollection[A](sb: StringBuilder, iterable: Iterable[A])(renderItem: A => StringBuilder): StringBuilder = {
+    val iterator = iterable.iterator
+    while (iterator.hasNext) {
+      val item = iterator.next()
+      sb.append("\n")
+      val _ = renderItem(item)
+      if (iterator.hasNext) {
+        sb.append(", ")
+      }
+    }
+    sb
+  }
+
+  /** Appends a separator between collection elements. */
+  def appendCollectionSeparator(sb: StringBuilder): StringBuilder =
+    sb.append(", ")
+
+  /** Closes a collection rendering with the closing bracket. */
+  def closeCollection(sb: StringBuilder): StringBuilder =
+    sb.append(")")
+
+  /** Opens a map entry rendering. */
+  def openMapEntry(sb: StringBuilder): StringBuilder =
+    sb
+
+  /** Appends the arrow separator between key and value in a map entry. */
+  def appendMapArrow(sb: StringBuilder): StringBuilder =
+    sb.append(" -> ")
+
+  /** Closes a map entry rendering. */
+  def closeMapEntry(sb: StringBuilder): StringBuilder =
+    sb
+}

--- a/hearth-tests/src/main/scala-newest/hearth/demo/sanely_automatic/Show.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/sanely_automatic/Show.scala
@@ -1,8 +1,9 @@
 // We've put things into a separate package and do not use:
 //   package hearth
-//   package demo_sanely_automatic
+//   package demo
+//   package sanely_automatic
 // here, because we want to show all the imports normal users would have to do.
-package hearth.demo_sanely_automatic
+package hearth.demo.sanely_automatic
 
 /** Example of Show type class with sanely-automatic derivation.
   *
@@ -27,7 +28,7 @@ object Show extends ShowCompanionCompat {
   /** Special type - is its implicit is in scope then macros will log the derivation process.
     *
     * @see
-    *   [[hearth.demo_sanely_automatic.debug.logDerivation]] for details
+    *   [[hearth.demo.sanely_automatic.debug.logDerivation]] for details
     */
   sealed trait LogDerivation
   object LogDerivation extends LogDerivation

--- a/hearth-tests/src/main/scala-newest/hearth/demo/sanely_automatic/debug/package.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/sanely_automatic/debug/package.scala
@@ -1,8 +1,9 @@
 // We've put things into a separate package and do not use:
 //   package hearth
 //   package demo
+//   package sanely_automatic
 // here, because we want to show all the imports normal users would have to do.
-package hearth.demo
+package hearth.demo.sanely_automatic
 
 package object debug {
 

--- a/hearth-tests/src/main/scala/hearth/demo/simple/Show.scala
+++ b/hearth-tests/src/main/scala/hearth/demo/simple/Show.scala
@@ -1,8 +1,9 @@
 // We've put things into a separate package and do not use:
 //   package hearth
 //   package demo
+//   package simple
 // here, because we want to show all the imports normal users would have to do.
-package hearth.demo
+package hearth.demo.simple
 
 /** Example of Show type class with sanely-automatic derivation.
   *
@@ -26,8 +27,14 @@ object Show extends ShowCompanionCompat {
     case show: Show[A] => show
   }
 
-  // Pre 2.13.17 and 3.7.0 we need this trick to avoid summoning the implicit value automatically.
-  // See hearth.demo_sanely_automatic for version which does not need this trick.
+  /** Pre 2.13.17 and 3.7.0 we need this trick to avoid summoning the implicit value automatically.
+    *
+    * @see
+    *   [[hearth.demo.sanely_automatic.Show]] for version which does not need this trick!
+    * @see
+    *   [[hearth.demo.allfeatures.FastShowPretty]] for version which NOT only does not need this trick, but also
+    *   utilizes every feature of this library!
+    */
   sealed trait AutoDerived[A] {
 
     def show(value: A): String

--- a/hearth-tests/src/main/scala/hearth/demo/simple/debug/package.scala
+++ b/hearth-tests/src/main/scala/hearth/demo/simple/debug/package.scala
@@ -1,8 +1,9 @@
 // We've put things into a separate package and do not use:
 //   package hearth
-//   package demo_sanely_automatic
+//   package demo
+//   package simple
 // here, because we want to show all the imports normal users would have to do.
-package hearth.demo_sanely_automatic
+package hearth.demo.simple
 
 package object debug {
 

--- a/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
@@ -1410,6 +1410,711 @@ trait ExprsFixturesImpl { this: MacroTypedCommons & hearth.untyped.UntypedMethod
       ._2
       .fold(es => throw es.head, identity)
 
+  // ValDefBuilder scope issue tests
+
+  def testValDefBuilderOfValScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfValInner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfValInner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofVal[Int]("v")
+            .traverse[MIO, Expr[Int]] { _ =>
+              MIO.pure(Expr.quote(42))
+            }
+            .map(_.build.close)
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfVarScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfVarInner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfVarInner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofVar[Int]("v")
+            .traverse[MIO, Expr[Int]] { _ =>
+              MIO.pure(Expr.quote(42))
+            }
+            .map(_.build.close)
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfLazyScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfLazyInner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfLazyInner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofLazy[Int]("v")
+            .traverse[MIO, Expr[Int]] { _ =>
+              MIO.pure(Expr.quote(42))
+            }
+            .map(_.build.close)
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef0ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef0Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef0Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef0[Int]("d")
+            .traverse[MIO, Expr[Int]] { _ =>
+              MIO.pure(Expr.quote(42))
+            }
+            .map(_.build.close)
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  // format: off
+  def testValDefBuilderOfDef1ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef1Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef1Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef1[Int, Int]("d", "a")
+            .traverse[MIO, Expr[Int]] { case (_, a) =>
+              MIO.pure(Expr.quote(Expr.splice(a) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef2ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef2Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef2Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef2[Int, Int, Int]("d", "a", "b")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef3ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef3Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef3Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef3[Int, Int, Int, Int]("d", "a", "b", "c")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef4ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef4Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef4Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef4[Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef5ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef5Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef5Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef5[Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef6ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef6Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef6Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef6[Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef7ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef7Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef7Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef7[Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef8ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef8Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef8Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef8[Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef9ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef9Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef9Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef9[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef10ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef10Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef10Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef10[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i", "j")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i, j)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) * Expr.splice(j) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23), Expr.quote(29))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef11ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef11Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef11Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef11[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i", "j", "k")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i, j, k)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) * Expr.splice(j) * Expr.splice(k) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23), Expr.quote(29), Expr.quote(31))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef12ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef12Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef12Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef12[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i", "j", "k", "l")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i, j, k, l)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) * Expr.splice(j) * Expr.splice(k) * Expr.splice(l) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23), Expr.quote(29), Expr.quote(31), Expr.quote(37))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef13ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef13Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef13Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef13[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i", "j", "k", "l", "m")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i, j, k, l, m)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) * Expr.splice(j) * Expr.splice(k) * Expr.splice(l) * Expr.splice(m) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23), Expr.quote(29), Expr.quote(31), Expr.quote(37), Expr.quote(41))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef14ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef14Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef14Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef14[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i, j, k, l, m, n)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) * Expr.splice(j) * Expr.splice(k) * Expr.splice(l) * Expr.splice(m) * Expr.splice(n) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23), Expr.quote(29), Expr.quote(31), Expr.quote(37), Expr.quote(41), Expr.quote(43))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef15ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef15Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef15Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef15[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) * Expr.splice(j) * Expr.splice(k) * Expr.splice(l) * Expr.splice(m) * Expr.splice(n) * Expr.splice(o) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23), Expr.quote(29), Expr.quote(31), Expr.quote(37), Expr.quote(41), Expr.quote(43), Expr.quote(47))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef16ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef16Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef16Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef16[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) * Expr.splice(j) * Expr.splice(k) * Expr.splice(l) * Expr.splice(m) * Expr.splice(n) * Expr.splice(o) * Expr.splice(p) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23), Expr.quote(29), Expr.quote(31), Expr.quote(37), Expr.quote(41), Expr.quote(43), Expr.quote(47), Expr.quote(53))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef17ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef17Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef17Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef17[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) * Expr.splice(j) * Expr.splice(k) * Expr.splice(l) * Expr.splice(m) * Expr.splice(n) * Expr.splice(o) * Expr.splice(p) * Expr.splice(q) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23), Expr.quote(29), Expr.quote(31), Expr.quote(37), Expr.quote(41), Expr.quote(43), Expr.quote(47), Expr.quote(53), Expr.quote(59))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef18ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef18Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef18Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef18[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) * Expr.splice(j) * Expr.splice(k) * Expr.splice(l) * Expr.splice(m) * Expr.splice(n) * Expr.splice(o) * Expr.splice(p) * Expr.splice(q) * Expr.splice(r) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23), Expr.quote(29), Expr.quote(31), Expr.quote(37), Expr.quote(41), Expr.quote(43), Expr.quote(47), Expr.quote(53), Expr.quote(59), Expr.quote(61))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef19ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef19Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef19Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef19[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) * Expr.splice(j) * Expr.splice(k) * Expr.splice(l) * Expr.splice(m) * Expr.splice(n) * Expr.splice(o) * Expr.splice(p) * Expr.splice(q) * Expr.splice(r) * Expr.splice(s) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23), Expr.quote(29), Expr.quote(31), Expr.quote(37), Expr.quote(41), Expr.quote(43), Expr.quote(47), Expr.quote(53), Expr.quote(59), Expr.quote(61), Expr.quote(67))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef20ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef20Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef20Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef20[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) * Expr.splice(j) * Expr.splice(k) * Expr.splice(l) * Expr.splice(m) * Expr.splice(n) * Expr.splice(o) * Expr.splice(p) * Expr.splice(q) * Expr.splice(r) * Expr.splice(s) * Expr.splice(t) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23), Expr.quote(29), Expr.quote(31), Expr.quote(37), Expr.quote(41), Expr.quote(43), Expr.quote(47), Expr.quote(53), Expr.quote(59), Expr.quote(61), Expr.quote(67), Expr.quote(71))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef21ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef21Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef21Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef21[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) * Expr.splice(j) * Expr.splice(k) * Expr.splice(l) * Expr.splice(m) * Expr.splice(n) * Expr.splice(o) * Expr.splice(p) * Expr.splice(q) * Expr.splice(r) * Expr.splice(s) * Expr.splice(t) * Expr.splice(u) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23), Expr.quote(29), Expr.quote(31), Expr.quote(37), Expr.quote(41), Expr.quote(43), Expr.quote(47), Expr.quote(53), Expr.quote(59), Expr.quote(61), Expr.quote(67), Expr.quote(71), Expr.quote(73))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
+  def testValDefBuilderOfDef22ScopeIssue: Expr[Data] = {
+    val result: Expr[Int] = Expr.quote {
+      val x: Int = Expr.splice {
+        valDefScopeIssueOfDef22Inner(Type.of[Int])
+      }
+      x
+    }
+    Expr.quote(Data(Expr.splice(result)))
+  }
+
+  private def valDefScopeIssueOfDef22Inner(implicit intType: Type[Int]): Expr[Int] =
+    MIO
+      .scoped { runSafe =>
+        runSafe {
+          ValDefBuilder
+            .ofDef22[Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int]("d", "a", "b", "c", "d0", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v")
+            .traverse[MIO, Expr[Int]] { case (_, (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v)) =>
+              MIO.pure(Expr.quote(Expr.splice(a) * Expr.splice(b) * Expr.splice(c) * Expr.splice(d) * Expr.splice(e) * Expr.splice(f) * Expr.splice(g) * Expr.splice(h) * Expr.splice(i) * Expr.splice(j) * Expr.splice(k) * Expr.splice(l) * Expr.splice(m) * Expr.splice(n) * Expr.splice(o) * Expr.splice(p) * Expr.splice(q) * Expr.splice(r) * Expr.splice(s) * Expr.splice(t) * Expr.splice(u) * Expr.splice(v) + 1))
+            }
+            .map(_.build.use(_(Expr.quote(2), Expr.quote(3), Expr.quote(5), Expr.quote(7), Expr.quote(11), Expr.quote(13), Expr.quote(17), Expr.quote(19), Expr.quote(23), Expr.quote(29), Expr.quote(31), Expr.quote(37), Expr.quote(41), Expr.quote(43), Expr.quote(47), Expr.quote(53), Expr.quote(59), Expr.quote(61), Expr.quote(67), Expr.quote(71), Expr.quote(73), Expr.quote(79))))
+        }
+      }
+      .unsafe
+      .runSync
+      ._2
+      .fold(es => throw es.head, identity)
+
   // format: on
 
   // ExprCodecs

--- a/hearth-tests/src/test/scala-3/hearth/typed/ExprsScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/ExprsScala3Spec.scala
@@ -1,0 +1,74 @@
+package hearth
+package typed
+
+import hearth.data.Data
+
+/** Scala 3-only tests for [[passQuotes]] and [[withQuotes]] utilities.
+  *
+  * These tests verify that [[LambdaBuilder]] and [[ValDefBuilder]] work correctly when using native Scala 3 quoting
+  * syntax (`'{...}` / `${...}`) with explicit [[passQuotes]]/[[withQuotes]] calls, as opposed to the cross-quotes
+  * ([[Expr.quote]]/[[Expr.splice]]) approach tested in [[ExprsSpec]].
+  *
+  * Macro implementation is in [[ExprsScala3Fixtures]].
+  */
+final class ExprsScala3Spec extends MacroSuite {
+
+  group("trait typed.Exprs (Scala 3, passQuotes/withQuotes)") {
+
+    group("type LambdaBuilder scope issue") {
+
+      test("method LambdaBuilder.of1 should handle body Expr from different scope") {
+        import ExprsScala3Fixtures.testLambdaBuilderOf1ScopeIssue
+
+        testLambdaBuilderOf1ScopeIssue ==> Data(2 + 1)
+      }
+
+      test("method LambdaBuilder.of2 should handle body Expr from different scope") {
+        import ExprsScala3Fixtures.testLambdaBuilderOf2ScopeIssue
+
+        testLambdaBuilderOf2ScopeIssue ==> Data(2 * 3 + 1)
+      }
+
+      test("method LambdaBuilder.of3 should handle body Expr from different scope") {
+        import ExprsScala3Fixtures.testLambdaBuilderOf3ScopeIssue
+
+        testLambdaBuilderOf3ScopeIssue ==> Data(2 * 3 * 5 + 1)
+      }
+    }
+
+    group("type ValDefBuilder scope issue") {
+
+      test("method ValDefBuilder.ofVal should handle body Expr from different scope") {
+        import ExprsScala3Fixtures.testValDefBuilderOfValScopeIssue
+
+        testValDefBuilderOfValScopeIssue ==> Data(42)
+      }
+
+      test("method ValDefBuilder.ofVar should handle body Expr from different scope") {
+        import ExprsScala3Fixtures.testValDefBuilderOfVarScopeIssue
+
+        @scala.annotation.nowarn // suppress "local var v$macro$N in value <local ExprsScala3Spec> is never updated" error
+        val result = testValDefBuilderOfVarScopeIssue
+        result ==> Data(42)
+      }
+
+      test("method ValDefBuilder.ofLazy should handle body Expr from different scope") {
+        import ExprsScala3Fixtures.testValDefBuilderOfLazyScopeIssue
+
+        testValDefBuilderOfLazyScopeIssue ==> Data(42)
+      }
+
+      test("method ValDefBuilder.ofDef0 should handle body Expr from different scope") {
+        import ExprsScala3Fixtures.testValDefBuilderOfDef0ScopeIssue
+
+        testValDefBuilderOfDef0ScopeIssue ==> Data(42)
+      }
+
+      test("method ValDefBuilder.ofDef1 should handle body Expr from different scope") {
+        import ExprsScala3Fixtures.testValDefBuilderOfDef1ScopeIssue
+
+        testValDefBuilderOfDef1ScopeIssue ==> Data(2 + 1)
+      }
+    }
+  }
+}

--- a/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
+++ b/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
@@ -131,31 +131,28 @@ final class FastShowPrettySpec extends MacroSuite {
           )
         }
 
-        // TODO: case class with collection field fails due to cross-quotes scope issue
-        //   when case classes are nested inside collections during inline macro expansion.
-        //   Error: "Expression created in a splice was used outside of that splice"
-        // test("case class with collection field") {
-        //   val result = FastShowPretty.render(
-        //     Team("Engineering", List(Person("Alice", 30), Person("Bob", 25))),
-        //     RenderConfig.Default
-        //   )
-        //   assertEquals(
-        //     result,
-        //     """Team(
-        //       |  name = "Engineering",
-        //       |  members = List(
-        //       |    Person(
-        //       |      name = "Alice",
-        //       |      age = 30
-        //       |    ),
-        //       |    Person(
-        //       |      name = "Bob",
-        //       |      age = 25
-        //       |    )
-        //       |  )
-        //       |)""".stripMargin
-        //   )
-        // }
+        test("case class with collection field") {
+          val result = FastShowPretty.render(
+            Team("Engineering", List(Person("Alice", 30), Person("Bob", 25))),
+            RenderConfig.Default
+          )
+          assertEquals(
+            result,
+            """Team(
+              |  name = "Engineering",
+              |  members = List(
+              |    Person(
+              |      name = "Alice",
+              |      age = 30
+              |    ),
+              |    Person(
+              |      name = "Bob",
+              |      age = 25
+              |    )
+              |  )
+              |)""".stripMargin
+          )
+        }
       }
 
       group("collections") {
@@ -199,28 +196,27 @@ final class FastShowPrettySpec extends MacroSuite {
           )
         }
 
-        // TODO: List of case classes fails due to cross-quotes scope issue
-        //   when case classes are nested inside collections during inline macro expansion.
-        //   Error: "Expression created in a splice was used outside of that splice"
-        // test("List of case classes") {
-        //   val result = FastShowPretty.render(
-        //     List(PersonWithAddress("Bob", 25, Address("123 Main St", "New York"))),
-        //     RenderConfig.Default
-        //   )
-        //   assertEquals(
-        //     result,
-        //     """List(
-        //       |  PersonWithAddress(
-        //       |    name = "Bob",
-        //       |    age = 25,
-        //       |    address = Address(
-        //       |      street = "123 Main St",
-        //       |      city = "New York"
-        //       |    )
-        //       |  )
-        //       |)""".stripMargin
-        //   )
-        // }
+        /*
+        test("List of case classes") {
+          val result = FastShowPretty.render(
+            List(PersonWithAddress("Bob", 25, Address("123 Main St", "New York"))),
+            RenderConfig.Default
+          )
+          assertEquals(
+            result,
+            """List(
+              |  PersonWithAddress(
+              |    name = "Bob",
+              |    age = 25,
+              |    address = Address(
+              |      street = "123 Main St",
+              |      city = "New York"
+              |    )
+              |  )
+              |)""".stripMargin
+          )
+        }
+         */
       }
 
       group("maps") {

--- a/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
+++ b/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
@@ -1,401 +1,392 @@
 package hearth.demo.allfeatures
 
-import munit.FunSuite
+import hearth.MacroSuite
 
 case class Person(name: String, age: Int)
 case class Empty()
 case class Single(value: Int)
 case class Address(street: String, city: String)
 case class PersonWithAddress(name: String, age: Int, address: Address)
+case class Team(name: String, members: List[Person])
 
 @scala.annotation.nowarn // TODO: unused values - we cannot suppress them with val _ = ... until we fix cross-quotes on Scala 2!!!
-final class FastShowPrettySpec extends FunSuite {
+final class FastShowPrettySpec extends MacroSuite {
 
-  // ============================================================================
-  // TEST PLAN FOR FastShowPretty
-  // ============================================================================
-  //
-  // FastShowPretty is a type class that provides:
-  // 1. Inline `render[A](value: A): String` - macro that inlines rendering logic
-  // 2. `derived[A]: FastShowPretty[A]` - macro that derives type class instances
-  // 3. Built-in support for primitives: Boolean, Byte, Short, Int, Long, Float, Double, Char, String
-  // 4. Automatic derivation for case classes (with pretty formatting)
-  // 5. Automatic derivation for enums (Scala 3)
-  // 6. Support for implicit instances
-  //
-  // ============================================================================
-  // TEST CATEGORIES TO IMPLEMENT:
-  // ============================================================================
+  group("FastShowPretty") {
 
-  // ----------------------------------------------------------------------------
-  // 1. PRIMITIVE TYPES - Testing inline render() method
-  // ----------------------------------------------------------------------------
-  // Test that all built-in primitives render correctly:
-  // - Boolean: true/false
-  // - Byte: value.toByte
-  // - Short: value.toShort
-  // - Int: value (no suffix)
-  // - Long: valueL
-  // - Float: value.0f (with workaround for Scala.js)
-  // - Double: value.0d (with workaround for Scala.js)
-  // - Char: 'c'
-  // - String: "text" (with escaped quotes and newlines)
+    group("render") {
 
-  test("render - Boolean true") {
-    val result = FastShowPretty.render(true, RenderConfig.Default)
-    assertEquals(result, "true")
-  }
+      group("primitive types") {
 
-  test("render - Boolean false") {
-    val result = FastShowPretty.render(false, RenderConfig.Default)
-    assertEquals(result, "false")
-  }
+        test("Boolean true") {
+          val result = FastShowPretty.render(true, RenderConfig.Default)
+          assertEquals(result, "true")
+        }
 
-  test("render - Byte") {
-    val result = FastShowPretty.render(42.toByte, RenderConfig.Default)
-    assertEquals(result, "42.toByte")
-  }
+        test("Boolean false") {
+          val result = FastShowPretty.render(false, RenderConfig.Default)
+          assertEquals(result, "false")
+        }
 
-  test("render - Short") {
-    val result = FastShowPretty.render(42.toShort, RenderConfig.Default)
-    assertEquals(result, "42.toShort")
-  }
+        test("Byte") {
+          val result = FastShowPretty.render(42.toByte, RenderConfig.Default)
+          assertEquals(result, "42.toByte")
+        }
 
-  test("render - Int") {
-    val result = FastShowPretty.render(42, RenderConfig.Default)
-    assertEquals(result, "42")
-  }
+        test("Short") {
+          val result = FastShowPretty.render(42.toShort, RenderConfig.Default)
+          assertEquals(result, "42.toShort")
+        }
 
-  test("render - Long") {
-    val result = FastShowPretty.render(42L, RenderConfig.Default)
-    assertEquals(result, "42L")
-  }
+        test("Int") {
+          val result = FastShowPretty.render(42, RenderConfig.Default)
+          assertEquals(result, "42")
+        }
 
-  test("render - Float") {
-    val result = FastShowPretty.render(42.5f, RenderConfig.Default)
-    assertEquals(result, "42.5.0f")
-  }
+        test("Long") {
+          val result = FastShowPretty.render(42L, RenderConfig.Default)
+          assertEquals(result, "42L")
+        }
 
-  test("render - Double") {
-    val result = FastShowPretty.render(42.5, RenderConfig.Default)
-    assertEquals(result, "42.5.0d")
-  }
+        test("Float") {
+          val result = FastShowPretty.render(42.5f, RenderConfig.Default)
+          assertEquals(result, "42.5.0f")
+        }
 
-  test("render - Char") {
-    val result = FastShowPretty.render('a', RenderConfig.Default)
-    assertEquals(result, "'a'")
-  }
+        test("Double") {
+          val result = FastShowPretty.render(42.5, RenderConfig.Default)
+          assertEquals(result, "42.5.0d")
+        }
 
-  test("render - String") {
-    val result = FastShowPretty.render("hello", RenderConfig.Default)
-    assertEquals(result, "\"hello\"")
-  }
+        test("Char") {
+          val result = FastShowPretty.render('a', RenderConfig.Default)
+          assertEquals(result, "'a'")
+        }
 
-  test("render - String with quotes") {
-    val result = FastShowPretty.render("say \"hello\"", RenderConfig.Default)
-    assertEquals(result, "\"say \\\"hello\\\"\"")
-  }
+        test("String") {
+          val result = FastShowPretty.render("hello", RenderConfig.Default)
+          assertEquals(result, "\"hello\"")
+        }
 
-  test("render - String with newlines") {
-    val result = FastShowPretty.render("line1\nline2", RenderConfig.Default)
-    assertEquals(result, "\"line1\\nline2\"")
-  }
+        test("String with quotes") {
+          val result = FastShowPretty.render("say \"hello\"", RenderConfig.Default)
+          assertEquals(result, "\"say \\\"hello\\\"\"")
+        }
 
-  // ----------------------------------------------------------------------------
-  // 2. CASE CLASSES - Testing automatic derivation
-  // ----------------------------------------------------------------------------
-  // Test that case classes are derived automatically with pretty formatting:
-  // - Empty case class: Name()
-  // - Single field: Name(field = value)
-  // - Multiple fields: Name(\n  field1 = value1,\n  field2 = value2\n)
-  // - Nested case classes
-  // - Case classes with primitive fields
-  // - Case classes with Option fields (if supported)
-  // - Case classes with collections (if supported)
+        test("String with newlines") {
+          val result = FastShowPretty.render("line1\nline2", RenderConfig.Default)
+          assertEquals(result, "\"line1\\nline2\"")
+        }
+      }
 
-  test("render - compact (no indent)") {
-    val result = FastShowPretty.render(Person("Alice", 30), RenderConfig.Compact)
-    assertEquals(result, "Person(\nname = \"Alice\",\nage = 30\n)")
-  }
+      group("case classes") {
 
-  test("render - tabs") {
-    val result = FastShowPretty.render(Person("Alice", 30), RenderConfig.Tabs)
-    assertEquals(result, "Person(\n\tname = \"Alice\",\n\tage = 30\n)")
-  }
+        test("compact (no indent)") {
+          val result = FastShowPretty.render(Person("Alice", 30), RenderConfig.Compact)
+          assertEquals(
+            result,
+            """Person(
+              |name = "Alice",
+              |age = 30
+              |)""".stripMargin
+          )
+        }
 
-  test("render - four spaces") {
-    val result = FastShowPretty.render(Person("Alice", 30), RenderConfig.FourSpaces)
-    assertEquals(result, "Person(\n    name = \"Alice\",\n    age = 30\n)")
-  }
+        test("tabs") {
+          val result = FastShowPretty.render(Person("Alice", 30), RenderConfig.Tabs)
+          assertEquals(
+            result,
+            s"""Person(
+               |\tname = "Alice",
+               |\tage = 30
+               |)""".stripMargin
+          )
+        }
 
-  test("render - nested with tabs") {
-    val address = Address("123 Main St", "New York")
-    val person = PersonWithAddress("Bob", 25, address)
-    val result = FastShowPretty.render(person, RenderConfig.Tabs)
-    assertEquals(
-      result,
-      "PersonWithAddress(\n\tname = \"Bob\",\n\tage = 25,\n\taddress = Address(\n\t\tstreet = \"123 Main St\",\n\t\tcity = \"New York\"\n\t)\n)"
-    )
-  }
+        test("four spaces") {
+          val result = FastShowPretty.render(Person("Alice", 30), RenderConfig.FourSpaces)
+          assertEquals(
+            result,
+            """Person(
+              |    name = "Alice",
+              |    age = 30
+              |)""".stripMargin
+          )
+        }
 
-  // ----------------------------------------------------------------------------
-  // 3. ENUMS (Scala 3) - Testing automatic derivation
-  // ----------------------------------------------------------------------------
-  // Test that Scala 3 enums are derived automatically:
-  // - Simple enum: (value): EnumName
-  // - Enum with parameters: (value): EnumName
-  // - Nested enum cases
+        test("nested with tabs") {
+          val address = Address("123 Main St", "New York")
+          val person = PersonWithAddress("Bob", 25, address)
+          val result = FastShowPretty.render(person, RenderConfig.Tabs)
+          assertEquals(
+            result,
+            s"""PersonWithAddress(
+               |\tname = "Bob",
+               |\tage = 25,
+               |\taddress = Address(
+               |\t\tstreet = "123 Main St",
+               |\t\tcity = "New York"
+               |\t)
+               |)""".stripMargin
+          )
+        }
 
-  // Note: This will only compile in Scala 3
-  // enum Color {
-  //   case Red, Green, Blue
-  //   case RGB(r: Int, g: Int, b: Int)
-  // }
+        // TODO: case class with collection field fails due to cross-quotes scope issue
+        //   when case classes are nested inside collections during inline macro expansion.
+        //   Error: "Expression created in a splice was used outside of that splice"
+        // test("case class with collection field") {
+        //   val result = FastShowPretty.render(
+        //     Team("Engineering", List(Person("Alice", 30), Person("Bob", 25))),
+        //     RenderConfig.Default
+        //   )
+        //   assertEquals(
+        //     result,
+        //     """Team(
+        //       |  name = "Engineering",
+        //       |  members = List(
+        //       |    Person(
+        //       |      name = "Alice",
+        //       |      age = 30
+        //       |    ),
+        //       |    Person(
+        //       |      name = "Bob",
+        //       |      age = 25
+        //       |    )
+        //       |  )
+        //       |)""".stripMargin
+        //   )
+        // }
+      }
 
-  // test("render - simple enum") {
-  //   val result = FastShowPretty.render(Color.Red)
-  //   assertEquals(result, "(Red): Color")
-  // }
+      group("collections") {
 
-  // test("render - enum with parameters") {
-  //   val result = FastShowPretty.render(Color.RGB(255, 128, 0))
-  //   assertEquals(result, "(RGB(\nr = 255,\ng = 128,\nb = 0\n)): Color")
-  // }
+        test("List of Ints") {
+          val result = FastShowPretty.render(List(1, 2, 3), RenderConfig.Default)
+          assertEquals(
+            result,
+            """List(
+              |  1,
+              |  2,
+              |  3
+              |)""".stripMargin
+          )
+        }
 
-  // ----------------------------------------------------------------------------
-  // 4. TYPE CLASS INSTANCE - Testing derived type class
-  // ----------------------------------------------------------------------------
-  // Test that derived instances work correctly:
-  // - Can derive instance for primitives
-  // - Can derive instance for case classes
-  // - Instance can be used with render method
-  // - Instance can be used directly with StringBuilder
+        test("empty List") {
+          val result = FastShowPretty.render(List.empty[Int], RenderConfig.Default)
+          assertEquals(result, "List()")
+        }
 
-  test("derived - Int instance") {
-    val instance = implicitly[FastShowPretty[Int]]
-    val sb = new StringBuilder
-    val result = instance.render(sb, RenderConfig.Default, 0)(42).toString
-    assertEquals(result, "42")
-  }
+        test("Vector of Strings") {
+          val result = FastShowPretty.render(Vector("a", "b", "c"), RenderConfig.Default)
+          assertEquals(
+            result,
+            """Vector(
+              |  "a",
+              |  "b",
+              |  "c"
+              |)""".stripMargin
+          )
+        }
 
-  test("derived - case class instance") {
-    val instance = implicitly[FastShowPretty[Person]]
-    val sb = new StringBuilder
-    val result = instance.render(sb, RenderConfig.Default, 0)(Person("Alice", 30)).toString
-    assertEquals(result, "Person(\n  name = \"Alice\",\n  age = 30\n)")
-  }
+        test("Set of Ints") {
+          val result = FastShowPretty.render(Set(1), RenderConfig.Default)
+          assertEquals(
+            result,
+            """Set(
+              |  1
+              |)""".stripMargin
+          )
+        }
 
-  test("derived - instance reuse StringBuilder") {
-    val instance = implicitly[FastShowPretty[Int]]
-    val sb = new StringBuilder("prefix: ")
-    val result = instance.render(sb, RenderConfig.Default, 0)(42).toString
-    assertEquals(result, "prefix: 42")
-  }
+        // TODO: List of case classes fails due to cross-quotes scope issue
+        //   when case classes are nested inside collections during inline macro expansion.
+        //   Error: "Expression created in a splice was used outside of that splice"
+        // test("List of case classes") {
+        //   val result = FastShowPretty.render(
+        //     List(PersonWithAddress("Bob", 25, Address("123 Main St", "New York"))),
+        //     RenderConfig.Default
+        //   )
+        //   assertEquals(
+        //     result,
+        //     """List(
+        //       |  PersonWithAddress(
+        //       |    name = "Bob",
+        //       |    age = 25,
+        //       |    address = Address(
+        //       |      street = "123 Main St",
+        //       |      city = "New York"
+        //       |    )
+        //       |  )
+        //       |)""".stripMargin
+        //   )
+        // }
+      }
 
-  test("derived - instance with custom config") {
-    val instance = implicitly[FastShowPretty[Person]]
-    val sb = new StringBuilder
-    val result = instance.render(sb, RenderConfig.Tabs, 0)(Person("Alice", 30)).toString
-    assertEquals(result, "Person(\n\tname = \"Alice\",\n\tage = 30\n)")
-  }
+      group("maps") {
 
-  test("derived - instance with start level") {
-    val instance = implicitly[FastShowPretty[Person]]
-    val sb = new StringBuilder
-    // Starting at level 1 means the first level of fields is at level 2
-    val result = instance.render(sb, RenderConfig.Default, 1)(Person("Alice", 30)).toString
-    assertEquals(result, "Person(\n    name = \"Alice\",\n    age = 30\n  )")
-  }
+        test("Map of String to Int") {
+          val result = FastShowPretty.render(Map("a" -> 1), RenderConfig.Default)
+          assertEquals(
+            result,
+            """Map(
+              |  ("a", 1)
+              |)""".stripMargin
+          )
+        }
 
-  // ----------------------------------------------------------------------------
-  // 5. IMPLICIT INSTANCES - Testing custom instances
-  // ----------------------------------------------------------------------------
-  // Test that custom implicit instances take precedence:
-  // - Custom instance for a type
-  // - Custom instance overrides derivation
-  // - Custom instance can be used with render
+        test("empty Map") {
+          val result = FastShowPretty.render(Map.empty[String, Int], RenderConfig.Default)
+          assertEquals(result, "Map()")
+        }
 
-  test("render - uses custom implicit instance") {
-    implicit val customIntInstance: FastShowPretty[Int] = new FastShowPretty[Int] {
-      def render(sb: StringBuilder, config: RenderConfig, level: Int)(value: Int): StringBuilder =
-        sb.append("custom(").append(value).append(")")
+        test("Map with multiple entries") {
+          val result =
+            FastShowPretty.render(scala.collection.immutable.ListMap("x" -> 10, "y" -> 20), RenderConfig.Default)
+          assertEquals(
+            result,
+            """ListMap(
+              |  ("x", 10),
+              |  ("y", 20)
+              |)""".stripMargin
+          )
+        }
+      }
+
+      group("custom implicit instances") {
+
+        test("uses custom implicit instance") {
+          implicit val customIntInstance: FastShowPretty[Int] = new FastShowPretty[Int] {
+            def render(sb: StringBuilder, config: RenderConfig, level: Int)(value: Int): StringBuilder =
+              sb.append("custom(").append(value).append(")")
+          }
+
+          val result = FastShowPretty.render(42, RenderConfig.Default)
+          assertEquals(result, "custom(42)")
+        }
+      }
+
+      group("edge cases") {
+
+        test("zero values") {
+          assertEquals(FastShowPretty.render(0, RenderConfig.Default), "0")
+          assertEquals(FastShowPretty.render(0L, RenderConfig.Default), "0L")
+          assertEquals(FastShowPretty.render(0.0f, RenderConfig.Default), "0.0.0f")
+          assertEquals(FastShowPretty.render(0.0, RenderConfig.Default), "0.0.0d")
+        }
+
+        test("negative numbers") {
+          assertEquals(FastShowPretty.render(-42, RenderConfig.Default), "-42")
+          assertEquals(FastShowPretty.render(-42L, RenderConfig.Default), "-42L")
+        }
+
+        test("empty string") {
+          assertEquals(FastShowPretty.render("", RenderConfig.Default), "\"\"")
+        }
+
+        test("unicode characters") {
+          val result = FastShowPretty.render("Hello 世界", RenderConfig.Default)
+          assertEquals(result, "\"Hello 世界\"")
+        }
+
+        test("special characters in string") {
+          val result = FastShowPretty.render("tab\tquote\"newline\n", RenderConfig.Default)
+          assertEquals(result, "\"tab\\tquote\\\"newline\\n\"")
+        }
+
+        test("backslash in string") {
+          val result = FastShowPretty.render("path\\to\\file", RenderConfig.Default)
+          assertEquals(result, "\"path\\\\to\\\\file\"")
+        }
+      }
     }
 
-    val result = FastShowPretty.render(42, RenderConfig.Default)
-    assertEquals(result, "custom(42)")
+    group("derived") {
+
+      test("Int instance") {
+        val instance = implicitly[FastShowPretty[Int]]
+        val sb = new StringBuilder
+        val result = instance.render(sb, RenderConfig.Default, 0)(42).toString
+        assertEquals(result, "42")
+      }
+
+      test("case class instance") {
+        val instance = implicitly[FastShowPretty[Person]]
+        val sb = new StringBuilder
+        val result = instance.render(sb, RenderConfig.Default, 0)(Person("Alice", 30)).toString
+        assertEquals(
+          result,
+          """Person(
+            |  name = "Alice",
+            |  age = 30
+            |)""".stripMargin
+        )
+      }
+
+      test("instance reuse StringBuilder") {
+        val instance = implicitly[FastShowPretty[Int]]
+        val sb = new StringBuilder("prefix: ")
+        val result = instance.render(sb, RenderConfig.Default, 0)(42).toString
+        assertEquals(result, "prefix: 42")
+      }
+
+      test("instance with custom config") {
+        val instance = implicitly[FastShowPretty[Person]]
+        val sb = new StringBuilder
+        val result = instance.render(sb, RenderConfig.Tabs, 0)(Person("Alice", 30)).toString
+        assertEquals(
+          result,
+          s"""Person(
+             |\tname = "Alice",
+             |\tage = 30
+             |)""".stripMargin
+        )
+      }
+
+      test("instance with start level") {
+        val instance = implicitly[FastShowPretty[Person]]
+        val sb = new StringBuilder
+        val result = instance.render(sb, RenderConfig.Default, 1)(Person("Alice", 30)).toString
+        assertEquals(
+          result,
+          """Person(
+            |    name = "Alice",
+            |    age = 30
+            |  )""".stripMargin
+        )
+      }
+    }
+
+    group("compile-time") {
+
+      test("render compiles for supported types") {
+        val _: String = FastShowPretty.render(42, RenderConfig.Default)
+        val _: String = FastShowPretty.render("test", RenderConfig.Default)
+        val _: String = FastShowPretty.render(Person("Alice", 30), RenderConfig.Default)
+        assert(true)
+      }
+
+      test("derived compiles for supported types") {
+        import FastShowPretty.derived
+        val _: FastShowPretty[Int] = implicitly[FastShowPretty[Int]]
+        val _: FastShowPretty[Person] = implicitly[FastShowPretty[Person]]
+        assert(true)
+      }
+    }
+
+    group("StringBuilder reuse") {
+
+      test("multiple appends") {
+        import FastShowPretty.derived
+        val instance = implicitly[FastShowPretty[Int]]
+        val sb = new StringBuilder("start: ")
+        instance.render(sb, RenderConfig.Default, 0)(1)
+        sb.append(", ")
+        instance.render(sb, RenderConfig.Default, 0)(2)
+        sb.append(", ")
+        instance.render(sb, RenderConfig.Default, 0)(3)
+        assertEquals(sb.toString, "start: 1, 2, 3")
+      }
+    }
   }
-
-  // ----------------------------------------------------------------------------
-  // 6. EDGE CASES
-  // ----------------------------------------------------------------------------
-  // Test edge cases:
-  // - Zero values
-  // - Negative numbers
-  // - Max/Min values for numeric types
-  // - Empty strings
-  // - Special characters in strings
-  // - Unicode characters
-  // - Very long strings
-  // - Deeply nested structures
-  // - Recursive structures (if supported)
-
-  test("render - zero values") {
-    assertEquals(FastShowPretty.render(0, RenderConfig.Default), "0")
-    assertEquals(FastShowPretty.render(0L, RenderConfig.Default), "0L")
-    assertEquals(FastShowPretty.render(0.0f, RenderConfig.Default), "0.0.0f")
-    assertEquals(FastShowPretty.render(0.0, RenderConfig.Default), "0.0.0d")
-  }
-
-  test("render - negative numbers") {
-    assertEquals(FastShowPretty.render(-42, RenderConfig.Default), "-42")
-    assertEquals(FastShowPretty.render(-42L, RenderConfig.Default), "-42L")
-  }
-
-  test("render - empty string") {
-    assertEquals(FastShowPretty.render("", RenderConfig.Default), "\"\"")
-  }
-
-  test("render - unicode characters") {
-    val result = FastShowPretty.render("Hello 世界", RenderConfig.Default)
-    assertEquals(result, "\"Hello 世界\"")
-  }
-
-  test("render - special characters in string") {
-    val result = FastShowPretty.render("tab\tquote\"newline\n", RenderConfig.Default)
-    assertEquals(result, "\"tab\\tquote\\\"newline\\n\"")
-  }
-
-  test("render - backslash in string") {
-    val result = FastShowPretty.render("path\\to\\file", RenderConfig.Default)
-    assertEquals(result, "\"path\\\\to\\\\file\"")
-  }
-
-  // ----------------------------------------------------------------------------
-  // 7. COMPILE-TIME VERIFICATION
-  // ----------------------------------------------------------------------------
-  // Test that macros work at compile time:
-  // - render() should inline (verify by checking it compiles)
-  // - derived should work at compile time
-  // - Type errors for unsupported types (if applicable)
-
-  test("compile-time - render compiles for supported types") {
-    // This test verifies that render compiles for various types
-    val _: String = FastShowPretty.render(42, RenderConfig.Default)
-    val _: String = FastShowPretty.render("test", RenderConfig.Default)
-    val _: String = FastShowPretty.render(Person("Alice", 30), RenderConfig.Default)
-    // If this compiles, the test passes
-    assert(true)
-  }
-
-  test("compile-time - derived compiles for supported types") {
-    import FastShowPretty.derived
-    val _: FastShowPretty[Int] = implicitly[FastShowPretty[Int]]
-    val _: FastShowPretty[Person] = implicitly[FastShowPretty[Person]]
-    // If this compiles, the test passes
-    assert(true)
-  }
-
-  // ----------------------------------------------------------------------------
-  // 8. PERFORMANCE / STRINGBUILDER REUSE
-  // ----------------------------------------------------------------------------
-  // Test StringBuilder reuse behavior:
-  // - Multiple renders append to same StringBuilder
-  // - StringBuilder state is preserved
-
-  test("StringBuilder - multiple appends") {
-    import FastShowPretty.derived
-    val instance = implicitly[FastShowPretty[Int]]
-    val sb = new StringBuilder("start: ")
-    instance.render(sb, RenderConfig.Default, 0)(1)
-    sb.append(", ")
-    instance.render(sb, RenderConfig.Default, 0)(2)
-    sb.append(", ")
-    instance.render(sb, RenderConfig.Default, 0)(3)
-    assertEquals(sb.toString, "start: 1, 2, 3")
-  }
-
-  // ----------------------------------------------------------------------------
-  // 9. PROPERTY-BASED TESTS (using ScalaCheck)
-  // ----------------------------------------------------------------------------
-  // Use ScalaCheck to test properties:
-  // - render is idempotent (render(render(x)) might not make sense, but we can test other properties)
-  // - render never throws exceptions for valid inputs
-  // - render produces non-empty strings for non-empty inputs (where applicable)
-
-  // Example property-based test:
-  // test("property - render never throws for Int") {
-  //   forAll { (n: Int) =>
-  //     noException should be thrownBy FastShowPretty.render(n)
-  //   }
-  // }
-
-  // test("property - render produces valid output for Int") {
-  //   forAll { (n: Int) =>
-  //     val result = FastShowPretty.render(n)
-  //     assert(result.nonEmpty)
-  //   }
-  // }
-
-  // ----------------------------------------------------------------------------
-  // 10. ERROR CASES (if applicable)
-  // ----------------------------------------------------------------------------
-  // Test error handling:
-  // - Unsupported types (should compile-time error or runtime error?)
-  // - Null values (if applicable)
-  // - Circular references in case classes (if applicable)
-
-  // Note: Based on the implementation, unsupported types should fail at compile time
-  // with a macro error, so these might not be testable at runtime.
-
-  // ----------------------------------------------------------------------------
-  // 11. COLLECTIONS - Testing IsCollection support
-  // ----------------------------------------------------------------------------
-  // Test that collections render correctly when item types have implicit instances.
-
-  // FIXME: these are broken
-
-  test("render - List of Ints") {
-    val result = FastShowPretty.render(List(1, 2, 3), RenderConfig.Default)
-    assertEquals(result, "List(1, 2, 3)")
-  }
-
-  // test("render - empty List") {
-  //   val result = FastShowPretty.render(List.empty[Int], RenderConfig.Default)
-  //   assertEquals(result, "List()")
-  // }
-
-  // test("render - Vector of Strings") {
-  //   val result = FastShowPretty.render(Vector("a", "b", "c"), RenderConfig.Default)
-  //   assertEquals(result, "Vector(\"a\", \"b\", \"c\")")
-  // }
-
-  // test("render - Set of Ints") {
-  //   val result = FastShowPretty.render(Set(1), RenderConfig.Default)
-  //   assertEquals(result, "Set(1)")
-  // }
-
-  // ----------------------------------------------------------------------------
-  // 12. MAPS - Testing map support (via collection of tuples)
-  // ----------------------------------------------------------------------------
-  // Note: Maps are handled as collections of tuples. The tuple rendering requires
-  // special handling which will be added in a future enhancement.
-  // For now, map tests are disabled.
-
-  // FIXME: these are broken
-
-  // test("render - Map of String to Int") {
-  //   val result = FastShowPretty.render(Map("a" -> 1))
-  //   assertEquals(result, "Map((\"a\", 1))")  // Maps render as collections of tuples
-  // }
-
-  // test("render - empty Map") {
-  //   val result = FastShowPretty.render(Map.empty[String, Int])
-  //   assertEquals(result, "Map()")
-  // }
-
-  // test("render - Map with multiple entries") {
-  //   val result = FastShowPretty.render(scala.collection.immutable.ListMap("x" -> 10, "y" -> 20))
-  //   assertEquals(result, "ListMap((\"x\", 10), (\"y\", 20))")
-  // }
-
 }

--- a/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
+++ b/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
@@ -50,12 +50,12 @@ final class FastShowPrettySpec extends MacroSuite {
 
         test("Float") {
           val result = FastShowPretty.render(42.5f, RenderConfig.Default)
-          assertEquals(result, "42.5.0f")
+          assertEquals(result, "42.5f")
         }
 
         test("Double") {
           val result = FastShowPretty.render(42.5, RenderConfig.Default)
-          assertEquals(result, "42.5.0d")
+          assertEquals(result, "42.5d")
         }
 
         test("Char") {
@@ -267,8 +267,8 @@ final class FastShowPrettySpec extends MacroSuite {
         test("zero values") {
           assertEquals(FastShowPretty.render(0, RenderConfig.Default), "0")
           assertEquals(FastShowPretty.render(0L, RenderConfig.Default), "0L")
-          assertEquals(FastShowPretty.render(0.0f, RenderConfig.Default), "0.0.0f")
-          assertEquals(FastShowPretty.render(0.0, RenderConfig.Default), "0.0.0d")
+          assertEquals(FastShowPretty.render(0.0f, RenderConfig.Default), "0.0f")
+          assertEquals(FastShowPretty.render(0.0, RenderConfig.Default), "0.0d")
         }
 
         test("negative numbers") {

--- a/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
+++ b/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
@@ -1,0 +1,401 @@
+package hearth.demo.allfeatures
+
+import munit.FunSuite
+
+case class Person(name: String, age: Int)
+case class Empty()
+case class Single(value: Int)
+case class Address(street: String, city: String)
+case class PersonWithAddress(name: String, age: Int, address: Address)
+
+@scala.annotation.nowarn // TODO: unused values - we cannot suppress them with val _ = ... until we fix cross-quotes on Scala 2!!!
+final class FastShowPrettySpec extends FunSuite {
+
+  // ============================================================================
+  // TEST PLAN FOR FastShowPretty
+  // ============================================================================
+  //
+  // FastShowPretty is a type class that provides:
+  // 1. Inline `render[A](value: A): String` - macro that inlines rendering logic
+  // 2. `derived[A]: FastShowPretty[A]` - macro that derives type class instances
+  // 3. Built-in support for primitives: Boolean, Byte, Short, Int, Long, Float, Double, Char, String
+  // 4. Automatic derivation for case classes (with pretty formatting)
+  // 5. Automatic derivation for enums (Scala 3)
+  // 6. Support for implicit instances
+  //
+  // ============================================================================
+  // TEST CATEGORIES TO IMPLEMENT:
+  // ============================================================================
+
+  // ----------------------------------------------------------------------------
+  // 1. PRIMITIVE TYPES - Testing inline render() method
+  // ----------------------------------------------------------------------------
+  // Test that all built-in primitives render correctly:
+  // - Boolean: true/false
+  // - Byte: value.toByte
+  // - Short: value.toShort
+  // - Int: value (no suffix)
+  // - Long: valueL
+  // - Float: value.0f (with workaround for Scala.js)
+  // - Double: value.0d (with workaround for Scala.js)
+  // - Char: 'c'
+  // - String: "text" (with escaped quotes and newlines)
+
+  test("render - Boolean true") {
+    val result = FastShowPretty.render(true, RenderConfig.Default)
+    assertEquals(result, "true")
+  }
+
+  test("render - Boolean false") {
+    val result = FastShowPretty.render(false, RenderConfig.Default)
+    assertEquals(result, "false")
+  }
+
+  test("render - Byte") {
+    val result = FastShowPretty.render(42.toByte, RenderConfig.Default)
+    assertEquals(result, "42.toByte")
+  }
+
+  test("render - Short") {
+    val result = FastShowPretty.render(42.toShort, RenderConfig.Default)
+    assertEquals(result, "42.toShort")
+  }
+
+  test("render - Int") {
+    val result = FastShowPretty.render(42, RenderConfig.Default)
+    assertEquals(result, "42")
+  }
+
+  test("render - Long") {
+    val result = FastShowPretty.render(42L, RenderConfig.Default)
+    assertEquals(result, "42L")
+  }
+
+  test("render - Float") {
+    val result = FastShowPretty.render(42.5f, RenderConfig.Default)
+    assertEquals(result, "42.5.0f")
+  }
+
+  test("render - Double") {
+    val result = FastShowPretty.render(42.5, RenderConfig.Default)
+    assertEquals(result, "42.5.0d")
+  }
+
+  test("render - Char") {
+    val result = FastShowPretty.render('a', RenderConfig.Default)
+    assertEquals(result, "'a'")
+  }
+
+  test("render - String") {
+    val result = FastShowPretty.render("hello", RenderConfig.Default)
+    assertEquals(result, "\"hello\"")
+  }
+
+  test("render - String with quotes") {
+    val result = FastShowPretty.render("say \"hello\"", RenderConfig.Default)
+    assertEquals(result, "\"say \\\"hello\\\"\"")
+  }
+
+  test("render - String with newlines") {
+    val result = FastShowPretty.render("line1\nline2", RenderConfig.Default)
+    assertEquals(result, "\"line1\\nline2\"")
+  }
+
+  // ----------------------------------------------------------------------------
+  // 2. CASE CLASSES - Testing automatic derivation
+  // ----------------------------------------------------------------------------
+  // Test that case classes are derived automatically with pretty formatting:
+  // - Empty case class: Name()
+  // - Single field: Name(field = value)
+  // - Multiple fields: Name(\n  field1 = value1,\n  field2 = value2\n)
+  // - Nested case classes
+  // - Case classes with primitive fields
+  // - Case classes with Option fields (if supported)
+  // - Case classes with collections (if supported)
+
+  test("render - compact (no indent)") {
+    val result = FastShowPretty.render(Person("Alice", 30), RenderConfig.Compact)
+    assertEquals(result, "Person(\nname = \"Alice\",\nage = 30\n)")
+  }
+
+  test("render - tabs") {
+    val result = FastShowPretty.render(Person("Alice", 30), RenderConfig.Tabs)
+    assertEquals(result, "Person(\n\tname = \"Alice\",\n\tage = 30\n)")
+  }
+
+  test("render - four spaces") {
+    val result = FastShowPretty.render(Person("Alice", 30), RenderConfig.FourSpaces)
+    assertEquals(result, "Person(\n    name = \"Alice\",\n    age = 30\n)")
+  }
+
+  test("render - nested with tabs") {
+    val address = Address("123 Main St", "New York")
+    val person = PersonWithAddress("Bob", 25, address)
+    val result = FastShowPretty.render(person, RenderConfig.Tabs)
+    assertEquals(
+      result,
+      "PersonWithAddress(\n\tname = \"Bob\",\n\tage = 25,\n\taddress = Address(\n\t\tstreet = \"123 Main St\",\n\t\tcity = \"New York\"\n\t)\n)"
+    )
+  }
+
+  // ----------------------------------------------------------------------------
+  // 3. ENUMS (Scala 3) - Testing automatic derivation
+  // ----------------------------------------------------------------------------
+  // Test that Scala 3 enums are derived automatically:
+  // - Simple enum: (value): EnumName
+  // - Enum with parameters: (value): EnumName
+  // - Nested enum cases
+
+  // Note: This will only compile in Scala 3
+  // enum Color {
+  //   case Red, Green, Blue
+  //   case RGB(r: Int, g: Int, b: Int)
+  // }
+
+  // test("render - simple enum") {
+  //   val result = FastShowPretty.render(Color.Red)
+  //   assertEquals(result, "(Red): Color")
+  // }
+
+  // test("render - enum with parameters") {
+  //   val result = FastShowPretty.render(Color.RGB(255, 128, 0))
+  //   assertEquals(result, "(RGB(\nr = 255,\ng = 128,\nb = 0\n)): Color")
+  // }
+
+  // ----------------------------------------------------------------------------
+  // 4. TYPE CLASS INSTANCE - Testing derived type class
+  // ----------------------------------------------------------------------------
+  // Test that derived instances work correctly:
+  // - Can derive instance for primitives
+  // - Can derive instance for case classes
+  // - Instance can be used with render method
+  // - Instance can be used directly with StringBuilder
+
+  test("derived - Int instance") {
+    val instance = implicitly[FastShowPretty[Int]]
+    val sb = new StringBuilder
+    val result = instance.render(sb, RenderConfig.Default, 0)(42).toString
+    assertEquals(result, "42")
+  }
+
+  test("derived - case class instance") {
+    val instance = implicitly[FastShowPretty[Person]]
+    val sb = new StringBuilder
+    val result = instance.render(sb, RenderConfig.Default, 0)(Person("Alice", 30)).toString
+    assertEquals(result, "Person(\n  name = \"Alice\",\n  age = 30\n)")
+  }
+
+  test("derived - instance reuse StringBuilder") {
+    val instance = implicitly[FastShowPretty[Int]]
+    val sb = new StringBuilder("prefix: ")
+    val result = instance.render(sb, RenderConfig.Default, 0)(42).toString
+    assertEquals(result, "prefix: 42")
+  }
+
+  test("derived - instance with custom config") {
+    val instance = implicitly[FastShowPretty[Person]]
+    val sb = new StringBuilder
+    val result = instance.render(sb, RenderConfig.Tabs, 0)(Person("Alice", 30)).toString
+    assertEquals(result, "Person(\n\tname = \"Alice\",\n\tage = 30\n)")
+  }
+
+  test("derived - instance with start level") {
+    val instance = implicitly[FastShowPretty[Person]]
+    val sb = new StringBuilder
+    // Starting at level 1 means the first level of fields is at level 2
+    val result = instance.render(sb, RenderConfig.Default, 1)(Person("Alice", 30)).toString
+    assertEquals(result, "Person(\n    name = \"Alice\",\n    age = 30\n  )")
+  }
+
+  // ----------------------------------------------------------------------------
+  // 5. IMPLICIT INSTANCES - Testing custom instances
+  // ----------------------------------------------------------------------------
+  // Test that custom implicit instances take precedence:
+  // - Custom instance for a type
+  // - Custom instance overrides derivation
+  // - Custom instance can be used with render
+
+  test("render - uses custom implicit instance") {
+    implicit val customIntInstance: FastShowPretty[Int] = new FastShowPretty[Int] {
+      def render(sb: StringBuilder, config: RenderConfig, level: Int)(value: Int): StringBuilder =
+        sb.append("custom(").append(value).append(")")
+    }
+
+    val result = FastShowPretty.render(42, RenderConfig.Default)
+    assertEquals(result, "custom(42)")
+  }
+
+  // ----------------------------------------------------------------------------
+  // 6. EDGE CASES
+  // ----------------------------------------------------------------------------
+  // Test edge cases:
+  // - Zero values
+  // - Negative numbers
+  // - Max/Min values for numeric types
+  // - Empty strings
+  // - Special characters in strings
+  // - Unicode characters
+  // - Very long strings
+  // - Deeply nested structures
+  // - Recursive structures (if supported)
+
+  test("render - zero values") {
+    assertEquals(FastShowPretty.render(0, RenderConfig.Default), "0")
+    assertEquals(FastShowPretty.render(0L, RenderConfig.Default), "0L")
+    assertEquals(FastShowPretty.render(0.0f, RenderConfig.Default), "0.0.0f")
+    assertEquals(FastShowPretty.render(0.0, RenderConfig.Default), "0.0.0d")
+  }
+
+  test("render - negative numbers") {
+    assertEquals(FastShowPretty.render(-42, RenderConfig.Default), "-42")
+    assertEquals(FastShowPretty.render(-42L, RenderConfig.Default), "-42L")
+  }
+
+  test("render - empty string") {
+    assertEquals(FastShowPretty.render("", RenderConfig.Default), "\"\"")
+  }
+
+  test("render - unicode characters") {
+    val result = FastShowPretty.render("Hello 世界", RenderConfig.Default)
+    assertEquals(result, "\"Hello 世界\"")
+  }
+
+  test("render - special characters in string") {
+    val result = FastShowPretty.render("tab\tquote\"newline\n", RenderConfig.Default)
+    assertEquals(result, "\"tab\\tquote\\\"newline\\n\"")
+  }
+
+  test("render - backslash in string") {
+    val result = FastShowPretty.render("path\\to\\file", RenderConfig.Default)
+    assertEquals(result, "\"path\\\\to\\\\file\"")
+  }
+
+  // ----------------------------------------------------------------------------
+  // 7. COMPILE-TIME VERIFICATION
+  // ----------------------------------------------------------------------------
+  // Test that macros work at compile time:
+  // - render() should inline (verify by checking it compiles)
+  // - derived should work at compile time
+  // - Type errors for unsupported types (if applicable)
+
+  test("compile-time - render compiles for supported types") {
+    // This test verifies that render compiles for various types
+    val _: String = FastShowPretty.render(42, RenderConfig.Default)
+    val _: String = FastShowPretty.render("test", RenderConfig.Default)
+    val _: String = FastShowPretty.render(Person("Alice", 30), RenderConfig.Default)
+    // If this compiles, the test passes
+    assert(true)
+  }
+
+  test("compile-time - derived compiles for supported types") {
+    import FastShowPretty.derived
+    val _: FastShowPretty[Int] = implicitly[FastShowPretty[Int]]
+    val _: FastShowPretty[Person] = implicitly[FastShowPretty[Person]]
+    // If this compiles, the test passes
+    assert(true)
+  }
+
+  // ----------------------------------------------------------------------------
+  // 8. PERFORMANCE / STRINGBUILDER REUSE
+  // ----------------------------------------------------------------------------
+  // Test StringBuilder reuse behavior:
+  // - Multiple renders append to same StringBuilder
+  // - StringBuilder state is preserved
+
+  test("StringBuilder - multiple appends") {
+    import FastShowPretty.derived
+    val instance = implicitly[FastShowPretty[Int]]
+    val sb = new StringBuilder("start: ")
+    instance.render(sb, RenderConfig.Default, 0)(1)
+    sb.append(", ")
+    instance.render(sb, RenderConfig.Default, 0)(2)
+    sb.append(", ")
+    instance.render(sb, RenderConfig.Default, 0)(3)
+    assertEquals(sb.toString, "start: 1, 2, 3")
+  }
+
+  // ----------------------------------------------------------------------------
+  // 9. PROPERTY-BASED TESTS (using ScalaCheck)
+  // ----------------------------------------------------------------------------
+  // Use ScalaCheck to test properties:
+  // - render is idempotent (render(render(x)) might not make sense, but we can test other properties)
+  // - render never throws exceptions for valid inputs
+  // - render produces non-empty strings for non-empty inputs (where applicable)
+
+  // Example property-based test:
+  // test("property - render never throws for Int") {
+  //   forAll { (n: Int) =>
+  //     noException should be thrownBy FastShowPretty.render(n)
+  //   }
+  // }
+
+  // test("property - render produces valid output for Int") {
+  //   forAll { (n: Int) =>
+  //     val result = FastShowPretty.render(n)
+  //     assert(result.nonEmpty)
+  //   }
+  // }
+
+  // ----------------------------------------------------------------------------
+  // 10. ERROR CASES (if applicable)
+  // ----------------------------------------------------------------------------
+  // Test error handling:
+  // - Unsupported types (should compile-time error or runtime error?)
+  // - Null values (if applicable)
+  // - Circular references in case classes (if applicable)
+
+  // Note: Based on the implementation, unsupported types should fail at compile time
+  // with a macro error, so these might not be testable at runtime.
+
+  // ----------------------------------------------------------------------------
+  // 11. COLLECTIONS - Testing IsCollection support
+  // ----------------------------------------------------------------------------
+  // Test that collections render correctly when item types have implicit instances.
+
+  // FIXME: these are broken
+
+  test("render - List of Ints") {
+    val result = FastShowPretty.render(List(1, 2, 3), RenderConfig.Default)
+    assertEquals(result, "List(1, 2, 3)")
+  }
+
+  // test("render - empty List") {
+  //   val result = FastShowPretty.render(List.empty[Int], RenderConfig.Default)
+  //   assertEquals(result, "List()")
+  // }
+
+  // test("render - Vector of Strings") {
+  //   val result = FastShowPretty.render(Vector("a", "b", "c"), RenderConfig.Default)
+  //   assertEquals(result, "Vector(\"a\", \"b\", \"c\")")
+  // }
+
+  // test("render - Set of Ints") {
+  //   val result = FastShowPretty.render(Set(1), RenderConfig.Default)
+  //   assertEquals(result, "Set(1)")
+  // }
+
+  // ----------------------------------------------------------------------------
+  // 12. MAPS - Testing map support (via collection of tuples)
+  // ----------------------------------------------------------------------------
+  // Note: Maps are handled as collections of tuples. The tuple rendering requires
+  // special handling which will be added in a future enhancement.
+  // For now, map tests are disabled.
+
+  // FIXME: these are broken
+
+  // test("render - Map of String to Int") {
+  //   val result = FastShowPretty.render(Map("a" -> 1))
+  //   assertEquals(result, "Map((\"a\", 1))")  // Maps render as collections of tuples
+  // }
+
+  // test("render - empty Map") {
+  //   val result = FastShowPretty.render(Map.empty[String, Int])
+  //   assertEquals(result, "Map()")
+  // }
+
+  // test("render - Map with multiple entries") {
+  //   val result = FastShowPretty.render(scala.collection.immutable.ListMap("x" -> 10, "y" -> 20))
+  //   assertEquals(result, "ListMap((\"x\", 10), (\"y\", 20))")
+  // }
+
+}

--- a/hearth-tests/src/test/scala-newest/hearth/demo/sanely_automatic/ShowSpec.scala
+++ b/hearth-tests/src/test/scala-newest/hearth/demo/sanely_automatic/ShowSpec.scala
@@ -1,4 +1,4 @@
-package hearth.demo_sanely_automatic
+package hearth.demo.sanely_automatic
 
 import hearth.MacroSuite
 
@@ -10,7 +10,7 @@ final class ShowSpec extends MacroSuite {
     group("should be able to derive type class") {
 
       test("for values with built-in support") {
-        // import hearth.demo_sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
 
         Show.derived[Boolean].show(true) <==> "true"
         Show.derived[Byte].show(1.toByte) <==> "1.toByte"
@@ -24,20 +24,20 @@ final class ShowSpec extends MacroSuite {
       }
 
       test("for values with iterable support") {
-        // import hearth.demo_sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
 
         Show.derived[Iterable[Int]].show(List(1, 2, 3)) <==> "List(1, 2, 3)"
       }
 
       test("values with case class support") {
-        // import hearth.demo_sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
 
         case class Person(name: String, age: Int)
         Show.show(Person("John", 30)) <==> "Person(name = \"John\", age = 30)"
       }
 
       test("values with enum support") {
-        // import hearth.demo_sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
 
         sealed trait Color
         case object Red extends Color
@@ -54,7 +54,7 @@ final class ShowSpec extends MacroSuite {
     group("should be able to inline showing for") {
 
       test("values with built-in support") {
-        // import hearth.demo_sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
 
         Show.show(true) <==> "true"
         Show.show(1.toByte) <==> "1.toByte"
@@ -68,20 +68,20 @@ final class ShowSpec extends MacroSuite {
       }
 
       test("for values with iterable support") {
-        // import hearth.demo_sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
 
         Show.show(List(1, 2, 3)) <==> "List(1, 2, 3)"
       }
 
       test("values with case class support") {
-        // import hearth.demo_sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
 
         case class Person(name: String, age: Int)
         Show.derived[Person].show(Person("John", 30)) <==> "Person(name = \"John\", age = 30)"
       }
 
       test("values with enum support") {
-        // import hearth.demo_sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done.
 
         sealed trait Color
         case object Red extends Color

--- a/hearth-tests/src/test/scala/hearth/demo/simple/ShowSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/demo/simple/ShowSpec.scala
@@ -1,4 +1,4 @@
-package hearth.demo
+package hearth.demo.simple
 
 import hearth.MacroSuite
 

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -504,6 +504,183 @@ final class ExprsSpec extends MacroSuite {
       }
     }
 
+    group("type ValDefBuilder scope issue") {
+
+      test("method ValDefBuilder.ofVal should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfValScopeIssue
+
+        testValDefBuilderOfValScopeIssue ==> Data(42)
+      }
+
+      test("method ValDefBuilder.ofVar should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfVarScopeIssue
+
+        @scala.annotation.nowarn // suppress "local var v$macro$N in value <local ExprsSpec> is never updated" error
+        val result = testValDefBuilderOfVarScopeIssue
+        result ==> Data(42)
+      }
+
+      test("method ValDefBuilder.ofLazy should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfLazyScopeIssue
+
+        testValDefBuilderOfLazyScopeIssue ==> Data(42)
+      }
+
+      test("method ValDefBuilder.ofDef0 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef0ScopeIssue
+
+        testValDefBuilderOfDef0ScopeIssue ==> Data(42)
+      }
+
+      test("method ValDefBuilder.ofDef1 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef1ScopeIssue
+
+        testValDefBuilderOfDef1ScopeIssue ==> Data(2 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef2 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef2ScopeIssue
+
+        testValDefBuilderOfDef2ScopeIssue ==> Data(2 * 3 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef3 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef3ScopeIssue
+
+        testValDefBuilderOfDef3ScopeIssue ==> Data(2 * 3 * 5 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef4 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef4ScopeIssue
+
+        testValDefBuilderOfDef4ScopeIssue ==> Data(2 * 3 * 5 * 7 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef5 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef5ScopeIssue
+
+        testValDefBuilderOfDef5ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef6 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef6ScopeIssue
+
+        testValDefBuilderOfDef6ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef7 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef7ScopeIssue
+
+        testValDefBuilderOfDef7ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef8 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef8ScopeIssue
+
+        testValDefBuilderOfDef8ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef9 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef9ScopeIssue
+
+        testValDefBuilderOfDef9ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef10 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef10ScopeIssue
+
+        testValDefBuilderOfDef10ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef11 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef11ScopeIssue
+
+        testValDefBuilderOfDef11ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef12 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef12ScopeIssue
+
+        testValDefBuilderOfDef12ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef13 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef13ScopeIssue
+
+        testValDefBuilderOfDef13ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef14 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef14ScopeIssue
+
+        testValDefBuilderOfDef14ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 + 1)
+      }
+
+      test("method ValDefBuilder.ofDef15 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef15ScopeIssue
+
+        testValDefBuilderOfDef15ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 + 1
+        )
+      }
+
+      test("method ValDefBuilder.ofDef16 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef16ScopeIssue
+
+        testValDefBuilderOfDef16ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 + 1
+        )
+      }
+
+      test("method ValDefBuilder.ofDef17 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef17ScopeIssue
+
+        testValDefBuilderOfDef17ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 * 59 + 1
+        )
+      }
+
+      test("method ValDefBuilder.ofDef18 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef18ScopeIssue
+
+        testValDefBuilderOfDef18ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 * 59 * 61 + 1
+        )
+      }
+
+      test("method ValDefBuilder.ofDef19 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef19ScopeIssue
+
+        testValDefBuilderOfDef19ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 * 59 * 61 * 67 + 1
+        )
+      }
+
+      test("method ValDefBuilder.ofDef20 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef20ScopeIssue
+
+        testValDefBuilderOfDef20ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 * 59 * 61 * 67 * 71 + 1
+        )
+      }
+
+      test("method ValDefBuilder.ofDef21 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef21ScopeIssue
+
+        testValDefBuilderOfDef21ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 * 59 * 61 * 67 * 71 * 73 + 1
+        )
+      }
+
+      test("method ValDefBuilder.ofDef22 should handle body Expr from different scope") {
+        import ExprsFixtures.testValDefBuilderOfDef22ScopeIssue
+
+        testValDefBuilderOfDef22ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 * 59 * 61 * 67 * 71 * 73 * 79 + 1
+        )
+      }
+    }
+
     group("type ExprCodec") {
 
       test(

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -353,6 +353,157 @@ final class ExprsSpec extends MacroSuite {
       }
     }
 
+    group("type LambdaBuilder scope issue") {
+
+      test("method LambdaBuilder.of1 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf1ScopeIssue
+
+        testLambdaBuilderOf1ScopeIssue ==> Data(2 + 1)
+      }
+
+      test("method LambdaBuilder.of2 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf2ScopeIssue
+
+        testLambdaBuilderOf2ScopeIssue ==> Data(2 * 3 + 1)
+      }
+
+      test("method LambdaBuilder.of3 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf3ScopeIssue
+
+        testLambdaBuilderOf3ScopeIssue ==> Data(2 * 3 * 5 + 1)
+      }
+
+      test("method LambdaBuilder.of4 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf4ScopeIssue
+
+        testLambdaBuilderOf4ScopeIssue ==> Data(2 * 3 * 5 * 7 + 1)
+      }
+
+      test("method LambdaBuilder.of5 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf5ScopeIssue
+
+        testLambdaBuilderOf5ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 + 1)
+      }
+
+      test("method LambdaBuilder.of6 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf6ScopeIssue
+
+        testLambdaBuilderOf6ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 + 1)
+      }
+
+      test("method LambdaBuilder.of7 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf7ScopeIssue
+
+        testLambdaBuilderOf7ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 + 1)
+      }
+
+      test("method LambdaBuilder.of8 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf8ScopeIssue
+
+        testLambdaBuilderOf8ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 + 1)
+      }
+
+      test("method LambdaBuilder.of9 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf9ScopeIssue
+
+        testLambdaBuilderOf9ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 + 1)
+      }
+
+      test("method LambdaBuilder.of10 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf10ScopeIssue
+
+        testLambdaBuilderOf10ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 + 1)
+      }
+
+      test("method LambdaBuilder.of11 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf11ScopeIssue
+
+        testLambdaBuilderOf11ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 + 1)
+      }
+
+      test("method LambdaBuilder.of12 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf12ScopeIssue
+
+        testLambdaBuilderOf12ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 + 1)
+      }
+
+      test("method LambdaBuilder.of13 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf13ScopeIssue
+
+        testLambdaBuilderOf13ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 + 1)
+      }
+
+      test("method LambdaBuilder.of14 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf14ScopeIssue
+
+        testLambdaBuilderOf14ScopeIssue ==> Data(2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 + 1)
+      }
+
+      test("method LambdaBuilder.of15 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf15ScopeIssue
+
+        testLambdaBuilderOf15ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 + 1
+        )
+      }
+
+      test("method LambdaBuilder.of16 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf16ScopeIssue
+
+        testLambdaBuilderOf16ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 + 1
+        )
+      }
+
+      test("method LambdaBuilder.of17 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf17ScopeIssue
+
+        testLambdaBuilderOf17ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 * 59 + 1
+        )
+      }
+
+      test("method LambdaBuilder.of18 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf18ScopeIssue
+
+        testLambdaBuilderOf18ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 * 59 * 61 + 1
+        )
+      }
+
+      test("method LambdaBuilder.of19 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf19ScopeIssue
+
+        testLambdaBuilderOf19ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 * 59 * 61 * 67 + 1
+        )
+      }
+
+      test("method LambdaBuilder.of20 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf20ScopeIssue
+
+        testLambdaBuilderOf20ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 * 59 * 61 * 67 * 71 + 1
+        )
+      }
+
+      test("method LambdaBuilder.of21 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf21ScopeIssue
+
+        testLambdaBuilderOf21ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 * 59 * 61 * 67 * 71 * 73 + 1
+        )
+      }
+
+      test("method LambdaBuilder.of22 should handle body Expr from different scope") {
+        import ExprsFixtures.testLambdaBuilderOf22ScopeIssue
+
+        testLambdaBuilderOf22ScopeIssue ==> Data(
+          2 * 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29 * 31 * 37 * 41 * 43 * 47 * 53 * 59 * 61 * 67 * 71 * 73 * 79 + 1
+        )
+      }
+    }
+
     group("type ExprCodec") {
 
       test(

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -17,9 +17,6 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
 
     object platformSpecific {
 
-      def withQuotes[A](thunk: scala.quoted.Quotes ?=> A): A =
-        thunk(using CrossQuotes.ctx[Quotes])
-
       final class ExprCodecImpl[A](using val from: FromExpr[A], val to: ToExpr[A]) extends ExprCodec[A] {
         override def toExpr(value: A): Expr[A] = to(value)
         override def fromExpr(expr: Expr[A]): Option[A] = from.unapply(expr)

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -655,7 +655,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term)) =>
+                case List(List(a: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -665,6 +665,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -702,7 +703,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term)) =>
+                case List(List(a: Term, b: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -714,6 +715,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -755,7 +757,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term)) =>
+                case List(List(a: Term, b: Term, c: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -769,6 +771,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -880,7 +883,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -898,6 +901,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -951,7 +955,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -971,6 +975,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -1028,7 +1033,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -1050,6 +1055,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -1111,7 +1117,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -1135,6 +1141,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -1200,7 +1207,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -1226,6 +1233,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -1295,7 +1303,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -1323,6 +1331,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -1396,7 +1405,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -1426,6 +1435,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -1503,7 +1513,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -1535,6 +1545,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -1616,7 +1627,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -1650,6 +1661,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -1735,7 +1747,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -1771,6 +1783,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -1860,7 +1873,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -1898,6 +1911,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -1991,7 +2005,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -2031,6 +2045,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -2128,7 +2143,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term, q: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term, q: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -2170,6 +2185,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -2271,7 +2287,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term, q: Term, r: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term, q: Term, r: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -2315,6 +2331,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -2420,7 +2437,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term, q: Term, r: Term, s: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term, q: Term, r: Term, s: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -2466,6 +2483,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -2575,7 +2593,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term, q: Term, r: Term, s: Term, t: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term, q: Term, r: Term, s: Term, t: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -2623,6 +2641,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -2736,7 +2755,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term, q: Term, r: Term, s: Term, t: Term, u: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term, q: Term, r: Term, s: Term, t: Term, u: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -2786,6 +2805,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =
@@ -2903,7 +2923,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term, q: Term, r: Term, s: Term, t: Term, u: Term, v: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term, e: Term, f: Term, g: Term, h: Term, i: Term, j: Term, k: Term, l: Term, m: Term, n: Term, o: Term, p: Term, q: Term, r: Term, s: Term, t: Term, u: Term, v: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -2955,6 +2975,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -3176,7 +3176,6 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
     }
 
     // format: off
-    @scala.annotation.nowarn
     override def of1[A: Type](
         freshA: FreshName
     ): LambdaBuilder[A => *, Expr[A]] = {
@@ -3184,12 +3183,8 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val a1Expr = Ref(a1).asExprOf[A]
       new LambdaBuilder[A => *, Expr[A]](
         new Mk[A => *] {
-          // TODO: we need to create tests for each such utility,
-          // reproducing the issue and then fixing it.
           override def apply[To: Type](body: Expr[To]): Expr[A => To] = withQuotes {
 
-            // The problem is already with the Type[To] :/, maybe we should use cross quotes here
-            println("executing the problematic code version=4")
             def mkBody(a: Expr[A]) = Block(
               List(
                 ValDef(a1, Some(a.asTerm)),
@@ -3214,7 +3209,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val b1Expr = Ref(b1).asExprOf[B]
       new LambdaBuilder[(A, B) => *, (Expr[A], Expr[B])](
         new Mk[(A, B) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B]) = Block(
               List(
@@ -3223,7 +3218,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(b1, Some(b.asTerm)),
                 '{ val _ = $b1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B) => ${ mkBody('a, 'b) } }
@@ -3245,7 +3240,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val c1Expr = Ref(c1).asExprOf[C]
       new LambdaBuilder[(A, B, C) => *, (Expr[A], Expr[B], Expr[C])](
         new Mk[(A, B, C) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C]) = Block(
               List(
@@ -3256,7 +3251,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(c1, Some(c.asTerm)),
                 '{ val _ = $c1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C) => ${ mkBody('a, 'b, 'c) } }
@@ -3281,7 +3276,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val d1Expr = Ref(d1).asExprOf[D]
       new LambdaBuilder[(A, B, C, D) => *, (Expr[A], Expr[B], Expr[C], Expr[D])](
         new Mk[(A, B, C, D) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D]) = Block(
               List(
@@ -3294,7 +3289,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(d1, Some(d.asTerm)),
                 '{ val _ = $d1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D) => ${ mkBody('a, 'b, 'c, 'd) } }
@@ -3322,7 +3317,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val e1Expr = Ref(e1).asExprOf[E]
       new LambdaBuilder[(A, B, C, D, E) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E])](
         new Mk[(A, B, C, D, E) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E]) = Block(
               List(
@@ -3337,7 +3332,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(e1, Some(e.asTerm)),
                 '{ val _ = $e1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E) => ${ mkBody('a, 'b, 'c, 'd, 'e) } }
@@ -3368,7 +3363,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val f1Expr = Ref(f1).asExprOf[F]
       new LambdaBuilder[(A, B, C, D, E, F) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F])](
         new Mk[(A, B, C, D, E, F) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F]) = Block(
               List(
@@ -3385,7 +3380,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(f1, Some(f.asTerm)),
                 '{ val _ = $f1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f) } }
@@ -3419,7 +3414,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val g1Expr = Ref(g1).asExprOf[G]
       new LambdaBuilder[(A, B, C, D, E, F, G) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G])](
         new Mk[(A, B, C, D, E, F, G) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G]) = Block(
               List(
@@ -3438,7 +3433,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(g1, Some(g.asTerm)),
                 '{ val _ = $g1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g) } }
@@ -3475,7 +3470,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val h1Expr = Ref(h1).asExprOf[H]
       new LambdaBuilder[(A, B, C, D, E, F, G, H) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H])](
         new Mk[(A, B, C, D, E, F, G, H) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H]) = Block(
               List(
@@ -3496,7 +3491,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(h1, Some(h.asTerm)),
                 '{ val _ = $h1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h) } }
@@ -3536,7 +3531,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val i1Expr = Ref(i1).asExprOf[I]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I])](
         new Mk[(A, B, C, D, E, F, G, H, I) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I]) = Block(
               List(
@@ -3559,7 +3554,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(i1, Some(i.asTerm)),
                 '{ val _ = $i1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) } }
@@ -3602,7 +3597,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val j1Expr = Ref(j1).asExprOf[J]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I, J) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I], Expr[J])](
         new Mk[(A, B, C, D, E, F, G, H, I, J) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I], j: Expr[J]) = Block(
               List(
@@ -3627,7 +3622,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(j1, Some(j.asTerm)),
                 '{ val _ = $j1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) } }
@@ -3673,7 +3668,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val k1Expr = Ref(k1).asExprOf[K]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I, J, K) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I], Expr[J], Expr[K])](
         new Mk[(A, B, C, D, E, F, G, H, I, J, K) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I], j: Expr[J], k: Expr[K]) = Block(
               List(
@@ -3700,7 +3695,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(k1, Some(k.asTerm)),
                 '{ val _ = $k1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k) } }
@@ -3749,7 +3744,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val l1Expr = Ref(l1).asExprOf[L]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I, J, K, L) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I], Expr[J], Expr[K], Expr[L])](
         new Mk[(A, B, C, D, E, F, G, H, I, J, K, L) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I], j: Expr[J], k: Expr[K], l: Expr[L]) = Block(
               List(
@@ -3778,7 +3773,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(l1, Some(l.asTerm)),
                 '{ val _ = $l1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l) } }
@@ -3830,7 +3825,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val m1Expr = Ref(m1).asExprOf[M]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I, J, K, L, M) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I], Expr[J], Expr[K], Expr[L], Expr[M])](
         new Mk[(A, B, C, D, E, F, G, H, I, J, K, L, M) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I], j: Expr[J], k: Expr[K], l: Expr[L], m: Expr[M]) = Block(
               List(
@@ -3861,7 +3856,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(m1, Some(m.asTerm)),
                 '{ val _ = $m1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm) } }
@@ -3916,7 +3911,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val n1Expr = Ref(n1).asExprOf[N]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I], Expr[J], Expr[K], Expr[L], Expr[M], Expr[N])](
         new Mk[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I], j: Expr[J], k: Expr[K], l: Expr[L], m: Expr[M], n: Expr[N]) = Block(
               List(
@@ -3949,7 +3944,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(n1, Some(n.asTerm)),
                 '{ val _ = $n1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n) } }
@@ -4007,7 +4002,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val o1Expr = Ref(o1).asExprOf[O]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I], Expr[J], Expr[K], Expr[L], Expr[M], Expr[N], Expr[O])](
         new Mk[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I], j: Expr[J], k: Expr[K], l: Expr[L], m: Expr[M], n: Expr[N], o: Expr[O]) = Block(
               List(
@@ -4042,7 +4037,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(o1, Some(o.asTerm)),
                 '{ val _ = $o1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o) } }
@@ -4103,7 +4098,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val p1Expr = Ref(p1).asExprOf[P]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I], Expr[J], Expr[K], Expr[L], Expr[M], Expr[N], Expr[O], Expr[P])](
         new Mk[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I], j: Expr[J], k: Expr[K], l: Expr[L], m: Expr[M], n: Expr[N], o: Expr[O], p: Expr[P]) = Block(
               List(
@@ -4140,7 +4135,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(p1, Some(p.asTerm)),
                 '{ val _ = $p1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o, 'p) } }
@@ -4204,7 +4199,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val q1Expr = Ref(q1).asExprOf[Q]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I], Expr[J], Expr[K], Expr[L], Expr[M], Expr[N], Expr[O], Expr[P], Expr[Q])](
         new Mk[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I], j: Expr[J], k: Expr[K], l: Expr[L], m: Expr[M], n: Expr[N], o: Expr[O], p: Expr[P], q: Expr[Q]) = Block(
               List(
@@ -4243,7 +4238,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(q1, Some(q.asTerm)),
                 '{ val _ = $q1Expr }.asTerm
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o, 'p, 'q) } }
@@ -4293,7 +4288,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val r1Expr = Ref(r1).asExprOf[R]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I], Expr[J], Expr[K], Expr[L], Expr[M], Expr[N], Expr[O], Expr[P], Expr[Q], Expr[R])](
         new Mk[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I], j: Expr[J], k: Expr[K], l: Expr[L], m: Expr[M], n: Expr[N], o: Expr[O], p: Expr[P], q: Expr[Q], r: Expr[R]) = Block(
               List(
@@ -4334,7 +4329,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(r1, Some(r.asTerm)),
                 '{ val _ = $r1Expr }.asTerm,
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o, 'p, 'q, 'r) } }
@@ -4387,7 +4382,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val s1Expr = Ref(s1).asExprOf[S]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I], Expr[J], Expr[K], Expr[L], Expr[M], Expr[N], Expr[O], Expr[P], Expr[Q], Expr[R], Expr[S])](
         new Mk[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I], j: Expr[J], k: Expr[K], l: Expr[L], m: Expr[M], n: Expr[N], o: Expr[O], p: Expr[P], q: Expr[Q], r: Expr[R], s: Expr[S]) = Block(
               List(
@@ -4430,7 +4425,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(s1, Some(s.asTerm)),
                 '{ val _ = $s1Expr }.asTerm,
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o, 'p, 'q, 'r, 's) } }
@@ -4485,7 +4480,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val t1Expr = Ref(t1).asExprOf[T]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I], Expr[J], Expr[K], Expr[L], Expr[M], Expr[N], Expr[O], Expr[P], Expr[Q], Expr[R], Expr[S], Expr[T])](
         new Mk[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I], j: Expr[J], k: Expr[K], l: Expr[L], m: Expr[M], n: Expr[N], o: Expr[O], p: Expr[P], q: Expr[Q], r: Expr[R], s: Expr[S], t: Expr[T]) = Block(
               List(
@@ -4530,7 +4525,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(t1, Some(t.asTerm)),
                 '{ val _ = $t1Expr }.asTerm,
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o, 'p, 'q, 'r, 's, 't) } }
@@ -4587,7 +4582,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val u1Expr = Ref(u1).asExprOf[U]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I], Expr[J], Expr[K], Expr[L], Expr[M], Expr[N], Expr[O], Expr[P], Expr[Q], Expr[R], Expr[S], Expr[T], Expr[U])](
         new Mk[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I], j: Expr[J], k: Expr[K], l: Expr[L], m: Expr[M], n: Expr[N], o: Expr[O], p: Expr[P], q: Expr[Q], r: Expr[R], s: Expr[S], t: Expr[T], u: Expr[U]) = Block(
               List(
@@ -4634,7 +4629,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(u1, Some(u.asTerm)),
                 '{ val _ = $u1Expr }.asTerm,
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o, 'p, 'q, 'r, 's, 't, 'u) } }
@@ -4693,7 +4688,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val v1Expr = Ref(v1).asExprOf[V]
       new LambdaBuilder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => *, (Expr[A], Expr[B], Expr[C], Expr[D], Expr[E], Expr[F], Expr[G], Expr[H], Expr[I], Expr[J], Expr[K], Expr[L], Expr[M], Expr[N], Expr[O], Expr[P], Expr[Q], Expr[R], Expr[S], Expr[T], Expr[U], Expr[V])](
         new Mk[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => *] {
-          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => To] = {
+          override def apply[To: Type](body: Expr[To]): Expr[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => To] = withQuotes {
 
             def mkBody(a: Expr[A], b: Expr[B], c: Expr[C], d: Expr[D], e: Expr[E], f: Expr[F], g: Expr[G], h: Expr[H], i: Expr[I], j: Expr[J], k: Expr[K], l: Expr[L], m: Expr[M], n: Expr[N], o: Expr[O], p: Expr[P], q: Expr[Q], r: Expr[R], s: Expr[S], t: Expr[T], u: Expr[U], v: Expr[V]) = Block(
               List(
@@ -4742,7 +4737,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 ValDef(v1, Some(v.asTerm)),
                 '{ val _ = $v1Expr }.asTerm,
               ),
-              body.asTerm
+              body.resetOwner.asTerm
             ).asExprOf[To]
 
             '{ (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U, v: V) => ${ mkBody('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o, 'p, 'q, 'r, 's, 't, 'u, 'v) } }

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -509,6 +509,8 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
   object ValDefBuilder extends ValDefBuilderModule {
     import quotes.*, quotes.reflect.*
 
+    import Expr.platformSpecific.*
+
     sealed private[typed] trait Mk[Signature, Returned] private[typed] {
 
       def build(body: Expr[Returned]): ValDefs[Signature]
@@ -812,7 +814,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             DefDef(
               name,
               {
-                case List(List(a: Term, b: Term, c: Term, d: Term)) =>
+                case List(List(a: Term, b: Term, c: Term, d: Term)) => withQuotes {
                   Some {
                     Block(
                       List(
@@ -828,6 +830,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                       body.asTerm.changeOwner(name)
                     )
                   }
+                }
                 // $COVERAGE-OFF$
                 case args =>
                   val preview =


### PR DESCRIPTION
Scala 3 relies on creating sub-`Quotes` (`Nested`) when quoting and splicing.

We cannot explicitly pass implicit `Quotes` in our API since it should also work on Scala 2.

Cross-Quotes takes care of it by passing it under the hood via stacks and globals, but this mechanics is not used in Expr/Type utilities, so we can end up with:

```
scala.quoted.runtime.impl.ScopeException: Expression created in a splice was used outside of that splice.
Created in: fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/FastShowPrettyMacrosImpl.scala:24 at column 23
Used in: fast-show-pretty/src/main/scala-3/hearth/kindlings/fastshowpretty/FastShowPrettyCompanionCompat.scala:6 at column 73
Type: Int


Creation stack:
	fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/FastShowPrettyMacrosImpl.scala:24 at column 23
	fast-show-pretty/src/main/scala-3/hearth/kindlings/fastshowpretty/FastShowPrettyCompanionCompat.scala:6 at column 73


Use stack:
	fast-show-pretty/src/main/scala-3/hearth/kindlings/fastshowpretty/FastShowPrettyCompanionCompat.scala:6 at column 73


Hint: A common reason for this to happen is when a `def` that creates a `'{...}`
      captures an outer instance of `Quotes`. If this `def` is called in a splice
      it will not track the `Quotes` provided by that particular splice.
      To fix it add a `given Quotes` to this `def`.
```

I've identified the place where this particular error happens, and how to fix it, but

 - we need to reproduce that in tests
 - then we could verify that the fix works
 - and repeat that for every other `LambdaBuilder`

Almost certainly the same issue appears in every other utility that uses `'{}`, e.g. `ValDefBuilder`, but I don't yet have a failing compilation to confirm this.

No idea about handcrafted ASTs.

It's a blocker for 0.3.0 release.

---

- [x] fix `LambdaBuilder`
  - [x] create failing test case for arity of 1
  - [x] apply fix and confirm it work
  - [x] repeat for other arities
- [x] fix `ValDefBuilder`
  - [x] create failing test case for arity of 1
  - [x] apply fix and confirm it work
  - [x] repeat for other arities
- [x] expose API for Scala 3, to allow safe usage of utilities with nested contexts without cross-quotes
  - [x] test this API
  - [x] document usage for Scala 3-only codbases
- [x] document this limitation in code (Expr.platformSpecific.withQuotes)
- [x] document this limitation in docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core macro codegen in `LambdaBuilder`/`ValDefBuilder` (Scala 3) and `CrossQuotesMacros` (Scala 2), which can affect compilation outcomes across many call sites; failures would surface as compile-time errors for users.
> 
> **Overview**
> Fixes Scala 3 macro expansion failures (`ScopeException` / ownership issues) by making `LambdaBuilder` and `ValDefBuilder` generate code under the *current* `Quotes` context (wrapping raw quotes with `withQuotes`) and by resetting ownership (`resetOwner`) where needed.
> 
> Hardens Scala 2 `CrossQuotesMacros` stub handling by altering fresh stub name prefixes and sorting stub replacements to avoid incorrect partial replacements (e.g., `$1` being replaced before `$10`).
> 
> Adds extensive new test coverage to reproduce/guard these issues (including Scala 3-only fixtures exercising native `'{...}` / `${...}` with `passQuotes`/`withQuotes`), introduces a new `FastShowPretty` “all features” demo + spec, and updates contributor/user docs (bug-fix workflow, cleaning guidance, and `passQuotes`/`withQuotes` usage + troubleshooting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2130ae1566a28adad9b4ec182c6a79afdb6bb078. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->