### PR TITLE
Fix typos in documentations and comments, fix links in mkdocs, symlink CLAUDE.md to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md - AI Agent Guidelines for Hearth
+# AI Agent Guidelines for Hearth
 
 This document provides guidelines for AI agents (like Claude Code, GitHub Copilot, Cursor, etc.) working with the Hearth codebase.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: 'Hearth documentation'
 repo_url: https://github.com/MateuszKubuszok/hearth
 edit_uri: edit/master/docs/user-guide/
 docs_dir: 'user-guide'
+strict: true # ensures that all links are valid
 theme:
   name: material
   palette:

--- a/docs/user-guide/basic-utilities.md
+++ b/docs/user-guide/basic-utilities.md
@@ -211,7 +211,7 @@ These examples show how to write Scala-specific macros with Hearth.
     !!! warning "Quotes context management"
 
         When using native Scala 3 `'{ ... }` / `${ ... }` syntax with Hearth builders (e.g. `LambdaBuilder`,
-        `ValDefBuilder`), you must use [`passQuotes` and `withQuotes`](#pass-quotes-and-with-quotes) to keep
+        `ValDefBuilder`), you must use [`passQuotes` and `withQuotes`](#passquotes-and-withquotes-scala-3-only) to keep
         the `Quotes` context in sync. This is **not** needed when using [Cross Quotes](cross-quotes.md)
         (`Expr.quote` / `Expr.splice`), which handle it automatically.
 
@@ -2780,7 +2780,7 @@ Behavior can be configured via `-Xmacro-settings:hearth.mioTerminationShouldUseR
 
 This is automatically handled when using [`mio.runToExprOrFail(...)(...)` extension](micro-fp.md#integration-with-macrocommons).
 
-### `passQuotes` and `withQuotes` (Scala 3 only) { #pass-quotes-and-with-quotes }
+### `passQuotes` and `withQuotes` (Scala 3 only)
 
 When writing **Scala 3-only macros** (without [Cross Quotes](cross-quotes.md)), Scala 3's native `'{ ... }` and `${ ... }` syntax
 resolves `scala.quoted.Quotes` through normal implicit resolution. This works for simple macros, but **breaks when using Hearth's
@@ -2878,4 +2878,4 @@ withQuotes {      // restores current Quotes before quoting
       Cannot call `asTerm` on an `Expr` that was defined in a different `Quotes` context.
     ```
 
-    See also the [FAQ entry](faq.md#faq-scope-exception) on this error.
+    See also the [FAQ entry](faq.md#how-to-fix-scopeexception-cannot-call-asterm-on-an-expr-that-was-defined-in-a-different-quotes-context) on this error.

--- a/docs/user-guide/cross-quotes.md
+++ b/docs/user-guide/cross-quotes.md
@@ -51,7 +51,7 @@ that makes the whole process possible.
     Because Cross Quotes handle `scala.quoted.Quotes` passing automatically, you do **not** need to use
     `passQuotes` or `withQuotes` when building expressions with `Expr.quote` / `Expr.splice`. These utilities
     are only needed when using native Scala 3 `'{ ... }` / `${ ... }` syntax — see
-    [`passQuotes` and `withQuotes`](basic-utilities.md#pass-quotes-and-with-quotes) for details.
+    [`passQuotes` and `withQuotes`](basic-utilities.md#passquotes-and-withquotes-scala-3-only) for details.
 
 ## Usage
 

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -205,7 +205,7 @@ locally {
 
 While it's a bit mundane, it makes it rather explicit which types we are using or not, and where.
 
-## How to fix `ScopeException: Cannot call 'asTerm' on an 'Expr' that was defined in a different 'Quotes' context`? { #faq-scope-exception }
+## How to fix `ScopeException: Cannot call 'asTerm' on an 'Expr' that was defined in a different 'Quotes' context`?
 
 This error occurs when native Scala 3 `'{ ... }` / `${ ... }` syntax is used with Hearth's builders (e.g. `LambdaBuilder`,
 `ValDefBuilder`) without properly managing the `scala.quoted.Quotes` context.
@@ -240,7 +240,7 @@ withQuotes {
 }
 ```
 
-See [`passQuotes` and `withQuotes`](basic-utilities.md#pass-quotes-and-with-quotes) for a full explanation and runnable example.
+See [`passQuotes` and `withQuotes`](basic-utilities.md#passquotes-and-withquotes-scala-3-only) for a full explanation and runnable example.
 
 !!! note "Not an issue with Cross Quotes"
 

--- a/docs/user-guide/standard-extensions.md
+++ b/docs/user-guide/standard-extensions.md
@@ -2,7 +2,7 @@
 
 While the [Basic Utilities](basic-utilities.md) try to be reasonably unopinionated, sometimes we can consider
 solutions that require us to follow some convention, but in turn give us a lot out of the box. To not mix
-these unopinionated core utilities and opinionated solution, we put the latter under `std` package as opt-in
+these unopinionated core utilities and opinionated solutions, we put the latter under the `std` package as opt-in
 mixins.
 
 ## Rule-based derivation
@@ -16,11 +16,11 @@ Let's say we need to derive a JSON encoder. After drafting the logic it should f
  * if there is an existing implicit in scope - use it
  * if the type we are deriving for is a collection, use recursion to figure out how to encode its items, and then handle the collection
  * if the type we are deriving for is an `Option`, use recursion to figure out how to encode its item, and handle as well the case when the value is `null`
- * if the type we are deriving for is a `case class`, use recursion to figuer out how to encode each field
+ * if the type we are deriving for is a `case class`, use recursion to figure out how to encode each field
 
 (For simplicity, we're skipping handling of enums, maps, value types, etc).
 
-We could try to implement it with if-elses:
+We could try to implement it with `if`/`else` branches:
 
 ```scala
 val IterableType = Type.Ctor1.of[Iterable]
@@ -38,10 +38,10 @@ else if (asCaseClass.isDefined) { ... }
 else Environment.reportErrorAndAbort("...")
 ```
 
-but it quickly becomes a giant method that is hard to read, and any adjustments to the methods requires shuffling a lot of code around.
+but it quickly becomes a giant method that is hard to read, and any adjustments to the methods require shuffling a lot of code around.
 
-But, we can use the fact that this code follows the patter of "if it matches, try derivation that might fail, or yield to the next rule".
-For start, we can start with handling these as `Option`s:
+But we can use the fact that this code follows the pattern: "if it matches, try derivation that might fail, or yield to the next rule".
+For starters, we can handle these as `Option`s:
 
 ```scala
 def asImplicit[A: Type]: Option[...] = {
@@ -81,7 +81,7 @@ That is much easier to maintain:
  - their order is easy to follow and adjust
  - it is easy to split some rule to its subcases, and combine them back again
 
-But, let's say, we want to also add some [logging](micro-fp.md#logging) to the derivation, e.g using `MIO`. It is still possible:
+But let's say we also want to add some [logging](micro-fp.md#logging) to the derivation, e.g. using `MIO`. It is still possible:
 
 ```scala
 def asImplicit[A: Type]: MIO[Option[...]] = ...
@@ -102,8 +102,8 @@ However at this point `Option` is no longer as self-explanatory. If we also want
 in `MIO.fail(...)`, we would have to replace it with some `Either`, and then somehow manually aggregate the reasons for each rule
 (e.g. there is implicit but there is ambiguity; something is iterable, but its elements cannot be rendered, etc).
 
-While it's not difficult task to write such aggregator, one might want for some existing solution to exist, one that would
-standardize the appoach to such problem.
+While it's not a difficult task to write such an aggregator, one might want an existing solution that
+standardizes the approach to such a problem.
 
 That's what `Rule` and `Rules` in `hearth.std` are providing.
 

--- a/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
+++ b/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
@@ -3125,7 +3125,7 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
       }
     val quasiquote = convert(ctx)(expr.tree)
 
-    // TODO: generare freshTerm fpr quasiquotes and then {Quasiquote => $FreshTerm}
+    // TODO: generate freshTerm for quasiquotes and then {Quasiquote => $FreshTerm}
     val unchecked = q"""
     val $wtt = $typeA
     val $ctx = CrossQuotes.ctx[_root_.scala.reflect.macros.blackbox.Context]
@@ -3137,7 +3137,7 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
     $ctx.Expr[$A]($quasiquote)($wtt.asInstanceOf[$ctx.WeakTypeTag[$A]]).asInstanceOf[Expr[$A]]
     """
 
-    // purposefuly not typechecking, because it would fail with: unexpected error: Position.point on NoPosition
+    // purposefully not typechecking, because it would fail with: unexpected error: Position.point on NoPosition
     val result = suppressWarnings(unchecked)
 
     log(

--- a/hearth-cross-quotes/src/main/scala/hearth/cq/CrossQuotesSettings.scala
+++ b/hearth-cross-quotes/src/main/scala/hearth/cq/CrossQuotesSettings.scala
@@ -26,7 +26,7 @@ object CrossQuotesSettings {
     val checks = settings
       .collect[(List[((Option[JFile], Int, Int) => Boolean)])] {
         case setting if setting.startsWith(loggingSettingName + "=") =>
-          // We're splitting by '|' because compiler treats ',' as a separator for settings (which looses the prefix).
+          // We're splitting by '|' because compiler treats ',' as a separator for settings (which loses the prefix).
           val value = setting.stripPrefix(loggingSettingName + "=").trim
           if (value == "true") List((_, _, _) => true)
           else if (value == "false") List((_, _, _) => false)

--- a/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/debug/package.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/allfeatures/debug/package.scala
@@ -1,6 +1,12 @@
 package hearth.demo.allfeatures
 
+// $COVERAGE-OFF$
 package object debug {
 
+  /** Import [[FastShowPretty.LogDerivation]] in the scope to preview how the derivation is done.
+    *
+    * Put outside of [[FastShowPretty]] companion to prevent the implicit from being summoned automatically!
+    */
   implicit val logDerivationForFastShowPretty: FastShowPretty.LogDerivation = FastShowPretty.LogDerivation
 }
+// $COVERAGE-ON$

--- a/hearth-tests/src/main/scala-newest/hearth/demo/sanely_automatic/Show.scala
+++ b/hearth-tests/src/main/scala-newest/hearth/demo/sanely_automatic/Show.scala
@@ -7,7 +7,7 @@ package hearth.demo.sanely_automatic
 
 /** Example of Show type class with sanely-automatic derivation.
   *
-  * It showcases how one can generate fast code, without taxing the compiler, with easy error handling, WITHOUT repying
+  * It showcases how one can generate fast code, without taxing the compiler, with easy error handling, WITHOUT relying
   * on tons of implicit defs in the companion object, nor heavy use of semi-automatic derivation: derive only for the
   * outermost type and macro will handle everything internally!
   *

--- a/hearth-tests/src/main/scala/hearth/EnvironmentFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/EnvironmentFixturesImpl.scala
@@ -2,7 +2,7 @@ package hearth
 
 import hearth.data.Data
 
-/** Fixtured for testing [[EnvironmentSpec]]. */
+/** Fixtures for testing [[EnvironmentSpec]]. */
 trait EnvironmentFixturesImpl { this: MacroCommons =>
 
   def testPosition: Expr[Data] = {

--- a/hearth-tests/src/main/scala/hearth/MioIntegrationsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/MioIntegrationsFixturesImpl.scala
@@ -3,7 +3,7 @@ package hearth
 import hearth.data.Data
 import hearth.fp.effect.*
 
-/** Fixtured for testing [[MioIntegrationsSpec]]. */
+/** Fixtures for testing [[MioIntegrationsSpec]]. */
 trait MioIntegrationsFixturesImpl { this: hearth.MacroTypedCommons =>
 
   @scala.annotation.nowarn

--- a/hearth-tests/src/main/scala/hearth/crossquotes/CrossExprsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/CrossExprsFixturesImpl.scala
@@ -3,7 +3,7 @@ package crossquotes
 
 import hearth.data.Data
 
-/** Fixtured for testing [[CrossExprsSpec]]. */
+/** Fixtures for testing [[CrossExprsSpec]]. */
 trait CrossExprsFixturesImpl { this: MacroTypedCommons =>
 
   def testExprOf[ExampleType: Type](example: Expr[ExampleType]): Expr[Data] = {
@@ -158,7 +158,7 @@ trait CrossExprsFixturesImpl { this: MacroTypedCommons =>
         Existential[MapType[Map[Int, String], *], (Int, String)](mapTypeExample)(using Type.of[(Int, String)])
       )(using Type.of[Map[Int, String]])
 
-      // ...but it's not very convenient, so we are making sure that the workaround it no longer necessary.
+      // ...but it's not very convenient, so we are making sure that the workaround is no longer necessary.
       def fromSplittedNestedImport[A: Type](value: Expr[A], mapType: Existential[MapType[A, *]]): Expr[Data] = {
         import mapType.{Underlying as Pair, value as mapTypeOf}
         import mapTypeOf.{Key, Value} // importing from another import

--- a/hearth-tests/src/main/scala/hearth/crossquotes/CrossTypesFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/CrossTypesFixturesImpl.scala
@@ -3,7 +3,7 @@ package crossquotes
 
 import hearth.data.Data
 
-/** Fixtured for testing [[CrossTypesSpec]]. */
+/** Fixtures for testing [[CrossTypesSpec]]. */
 trait CrossTypesFixturesImpl { this: MacroTypedCommons =>
 
   def testTypeOf[A: Type]: Expr[Data] = {

--- a/hearth-tests/src/main/scala/hearth/data/DataFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/data/DataFixturesImpl.scala
@@ -1,7 +1,7 @@
 package hearth
 package data
 
-/** Fixtured for testing [[DataSpec]]. */
+/** Fixtures for testing [[DataSpec]]. */
 trait DataFixturesImpl { this: MacroCommons =>
 
   def example: Expr[Data] = Expr(DataFixturesImpl.example)

--- a/hearth-tests/src/main/scala/hearth/demo/simple/Show.scala
+++ b/hearth-tests/src/main/scala/hearth/demo/simple/Show.scala
@@ -7,7 +7,7 @@ package hearth.demo.simple
 
 /** Example of Show type class with sanely-automatic derivation.
   *
-  * It showcases how one can generate fast code, without taxing the compiler, with easy error handling, WITHOUT repying
+  * It showcases how one can generate fast code, without taxing the compiler, with easy error handling, WITHOUT relying
   * on tons of implicit defs in the companion object, nor heavy use of semi-automatic derivation: derive only for the
   * outermost type and macro will handle everything internally!
   *

--- a/hearth-tests/src/main/scala/hearth/std/StdExtensionsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/std/StdExtensionsFixturesImpl.scala
@@ -3,7 +3,7 @@ package std
 
 import hearth.data.Data
 
-/** Fixtured for testing [[StdExtensionsSpec]]. */
+/** Fixtures for testing [[StdExtensionsSpec]]. */
 @scala.annotation.nowarn // TODO: remove later?
 trait StdExtensionsFixturesImpl { this: MacroCommons & StdExtensions =>
 

--- a/hearth-tests/src/main/scala/hearth/typed/ClassesFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ClassesFixturesImpl.scala
@@ -4,7 +4,7 @@ package typed
 import hearth.data.Data
 import hearth.fp.effect.MIO
 
-/** Fixtured for testing [[ClassesSpec]]. */
+/** Fixtures for testing [[ClassesSpec]]. */
 trait ClassesFixturesImpl { this: MacroCommons =>
 
   def testClass[A: Type](excluding: VarArgs[String]): Expr[Data] = {

--- a/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
@@ -6,7 +6,7 @@ import hearth.fp.effect.MIO
 import hearth.fp.instances.*
 import hearth.fp.syntax.*
 
-/** Fixtured for testing [[ExprsSpec]]. */
+/** Fixtures for testing [[ExprsSpec]]. */
 trait ExprsFixturesImpl { this: MacroTypedCommons & hearth.untyped.UntypedMethods =>
 
   // Expr methods

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -3,7 +3,7 @@ package typed
 
 import hearth.data.Data
 
-/** Fixtured for testing [[MethodsSpec]]. */
+/** Fixtures for testing [[MethodsSpec]]. */
 trait MethodsFixturesImpl { this: MacroCommons =>
 
   def testConstructorsExtraction[A: Type]: Expr[Data] = Expr(

--- a/hearth-tests/src/main/scala/hearth/typed/TypesFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/TypesFixturesImpl.scala
@@ -3,7 +3,7 @@ package typed
 
 import hearth.data.Data
 
-/** Fixtured for testing [[TypesSpec]] and [[TypedJvmSpec]]. */
+/** Fixtures for testing [[TypesSpec]] and [[TypesJvmSpec]]. */
 trait TypesFixturesImpl { this: MacroTypedCommons =>
 
   // Type methods

--- a/hearth/src/main/scala-3/hearth/std/extensions/IsValueTypeProviderForOpaque.scala
+++ b/hearth/src/main/scala-3/hearth/std/extensions/IsValueTypeProviderForOpaque.scala
@@ -24,8 +24,9 @@ final class IsValueTypeProviderForOpaque extends StandardMacroExtension {
         *
         * Strategy:
         *   1. Try `simplified` which reduces TypeRefs to their underlying type when in scope
-        *   2. Try `translucentSuperType` which returns the upper bound of an opaque type
-        *   3. Fall back to inferring from PlainValue ctor (the one that returns A directly, not Either[?, A])
+        *   2. Outside the opaque type's scope
+        *    - try to infer from PlainValue ctor (the one that returns A directly, not Either[?, A])
+        *    - fall back to the underlying type of the opaque type
         *
         * Note: We cannot use `sym.tree` from outside the opaque type's scope because it only shows TypeBounds, not the
         * actual underlying type.

--- a/hearth/src/main/scala-3/hearth/std/extensions/IsValueTypeProviderForOpaque.scala
+++ b/hearth/src/main/scala-3/hearth/std/extensions/IsValueTypeProviderForOpaque.scala
@@ -25,8 +25,8 @@ final class IsValueTypeProviderForOpaque extends StandardMacroExtension {
         * Strategy:
         *   1. Try `simplified` which reduces TypeRefs to their underlying type when in scope
         *   2. Outside the opaque type's scope
-        *    - try to infer from PlainValue ctor (the one that returns A directly, not Either[?, A])
-        *    - fall back to the underlying type of the opaque type
+        *      - try to infer from PlainValue ctor (the one that returns A directly, not Either[?, A])
+        *      - fall back to the underlying type of the opaque type
         *
         * Note: We cannot use `sym.tree` from outside the opaque type's scope because it only shows TypeBounds, not the
         * actual underlying type.

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
@@ -31,7 +31,7 @@ final class IsCollectionProviderForJavaBitSet extends StandardMacroExtension {
               else Some(currentValue, bitSet.nextSetBit(currentValue + 1))
             }
           }
-          // Java BitSet has no smart constructors, we we'll provide a Factory that build them as plain values.
+          // Java BitSet has no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
           override def factory: Expr[scala.collection.Factory[Int, CtorResult]] = Expr.quote {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
@@ -5,7 +5,7 @@ package extensions
 /** Macro extension providing support for Java collections.
   *
   * Supports all Java built-in collections, turns them into [[scala.collection.Iterable]] using
-  * [[scala.jdk.javaapi.CollectionConverters.asScala]], and providing as [[scala.collection.Factory]] implementation.
+  * [[scala.jdk.javaapi.CollectionConverters.asScala]], and provides a [[scala.collection.Factory]] implementation.
   * Treats them as types without smart constructors.
   *
   * @since 0.3.0
@@ -57,7 +57,7 @@ final class IsCollectionProviderForJavaCollection extends StandardMacroExtension
           override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = Expr.quote {
             scala.jdk.javaapi.CollectionConverters.asScala(Expr.splice(value).iterator()).to(Iterable)
           }
-          // Java collections have no smart constructors, we we'll provide a Factory that build them as plain values.
+          // Java collections have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
           override def factory: Expr[scala.collection.Factory[Item, CtorResult]] = Expr.quote {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
@@ -5,7 +5,7 @@ package extensions
 /** Macro extension providing support for Java dictionaries.
   *
   * Supports all Java [[java.util.Dictionary]]. Converts them to [[scala.collection.Iterable]] using
-  * [[scala.jdk.javaapi.CollectionConverters.asScala]], and providing as [[scala.collection.Factory]] implementation.
+  * [[scala.jdk.javaapi.CollectionConverters.asScala]], and provides a [[scala.collection.Factory]] implementation.
   * Treats them as types without smart constructors.
   *
   * @since 0.3.0
@@ -47,7 +47,7 @@ final class IsCollectionProviderForJavaDictionary extends StandardMacroExtension
           // even though it works in provider ForJavaMap and ForScalaCollection.
           override def asIterable(value: Expr[A]): Expr[Iterable[Pair]] =
             asScalaExpr(value.asInstanceOf[Expr[java.util.Dictionary[Key0, Value0]]])
-          // Java dictionaries have no smart constructors, we we'll provide a Factory that build them as plain values.
+          // Java dictionaries have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
 
@@ -121,7 +121,7 @@ final class IsCollectionProviderForJavaDictionary extends StandardMacroExtension
             // We will use scala.jdk.javaapi.CollectionConverters.asScala to convert the dictionary to Iterable.
             override def asIterable(value: Expr[java.util.Properties]): Expr[Iterable[(String, String)]] =
               asScalaExpr(value)
-            // Java dictionaries have no smart constructors, we we'll provide a Factory that build them as plain values.
+            // Java dictionaries have no smart constructors, we'll provide a Factory that builds them as plain values.
             override type CtorResult = java.util.Properties
             implicit override val CtorResult: Type[CtorResult] = Type.of[java.util.Properties]
 

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaEnumeration.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaEnumeration.scala
@@ -5,7 +5,7 @@ package extensions
 /** Macro extension providing support for Java enumerations.
   *
   * Supports all Java [[java.util.Enumeration]]. Converts them to [[scala.collection.Iterable]] using
-  * [[scala.jdk.javaapi.CollectionConverters.asScala]], and providing as [[scala.collection.Factory]] implementation.
+  * [[scala.jdk.javaapi.CollectionConverters.asScala]], and provides a [[scala.collection.Factory]] implementation.
   * Treats them as types without smart constructors.
   *
   * @since 0.3.0
@@ -29,7 +29,7 @@ final class IsCollectionProviderForJavaEnumeration extends StandardMacroExtensio
           override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = Expr.quote {
             scala.jdk.javaapi.CollectionConverters.asScala(Expr.splice(toEnumeration(value))).to(Iterable)
           }
-          // Java enumerations have no smart constructors, we we'll provide a Factory that build them as plain values.
+          // Java enumerations have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
           override def factory: Expr[scala.collection.Factory[Item, CtorResult]] = Expr.quote {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterator.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterator.scala
@@ -5,7 +5,7 @@ package extensions
 /** Macro extension providing support for Java iterators.
   *
   * Supports all Java [[java.util.Iterator]]. Converts them to [[scala.collection.Iterable]] using
-  * [[scala.jdk.javaapi.CollectionConverters.asScala]], and providing as [[scala.collection.Factory]] implementation.
+  * [[scala.jdk.javaapi.CollectionConverters.asScala]], and provides a [[scala.collection.Factory]] implementation.
   * Treats them as types without smart constructors.
   *
   * @since 0.3.0
@@ -29,7 +29,7 @@ final class IsCollectionProviderForJavaIterator extends StandardMacroExtension {
           override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = Expr.quote {
             scala.jdk.javaapi.CollectionConverters.asScala(Expr.splice(toIterator(value))).to(Iterable)
           }
-          // Java iterators have no smart constructors, we we'll provide a Factory that build them as plain values.
+          // Java iterators have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
           override def factory: Expr[scala.collection.Factory[Item, CtorResult]] = Expr.quote {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
@@ -5,7 +5,7 @@ package extensions
 /** Macro extension providing support for Java maps.
   *
   * Supports all Java [[java.util.Map]]. Converts them to [[scala.collection.Iterable]] using
-  * [[scala.jdk.javaapi.CollectionConverters.asScala]], and providing as [[scala.collection.Factory]] implementation.
+  * [[scala.jdk.javaapi.CollectionConverters.asScala]], and provides a [[scala.collection.Factory]] implementation.
   * Treats them as types without smart constructors.
   *
   * @since 0.3.0
@@ -57,7 +57,7 @@ final class IsCollectionProviderForJavaMap extends StandardMacroExtension {
           override def asIterable(value: Expr[A]): Expr[Iterable[Pair]] = Expr.quote {
             scala.jdk.javaapi.CollectionConverters.asScala(Expr.splice(value).entrySet().iterator()).to(Iterable)
           }
-          // Java maps have no smart constructors, we we'll provide a Factory that build them as plain values.
+          // Java maps have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
           override def factory: Expr[scala.collection.Factory[Pair, CtorResult]] = Expr.quote {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaStream.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaStream.scala
@@ -5,7 +5,7 @@ package extensions
 /** Macro extension providing support for Java streams.
   *
   * Supports all Java [[java.util.stream.Stream]] types including primitive specializations. Converts them to
-  * [[scala.collection.Iterable]] using [[scala.jdk.javaapi.StreamConverters.asScala]], and providing as
+  * [[scala.collection.Iterable]] using [[scala.jdk.javaapi.StreamConverters.asScala]], and provides a
   * [[scala.collection.Factory]] implementation. Treats them as types without smart constructors.
   *
   * Note: Streams are consumed when converted to Iterable, so they can only be used once.
@@ -49,7 +49,7 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension {
           ]
       ): IsCollection[A] =
         Existential[IsCollectionOf[A, *], Item](new IsCollectionOf[A, Item] {
-          // FIXME: Investigate why the resolved implicit it's printed as:
+          // FIXME: Investigate why the resolved implicit is shown as:
           //   (StreamExtensions.this.AccumulatorFactoryInfo.noAccumulatorFactoryInfo[java.lang.String, scala.collection.Iterable[java.lang.String]])
           // when it should be:
           //   (scala.collection.convert.StreamExtensions.AccumulatorFactoryInfo....).
@@ -57,7 +57,7 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension {
             new scala.jdk.StreamConverters.StreamHasToScala(Expr.splice(toStreamExpr(value)))
               .toScala(Iterable)(using Expr.splice(accumulatorFactoryInfoExpr))
           }
-          // Java streams have no smart constructors, we we'll provide a Factory that build them as plain values.
+          // Java streams have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
           override def factory: Expr[scala.collection.Factory[Item, CtorResult]] = Expr.quote {
@@ -93,7 +93,7 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension {
             new scala.jdk.StreamConverters.IntStreamHasToScala(Expr.splice(toIntStreamExpr(value)))
               .toScala(Iterable)(using Expr.splice(accumulatorFactoryInfoExpr))
           }
-          // Java int streams have no smart constructors, we we'll provide a Factory that build them as plain values.
+          // Java int streams have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
           override def factory: Expr[scala.collection.Factory[Int, CtorResult]] = Expr.quote {
@@ -128,7 +128,7 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension {
             new scala.jdk.StreamConverters.LongStreamHasToScala(Expr.splice(toLongStreamExpr(value)))
               .toScala(Iterable)(using Expr.splice(accumulatorFactoryInfoExpr))
           }
-          // Java long streams have no smart constructors, we we'll provide a Factory that build them as plain values.
+          // Java long streams have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
           override def factory: Expr[scala.collection.Factory[Long, CtorResult]] = Expr.quote {
@@ -164,7 +164,7 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension {
             new scala.jdk.StreamConverters.DoubleStreamHasToScala(Expr.splice(toDoubleStreamExpr(value)))
               .toScala(Iterable)(using Expr.splice(accumulatorFactoryInfoExpr))
           }
-          // Java double streams have no smart constructors, we we'll provide a Factory that build them as plain values.
+          // Java double streams have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
           override def factory: Expr[scala.collection.Factory[Double, CtorResult]] = Expr.quote {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly documentation and comment/typo fixes; the only functional changes are minor test-fixture refactors and enabling MkDocs strict link checking, which may surface existing doc link issues in CI.
> 
> **Overview**
> **Documentation updates**: adds `CLAUDE.md` pointing to `AGENTS.md`, enables MkDocs `strict` mode to validate links, expands test guidelines with a detailed `scala-newest`/`NEWEST_SCALA_TESTS` workflow, and fixes several intra-doc anchors/typos.
> 
> **Minor code/test cleanups**: small fixture refactors in `StdExtensionsFixturesImpl` (avoid unused bindings, simplify a helper, remove a `nowarn`), plus comment/typo fixes and coverage markers in a `scala-newest` demo debug package object and a few macro/extension sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19385a92009c08c14106f34515e22af7abec1601. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->