### PR TITLE
Cross-Quotes should detect implicit in same class on Scala 2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,9 @@ Agents should:
 - make sure that the code was actually compiled by sbt and that `quick-tests` succeeded
 - make sure that new snippets where runnable Scala CLI examples that pass tests
 - coverage and MiMa can be skipped
+- **before reporting that a task is done**, run `sbt --client "quick-clean ; quick-test"` as the final
+  verification step — while MCP speeds up the development loop, `sbt --client` compiles and tests across
+  both Scala versions and is the more reliable way to confirm a fix
 
 If an agent was used to generate the code (e.g. following GitHub issue instructions),
 but an agent was not able to run the compilation and tests (e.g. because GitHub sandboxing

--- a/hearth-tests/src/test/scala/hearth/crossquotes/CrossExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/crossquotes/CrossExprsSpec.scala
@@ -33,7 +33,8 @@ final class CrossExprsSpec extends MacroSuite {
               "fromTypeParamInferred" -> Data("123"),
               "fromTypeParamExplicit" -> Data("123"),
               "fromNestedImport" -> Data("key: 1, value: onekey: 2, value: two"),
-              "fromSplittedNestedImport" -> Data("key: 1, value: onekey: 2, value: two")
+              "fromSplittedNestedImport" -> Data("key: 1, value: onekey: 2, value: two"),
+              "fromSameClassImplicit" -> Data("key: 1, value: onekey: 2, value: two")
             )
           )
         )


### PR DESCRIPTION
One-shot by Opus 4.6 in Cursor with this prompt:

> I need to implement https://github.com/MateuszKubuszok/hearth/issues/168  . In codebase you can find FIXME issues lines like
> ```
> // FIXME: We pass these from the outside, because Cross-Quotes on Scala 2 was missing Key and Value type substitution.
> ```
> The issue is that these implicits, even though they come from types annotates as `ImportedCrossTypeImplicit`, are ignored by Cross-Quotes on Scala 2:
> - Scala 2 currently only scans for implicits for type parameters
> - or implicit vals imported from some value (e.g. `import someValue.{Underlying as SomeValue}`)
> It would have to also check values defined in the same scope with names that use `ImportedCrossTypeImplicit.
> 
> You'd have to:
> - reproduce the issue in Cross-Quotes Expr specification
> - fingure out the AST that would have to be found
> - match on this AST similarly how other implicits are captured to extract it
> - confirm that this fixes the issue


 