### PR TITLE
FastShowPretty improvements

### DIFF
--- a/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/FastShowPretty.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/FastShowPretty.scala
@@ -17,4 +17,13 @@ trait FastShowPretty[A] {
   /** Renders a value to a StringBuilder with indentation support. */
   def render(sb: StringBuilder, config: RenderConfig, level: Int)(value: A): StringBuilder
 }
-object FastShowPretty extends FastShowPrettyCompanionCompat
+object FastShowPretty extends FastShowPrettyCompanionCompat {
+
+  /** Special type - if its implicit is in scope then macros will log the derivation process.
+    *
+    * @see
+    *   [[hearth.demo.allfeatures.debug.logDerivation]] for details
+    */
+  sealed trait LogDerivation
+  object LogDerivation extends LogDerivation
+}

--- a/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/debug/package.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/debug/package.scala
@@ -1,0 +1,6 @@
+package hearth.demo.allfeatures
+
+package object debug {
+
+  implicit val logDerivationForFastShowPretty: FastShowPretty.LogDerivation = FastShowPretty.LogDerivation
+}

--- a/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/compiletime/FastShowPrettyMacrosImpl.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/compiletime/FastShowPrettyMacrosImpl.scala
@@ -425,9 +425,12 @@ trait FastShowPrettyMacrosImpl { this: MacroCommons & StdExtensions =>
           val lambda = builder.build[StringBuilder]
           Rule.matched(Expr.quote {
             FastShowPrettyUtils.openCollection(Expr.splice(ctx.sb), Expr.splice(name))
-            FastShowPrettyUtils.fillCollection(Expr.splice(ctx.sb), Expr.splice(iterableExpr))(Expr.splice(lambda))
-            FastShowPrettyUtils
-              .appendIndent(Expr.splice(ctx.sb), Expr.splice(ctx.config).indentString, Expr.splice(ctx.level))
+            FastShowPrettyUtils.fillCollection(
+              Expr.splice(ctx.sb),
+              Expr.splice(iterableExpr),
+              Expr.splice(ctx.config).indentString,
+              Expr.splice(ctx.level)
+            )(Expr.splice(lambda))
             FastShowPrettyUtils.closeCollection(Expr.splice(ctx.sb))
           })
         }
@@ -476,9 +479,12 @@ trait FastShowPrettyMacrosImpl { this: MacroCommons & StdExtensions =>
           val lambda = builder.build[StringBuilder]
           Rule.matched(Expr.quote {
             FastShowPrettyUtils.openCollection(Expr.splice(ctx.sb), Expr.splice(name))
-            FastShowPrettyUtils.fillCollection(Expr.splice(ctx.sb), Expr.splice(iterableExpr))(Expr.splice(lambda))
-            FastShowPrettyUtils
-              .appendIndent(Expr.splice(ctx.sb), Expr.splice(ctx.config).indentString, Expr.splice(ctx.level))
+            FastShowPrettyUtils.fillCollection(
+              Expr.splice(ctx.sb),
+              Expr.splice(iterableExpr),
+              Expr.splice(ctx.config).indentString,
+              Expr.splice(ctx.level)
+            )(Expr.splice(lambda))
             FastShowPrettyUtils.closeCollection(Expr.splice(ctx.sb))
           })
         }

--- a/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/runtime/FastShowPrettyUtils.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/internal/runtime/FastShowPrettyUtils.scala
@@ -64,7 +64,9 @@ object FastShowPrettyUtils {
   def openCollection(sb: StringBuilder, typeName: String): StringBuilder =
     sb.append(typeName).append("(")
 
-  def fillCollection[A](sb: StringBuilder, iterable: Iterable[A])(renderItem: A => StringBuilder): StringBuilder = {
+  def fillCollection[A](sb: StringBuilder, iterable: Iterable[A], indentString: String, level: Int)(
+      renderItem: A => StringBuilder
+  ): StringBuilder = {
     val iterator = iterable.iterator
     while (iterator.hasNext) {
       val item = iterator.next()
@@ -74,6 +76,7 @@ object FastShowPrettyUtils {
         sb.append(",")
       } else {
         sb.append("\n")
+        appendIndent(sb, indentString, level): Unit
       }
     }
     sb

--- a/hearth-tests/src/main/scala-newest/hearth/demo/sanely_automatic/Show.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/sanely_automatic/Show.scala
@@ -25,7 +25,7 @@ object Show extends ShowCompanionCompat {
 
   def apply[A](implicit show: Show[A]): Show[A] = show
 
-  /** Special type - is its implicit is in scope then macros will log the derivation process.
+  /** Special type - if its implicit is in scope then macros will log the derivation process.
     *
     * @see
     *   [[hearth.demo.sanely_automatic.debug.logDerivation]] for details

--- a/hearth-tests/src/main/scala/hearth/demo/simple/Show.scala
+++ b/hearth-tests/src/main/scala/hearth/demo/simple/Show.scala
@@ -40,7 +40,7 @@ object Show extends ShowCompanionCompat {
     def show(value: A): String
   }
 
-  /** Special type - is its implicit is in scope then macros will log the derivation process.
+  /** Special type - if its implicit is in scope then macros will log the derivation process.
     *
     * @see
     *   [[hearth.demo.debug.logDerivation]] for details

--- a/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
+++ b/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
@@ -453,7 +453,7 @@ final class FastShowPrettySpec extends MacroSuite {
           result,
           """Tree(
             |  value = 1,
-            |  children = List(  )
+            |  children = List()
             |)""".stripMargin
         )
       }
@@ -468,14 +468,14 @@ final class FastShowPrettySpec extends MacroSuite {
             |  children = List(
             |    Tree(
             |      value = 2,
-            |      children = List(      )
+            |      children = List()
             |    ),
             |    Tree(
             |      value = 3,
             |      children = List(
             |        Tree(
             |          value = 4,
-            |          children = List(          )
+            |          children = List()
             |        )
             |      )
             |    )

--- a/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
+++ b/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
@@ -434,13 +434,14 @@ final class FastShowPrettySpec extends MacroSuite {
           FastShowPretty.render(new hearth.demo.allfeatures.NotAHandledType, RenderConfig.Default)
           """
         ).check(
-          "The type hearth.demo.allfeatures.NotAHandledType was not handled by any derivation rule:",
-          "The rule use implicit when available was not applicable",
-          "The rule use built-in support when handling primitive types was not applicable",
-          "The rule handle as map when possible was not applicable",
-          "The rule handle as collection when possible was not applicable",
-          "The rule handle as case class when possible was not applicable",
-          "The rule handle as enum when possible was not applicable"
+          "Macro derivation failed with the following errors:",
+          "  - The type hearth.demo.allfeatures.NotAHandledType was not handled by any derivation rule:",
+          "    - The rule use implicit when available was not applicable, for the following reasons: The type hearth.demo.allfeatures.NotAHandledType does not have an implicit FastShowPretty instance: No implicit value of type hearth.demo.allfeatures.FastShowPretty[hearth.demo.allfeatures.NotAHandledType] found",
+          "    - The rule use built-in support when handling primitive types was not applicable, for the following reasons: The type hearth.demo.allfeatures.NotAHandledType is not considered to be a built-in type",
+          "    - The rule handle as map when possible was not applicable, for the following reasons: The type hearth.demo.allfeatures.NotAHandledType is not considered to be a map",
+          "    - The rule handle as collection when possible was not applicable, for the following reasons: The type hearth.demo.allfeatures.NotAHandledType is not considered to be a collection",
+          "    - The rule handle as case class when possible was not applicable, for the following reasons: The type hearth.demo.allfeatures.NotAHandledType is not considered to be a case class",
+          "    - The rule handle as enum when possible was not applicable, for the following reasons: The type hearth.demo.allfeatures.NotAHandledType is not considered to be an enum"
         )
       }
     }

--- a/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
+++ b/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
@@ -93,6 +93,24 @@ final class FastShowPrettySpec extends MacroSuite {
         }
       }
 
+      group("value types") {
+        import hearth.examples.ExampleValueClass
+
+        test("ExampleValueClass") {
+          // import hearth.demo.allfeatures.debug.logDerivationForFastShowPretty // Uncomment to see how the derivation is done.
+          val result = FastShowPretty.render(ExampleValueClass(42), RenderConfig.Default)
+          assertEquals(result, "42")
+        }
+
+        test("ExampleValueClass with derived") {
+          // import hearth.demo.allfeatures.debug.logDerivationForFastShowPretty // Uncomment to see how the derivation is done.
+          import FastShowPretty.derived
+          val instance = implicitly[FastShowPretty[ExampleValueClass]]
+          val result = instance.render(new StringBuilder, RenderConfig.Default, 0)(ExampleValueClass(99)).toString
+          assertEquals(result, "99")
+        }
+      }
+
       group("case classes") {
 
         test("compact (no indent)") {
@@ -438,6 +456,7 @@ final class FastShowPrettySpec extends MacroSuite {
           "  - The type hearth.demo.allfeatures.NotAHandledType was not handled by any derivation rule:",
           "    - The rule use implicit when available was not applicable, for the following reasons: The type hearth.demo.allfeatures.NotAHandledType does not have an implicit FastShowPretty instance: No implicit value of type hearth.demo.allfeatures.FastShowPretty[hearth.demo.allfeatures.NotAHandledType] found",
           "    - The rule use built-in support when handling primitive types was not applicable, for the following reasons: The type hearth.demo.allfeatures.NotAHandledType is not considered to be a built-in type",
+          "    - The rule handle as value type when possible was not applicable, for the following reasons: The type hearth.demo.allfeatures.NotAHandledType is not considered to be a value type",
           "    - The rule handle as map when possible was not applicable, for the following reasons: The type hearth.demo.allfeatures.NotAHandledType is not considered to be a map",
           "    - The rule handle as collection when possible was not applicable, for the following reasons: The type hearth.demo.allfeatures.NotAHandledType is not considered to be a collection",
           "    - The rule handle as case class when possible was not applicable, for the following reasons: The type hearth.demo.allfeatures.NotAHandledType is not considered to be a case class",

--- a/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
+++ b/hearth-tests/src/test/scala-newest/hearth/demo/allfeatures/FastShowPrettySpec.scala
@@ -19,61 +19,73 @@ final class FastShowPrettySpec extends MacroSuite {
       group("primitive types") {
 
         test("Boolean true") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(true, RenderConfig.Default)
           assertEquals(result, "true")
         }
 
         test("Boolean false") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(false, RenderConfig.Default)
           assertEquals(result, "false")
         }
 
         test("Byte") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(42.toByte, RenderConfig.Default)
           assertEquals(result, "42.toByte")
         }
 
         test("Short") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(42.toShort, RenderConfig.Default)
           assertEquals(result, "42.toShort")
         }
 
         test("Int") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(42, RenderConfig.Default)
           assertEquals(result, "42")
         }
 
         test("Long") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(42L, RenderConfig.Default)
           assertEquals(result, "42L")
         }
 
         test("Float") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(42.5f, RenderConfig.Default)
           assertEquals(result, "42.5f")
         }
 
         test("Double") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(42.5, RenderConfig.Default)
           assertEquals(result, "42.5d")
         }
 
         test("Char") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render('a', RenderConfig.Default)
           assertEquals(result, "'a'")
         }
 
         test("String") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render("hello", RenderConfig.Default)
           assertEquals(result, "\"hello\"")
         }
 
         test("String with quotes") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render("say \"hello\"", RenderConfig.Default)
           assertEquals(result, "\"say \\\"hello\\\"\"")
         }
 
         test("String with newlines") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render("line1\nline2", RenderConfig.Default)
           assertEquals(result, "\"line1\\nline2\"")
         }
@@ -82,6 +94,7 @@ final class FastShowPrettySpec extends MacroSuite {
       group("case classes") {
 
         test("compact (no indent)") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(Person("Alice", 30), RenderConfig.Compact)
           assertEquals(
             result,
@@ -93,6 +106,7 @@ final class FastShowPrettySpec extends MacroSuite {
         }
 
         test("tabs") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(Person("Alice", 30), RenderConfig.Tabs)
           assertEquals(
             result,
@@ -104,6 +118,7 @@ final class FastShowPrettySpec extends MacroSuite {
         }
 
         test("four spaces") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(Person("Alice", 30), RenderConfig.FourSpaces)
           assertEquals(
             result,
@@ -115,6 +130,7 @@ final class FastShowPrettySpec extends MacroSuite {
         }
 
         test("nested with tabs") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val address = Address("123 Main St", "New York")
           val person = PersonWithAddress("Bob", 25, address)
           val result = FastShowPretty.render(person, RenderConfig.Tabs)
@@ -132,6 +148,7 @@ final class FastShowPrettySpec extends MacroSuite {
         }
 
         test("case class with collection field") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(
             Team("Engineering", List(Person("Alice", 30), Person("Bob", 25))),
             RenderConfig.Default
@@ -158,6 +175,7 @@ final class FastShowPrettySpec extends MacroSuite {
       group("collections") {
 
         test("List of Ints") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(List(1, 2, 3), RenderConfig.Default)
           assertEquals(
             result,
@@ -170,11 +188,13 @@ final class FastShowPrettySpec extends MacroSuite {
         }
 
         test("empty List") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(List.empty[Int], RenderConfig.Default)
           assertEquals(result, "List()")
         }
 
         test("Vector of Strings") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(Vector("a", "b", "c"), RenderConfig.Default)
           assertEquals(
             result,
@@ -187,6 +207,7 @@ final class FastShowPrettySpec extends MacroSuite {
         }
 
         test("Set of Ints") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(Set(1), RenderConfig.Default)
           assertEquals(
             result,
@@ -196,8 +217,8 @@ final class FastShowPrettySpec extends MacroSuite {
           )
         }
 
-        /*
         test("List of case classes") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(
             List(PersonWithAddress("Bob", 25, Address("123 Main St", "New York"))),
             RenderConfig.Default
@@ -216,12 +237,12 @@ final class FastShowPrettySpec extends MacroSuite {
               |)""".stripMargin
           )
         }
-         */
       }
 
       group("maps") {
 
         test("Map of String to Int") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(Map("a" -> 1), RenderConfig.Default)
           assertEquals(
             result,
@@ -232,11 +253,13 @@ final class FastShowPrettySpec extends MacroSuite {
         }
 
         test("empty Map") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render(Map.empty[String, Int], RenderConfig.Default)
           assertEquals(result, "Map()")
         }
 
         test("Map with multiple entries") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result =
             FastShowPretty.render(scala.collection.immutable.ListMap("x" -> 10, "y" -> 20), RenderConfig.Default)
           assertEquals(
@@ -252,6 +275,7 @@ final class FastShowPrettySpec extends MacroSuite {
       group("custom implicit instances") {
 
         test("uses custom implicit instance") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           implicit val customIntInstance: FastShowPretty[Int] = new FastShowPretty[Int] {
             def render(sb: StringBuilder, config: RenderConfig, level: Int)(value: Int): StringBuilder =
               sb.append("custom(").append(value).append(")")
@@ -265,6 +289,7 @@ final class FastShowPrettySpec extends MacroSuite {
       group("edge cases") {
 
         test("zero values") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           assertEquals(FastShowPretty.render(0, RenderConfig.Default), "0")
           assertEquals(FastShowPretty.render(0L, RenderConfig.Default), "0L")
           assertEquals(FastShowPretty.render(0.0f, RenderConfig.Default), "0.0f")
@@ -272,25 +297,30 @@ final class FastShowPrettySpec extends MacroSuite {
         }
 
         test("negative numbers") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           assertEquals(FastShowPretty.render(-42, RenderConfig.Default), "-42")
           assertEquals(FastShowPretty.render(-42L, RenderConfig.Default), "-42L")
         }
 
         test("empty string") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           assertEquals(FastShowPretty.render("", RenderConfig.Default), "\"\"")
         }
 
         test("unicode characters") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render("Hello 世界", RenderConfig.Default)
           assertEquals(result, "\"Hello 世界\"")
         }
 
         test("special characters in string") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render("tab\tquote\"newline\n", RenderConfig.Default)
           assertEquals(result, "\"tab\\tquote\\\"newline\\n\"")
         }
 
         test("backslash in string") {
+          // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
           val result = FastShowPretty.render("path\\to\\file", RenderConfig.Default)
           assertEquals(result, "\"path\\\\to\\\\file\"")
         }
@@ -300,6 +330,7 @@ final class FastShowPrettySpec extends MacroSuite {
     group("derived") {
 
       test("Int instance") {
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
         val instance = implicitly[FastShowPretty[Int]]
         val sb = new StringBuilder
         val result = instance.render(sb, RenderConfig.Default, 0)(42).toString
@@ -307,6 +338,7 @@ final class FastShowPrettySpec extends MacroSuite {
       }
 
       test("case class instance") {
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
         val instance = implicitly[FastShowPretty[Person]]
         val sb = new StringBuilder
         val result = instance.render(sb, RenderConfig.Default, 0)(Person("Alice", 30)).toString
@@ -320,6 +352,7 @@ final class FastShowPrettySpec extends MacroSuite {
       }
 
       test("instance reuse StringBuilder") {
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
         val instance = implicitly[FastShowPretty[Int]]
         val sb = new StringBuilder("prefix: ")
         val result = instance.render(sb, RenderConfig.Default, 0)(42).toString
@@ -327,6 +360,7 @@ final class FastShowPrettySpec extends MacroSuite {
       }
 
       test("instance with custom config") {
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
         val instance = implicitly[FastShowPretty[Person]]
         val sb = new StringBuilder
         val result = instance.render(sb, RenderConfig.Tabs, 0)(Person("Alice", 30)).toString
@@ -340,6 +374,7 @@ final class FastShowPrettySpec extends MacroSuite {
       }
 
       test("instance with start level") {
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
         val instance = implicitly[FastShowPretty[Person]]
         val sb = new StringBuilder
         val result = instance.render(sb, RenderConfig.Default, 1)(Person("Alice", 30)).toString
@@ -356,6 +391,7 @@ final class FastShowPrettySpec extends MacroSuite {
     group("compile-time") {
 
       test("render compiles for supported types") {
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
         val _: String = FastShowPretty.render(42, RenderConfig.Default)
         val _: String = FastShowPretty.render("test", RenderConfig.Default)
         val _: String = FastShowPretty.render(Person("Alice", 30), RenderConfig.Default)
@@ -363,6 +399,7 @@ final class FastShowPrettySpec extends MacroSuite {
       }
 
       test("derived compiles for supported types") {
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
         import FastShowPretty.derived
         val _: FastShowPretty[Int] = implicitly[FastShowPretty[Int]]
         val _: FastShowPretty[Person] = implicitly[FastShowPretty[Person]]
@@ -373,6 +410,7 @@ final class FastShowPrettySpec extends MacroSuite {
     group("StringBuilder reuse") {
 
       test("multiple appends") {
+        // import hearth.demo.sanely_automatic.debug.logDerivation // Uncomment to see how the derivation is done. is done.
         import FastShowPretty.derived
         val instance = implicitly[FastShowPretty[Int]]
         val sb = new StringBuilder("start: ")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes macro derivation rules and collection rendering behavior, which can affect generated code, formatting, and compile-time diagnostics. Scope is limited to the `FastShowPretty` demo/test implementation but touches compile-time macro logic.
> 
> **Overview**
> Improves `FastShowPretty` macro derivation by adding opt-in derivation logging (via `FastShowPretty.LogDerivation` implicit import or `-Xmacro-settings:fastShowPretty.logDerivation=true`) and by enhancing compile-time error messages (better formatting and omitting empty log sections).
> 
> Extends derivation to unwrap and render *value classes* via a new `HandleAsValueTypeRule`, and tweaks collection/map rendering so the closing bracket is indented consistently (updated `fillCollection` signature and call sites).
> 
> Expands the `FastShowPrettySpec` coverage with value-class rendering, recursive tree rendering, and a compile-time assertion for the new unhandled-type error output; also adds the `debug` package object helper implicit and minor doc comment typo fixes in `Show` examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b37454ba875ab8a35820545b7b99b8bd2b6024f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->