### PR TITLE
Handle missed cases of implicit Type.CtorN usage in Cross-Quotes, and allow using type params from a method on the colice in its body

### DIFF
--- a/docs/user-guide/cross-quotes.md
+++ b/docs/user-guide/cross-quotes.md
@@ -811,7 +811,7 @@ Since Cross-Quotes rewrites some code into the native macro representations of e
     Names `setA`, `setB`, `setC` etc assumes convention where type parameters of each type constructor are named: `A`, `B`, `C`, ...
 
     Since:
-    
+
      - we are fixing 1 type parameter at a time
      - fixing the type paramter returns a type constructor if arity 1 smaller
      - type parameters would be reindexed
@@ -873,11 +873,98 @@ While all of these are inconvenient, they can usually be worked around. The issu
     - Nested `Expr.quote` inside `Expr.splice` with local type params (including multi-level
       quote-splice-quote-splice-quote composition)
     - Type class derivation patterns (e.g., deriving `Functor[List]` with nested quotes)
+    - Using `Type.Ctor1[F]` from an outer enclosing method inside a splice whose nearest method
+      is different (e.g. `map[A, B]`) — the outer method's implicits are found automatically
 
-### Known Issues
+### Known Issues and Gotchas
 
-- Very deeply nested expressions might hit compiler limits
-- Some edge cases in type parameter handling may not work as expected
+!!! warning "Self-referential implicit `Type` / `Type.CtorN` initialization"
+
+    Both `weakTypeTag[A]` (Scala 2) and `scala.quoted.Type.of[A]` (Scala 3) pick up an implicit if it is in scope.
+    Writing:
+
+    ```scala
+    implicit val A: Type[A] = Type.of[A]
+    ```
+
+    generates `implicit val A: Type[A] = A` — an infinite recursion. **Run `Type.of` in a scope where its result
+    is not being pulled in as an implicit/given.**
+
+    The same applies to `Type.CtorN`:
+
+    ```scala
+    // BAD — circular initialization:
+    implicit val FC: Type.Ctor1[Option] = Type.Ctor1.of[Option]
+
+    // GOOD — create the value outside, then assign:
+    val optCtor = Type.Ctor1.of[Option] // or a factory method
+    implicit val FC: Type.Ctor1[Option] = optCtor
+    ```
+
+!!! warning "`Type.of` with local type params — avoid `implicit val`"
+
+    Inside `Expr.splice` (within `Expr.quote`), **do not** write:
+
+    ```scala
+    Expr.splice {
+      implicit val evA: Type[A] = Type.of[A] // BAD — forward reference error
+      someHelper[A]
+    }
+    ```
+
+    On Scala 2, `Type.of[A]`'s expansion finds the `evA` being defined (via position checks), causing a forward
+    reference error. Instead, use non-implicit vals and pass explicitly:
+
+    ```scala
+    Expr.splice {
+      val tpeA = Type.of[A]         // GOOD — non-implicit val
+      val tpeB = Type.of[B]
+      someHelper[A, B](tpeA, tpeB)  // pass explicitly
+    }
+    ```
+
+!!! warning "Extracted methods cannot use `Expr.quote` with local type params (Scala 2)"
+
+    On Scala 2, a helper method defined outside the quote that creates its own `Expr.quote` will produce a
+    **separate quasiquote**. Free types from the outer workaround do not resolve across separate quasiquote
+    boundaries:
+
+    ```scala
+    // BAD on Scala 2 — "free type variable A" error:
+    def mapBody[A: Type, B: Type](fa: Expr[List[A]], f: Expr[A => B]): Expr[List[B]] =
+      Expr.quote { Expr.splice(fa).map(Expr.splice(f)) } // separate quasiquote!
+
+    Expr.quote {
+      def map[A, B](fa: List[A])(f: A => B): List[B] = Expr.splice {
+        mapBody[A, B](Expr.quote(fa), Expr.quote(f))
+      }
+    }
+    ```
+
+    **Workaround:** Keep `Expr.quote` calls inline in the splice body. Extracted methods can do computation
+    (build strings, create `Expr(...)` values) but must not create their own quasiquotes referencing local
+    type params:
+
+    ```scala
+    // GOOD — Expr.quote is inline in the splice body:
+    Expr.quote {
+      def map[A, B](fa: List[A])(f: A => B): List[B] = Expr.splice {
+        val faExpr: Expr[List[A]] = Expr.quote(fa)
+        val fExpr: Expr[A => B] = Expr.quote(f)
+        Expr.quote {
+          Expr.splice(faExpr).map(Expr.splice(fExpr))
+        }
+      }
+    }
+    ```
+
+    This limitation does not affect Scala 3, where the staging system handles type params natively across
+    quote boundaries.
+
+!!! note "Very deeply nested expressions"
+
+    Very deeply nested quote-splice-quote chains might hit compiler limits. If you encounter issues,
+    try simplifying the nesting structure.
 
 ## Debugging
 

--- a/docs/user-guide/cross-quotes.md
+++ b/docs/user-guide/cross-quotes.md
@@ -425,6 +425,76 @@ Nested expressions are also correctly handled by Cross Quotes:
     }
     ```
 
+### Local Type Parameters in Splices
+
+When a method defined inside `Expr.quote` has its own type parameters, those type parameters can be used
+with `Type.of` inside `Expr.splice`. This is the key building block for generating type class instances
+where methods have their own type parameters (e.g., `Functor.map[A, B]`).
+
+!!! example "Using Type.of with local type params"
+
+    ```scala
+    def example: Expr[Data] =
+      Expr.quote {
+        def helper[A]: String = Expr.splice {
+          hearth.fp.ignore(Type.of[A]) // Type.of[A] works for local type param A
+          Expr("ok")
+        }
+        Data(helper[Int])
+      }
+    ```
+
+!!! example "Functor skeleton with HKT + local type params"
+
+    ```scala
+    def functorSkeleton[F[_]](implicit FC: Type.Ctor1[F]): Expr[Data] = {
+      hearth.fp.ignore(FC)
+      Expr.quote {
+        val functor: Functor[F] = new Functor[F] {
+          def map[A, B](fa: F[A])(f: A => B): F[B] = {
+            // Type.of[A] and Type.of[B] are available inside the splice
+            val _evidence: String = Expr.splice {
+              hearth.fp.ignore(Type.of[A], Type.of[B])
+              Expr("ok")
+            }
+            null.asInstanceOf[F[B]] // placeholder
+          }
+        }
+        // ...
+      }
+    }
+    ```
+
+!!! info "How local type params work across Scala versions"
+
+    - **Scala 3**: Works natively. The staging system automatically provides `scala.quoted.Type[A]` for
+      type params from enclosing `'{ ... }` blocks. No special handling needed.
+    - **Scala 2**: Cross Quotes generates a workaround method with the same type param names as the originals
+      and implicit `WeakTypeTag` context bounds. Free type symbols (`newFreeType("A")`) are passed as arguments,
+      which the quasiquote system resolves by name to the actual type params in the generated code.
+
+!!! warning "Nested `Expr.quote` inside `Expr.splice` with local type params"
+
+    Nested `Expr.quote` inside `Expr.splice` that references local type params is **not currently supported**.
+    The inner quote's own expansion cannot handle type params from the outer quote's method definitions.
+
+    ```scala
+    // ❌ Does NOT work:
+    def map[A, B](fa: F[A])(f: A => B): F[B] =
+      Expr.splice {
+        Expr.quote(f(fa).asInstanceOf[F[B]]) // inner Expr.quote can't handle A, B
+      }
+
+    // ✅ Works: use Type.of[A] inside the splice, avoid nested Expr.quote with local type params
+    def map[A, B](fa: F[A])(f: A => B): F[B] = {
+      val _: String = Expr.splice {
+        hearth.fp.ignore(Type.of[A], Type.of[B])
+        Expr("ok")
+      }
+      null.asInstanceOf[F[B]]
+    }
+    ```
+
 ## Examples
 
 ### Simple Type Analysis
@@ -788,6 +858,25 @@ Since Cross-Quotes rewrites some code into the native macro representations of e
     **Using Cross-Quotes with code that, e.g., uses `scala.quoted.Type.of` directly is undefined behavior (and the compiler will probably crash)**.
 
 While all of these are inconvenient, they can usually be worked around. The issues they cause typically occur when we are compiling the macro code, not when the user expands it, so they shouldn't be a problem for end users.
+
+ 6. **Local type params inside `Expr.splice` inside `Expr.quote`**
+
+    When a method inside `Expr.quote` defines its own type parameters (e.g., `def map[A, B](...)`),
+    `Type.of[A]` and `Type.of[B]` can be used inside `Expr.splice` to access those type params at
+    macro-expansion time.
+
+    **What works:**
+
+    - `Type.of[A]`, `Type.of[B]` for local type params inside splices
+    - Multiple local type params simultaneously
+    - Combining HKT (`Type.Ctor1[F]`) with local type params in the same splice
+
+    **What does not work yet:**
+
+    - Nested `Expr.quote` inside `Expr.splice` that references local type params — the inner quote's
+      expansion cannot resolve type params from the outer quote's method definitions. This means a real
+      Functor derivation (where the `map` body uses `Expr.quote` to build the result expression)
+      requires platform-specific code or an alternative approach.
 
 ### Known Issues
 

--- a/docs/user-guide/cross-quotes.md
+++ b/docs/user-guide/cross-quotes.md
@@ -473,26 +473,26 @@ where methods have their own type parameters (e.g., `Functor.map[A, B]`).
       and implicit `WeakTypeTag` context bounds. Free type symbols (`newFreeType("A")`) are passed as arguments,
       which the quasiquote system resolves by name to the actual type params in the generated code.
 
-!!! warning "Nested `Expr.quote` inside `Expr.splice` with local type params"
+!!! example "Nested `Expr.quote` inside `Expr.splice` — Functor derivation"
 
-    Nested `Expr.quote` inside `Expr.splice` that references local type params is **not currently supported**.
-    The inner quote's own expansion cannot handle type params from the outer quote's method definitions.
+    Nested `Expr.quote` inside `Expr.splice` works with local type params. This enables the
+    quote-splice-quote pattern needed for type class derivation:
 
     ```scala
-    // ❌ Does NOT work:
-    def map[A, B](fa: F[A])(f: A => B): F[B] =
-      Expr.splice {
-        Expr.quote(f(fa).asInstanceOf[F[B]]) // inner Expr.quote can't handle A, B
+    // Derive Functor[List] using nested quotes
+    def deriveFunctorList: Expr[Data] =
+      Expr.quote {
+        val functor: Functor[List] = new Functor[List] {
+          def map[A, B](fa: List[A])(f: A => B): List[B] = Expr.splice {
+            val faExpr: Expr[List[A]] = Expr.quote(fa)
+            val fExpr: Expr[A => B] = Expr.quote(f)
+            Expr.quote {
+              Expr.splice(faExpr).map(Expr.splice(fExpr))
+            }
+          }
+        }
+        Data(functor.map(List(1, 2, 3))(_.toString).mkString(", "))
       }
-
-    // ✅ Works: use Type.of[A] inside the splice, avoid nested Expr.quote with local type params
-    def map[A, B](fa: F[A])(f: A => B): F[B] = {
-      val _: String = Expr.splice {
-        hearth.fp.ignore(Type.of[A], Type.of[B])
-        Expr("ok")
-      }
-      null.asInstanceOf[F[B]]
-    }
     ```
 
 ## Examples
@@ -870,13 +870,9 @@ While all of these are inconvenient, they can usually be worked around. The issu
     - `Type.of[A]`, `Type.of[B]` for local type params inside splices
     - Multiple local type params simultaneously
     - Combining HKT (`Type.Ctor1[F]`) with local type params in the same splice
-
-    **What does not work yet:**
-
-    - Nested `Expr.quote` inside `Expr.splice` that references local type params — the inner quote's
-      expansion cannot resolve type params from the outer quote's method definitions. This means a real
-      Functor derivation (where the `map` body uses `Expr.quote` to build the result expression)
-      requires platform-specific code or an alternative approach.
+    - Nested `Expr.quote` inside `Expr.splice` with local type params (including multi-level
+      quote-splice-quote-splice-quote composition)
+    - Type class derivation patterns (e.g., deriving `Functor[List]` with nested quotes)
 
 ### Known Issues
 

--- a/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
+++ b/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
@@ -1071,16 +1071,124 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
     */
   private class SpliceReplacer(ctx: TermName) extends Transformer {
 
+    /** Local type params from DefDef nodes currently in scope during tree traversal. */
+    private var localTypeParamsInScope = Map.empty[Symbol, String]
+
+    /** Finds local type param symbols referenced in a tree.
+      *
+      * Checks TypeTrees (which have `.tpe`) and Idents for references to any of the tracked local type param symbols.
+      */
+    private def findLocalTypeParamRefs(tree: Tree): Set[(Symbol, String)] = {
+      val refs = scala.collection.mutable.Set.empty[(Symbol, String)]
+      object finder extends Traverser {
+        override def traverse(t: Tree): Unit = {
+          t match {
+            case tt: TypeTree if tt.tpe != null =>
+              tt.tpe.foreach { tpe =>
+                localTypeParamsInScope.get(tpe.typeSymbol).foreach(name => refs += (tpe.typeSymbol -> name))
+              }
+            case id @ Ident(_) if id.symbol != null && id.symbol.isType =>
+              localTypeParamsInScope.get(id.symbol).foreach(n => refs += (id.symbol -> n))
+            case _ => ()
+          }
+          super.traverse(t)
+        }
+      }
+      finder.traverse(tree)
+      refs.toSet
+    }
+
+    /** Generates the free type construction code for a local type param.
+      *
+      * Creates a `Type[Any]` value that wraps a free type symbol named after the original type param. The quasiquote
+      * system resolves free types by name, connecting them to the actual type params in the generated code.
+      */
+    private def freeTypeCode(paramName: String): String =
+      s"""{
+         |  val __ctx = CrossQuotes.ctx[_root_.scala.reflect.macros.blackbox.Context]
+         |  val __sym = __ctx.universe.internal.reificationSupport.newFreeType("$paramName")
+         |  __ctx.WeakTypeTag(__ctx.internal.typeRef(__ctx.universe.NoPrefix, __sym, _root_.scala.Nil))
+         |    .asInstanceOf[$ctx.WeakTypeTag[Any]]
+         |}""".stripMargin
+
     object Splices {
       private val caches = scala.collection.mutable.Map.empty[String, String]
 
       def store(expr: Tree, tpe: Tree): Tree = {
-        // This code can contain $ which has to be escaped before printing, also we should use better printers for all such things.
+        val localRefs = findLocalTypeParamRefs(expr)
+
+        if (localRefs.isEmpty) {
+          // Simple case: no local type params referenced
+          val printedExpr = renderCode(expr)
+          val printedTpe = renderCode(tpe)
+          val stub = Ident(freshName("expressionStub"))
+          caches += (stub.toString() -> s"$${ {$printedExpr}.asInstanceOf[$ctx.Expr[$printedTpe]] }")
+          stub
+        } else {
+          // Workaround case: splice references local type params
+          storeWithWorkaround(expr, tpe, localRefs)
+        }
+      }
+
+      /** Generates a workaround method for splices that reference local type params.
+        *
+        * Instead of `$${ expr.asInstanceOf[ctx.Expr[A]] }`, generates:
+        * {{{
+        * $${
+        *   def workaround[A: ctx.WeakTypeTag] = {
+        *     <original expr unchanged>
+        *   }
+        *   workaround[Any](<freeType("A")>).asInstanceOf[ctx.Expr[Any]]
+        * }
+        * }}}
+        *
+        * Key insight: the workaround method uses the SAME type param names as the originals. The rendered expression
+        * code (via showCodePretty) contains references to `A` — by defining a type param `A` on the workaround method,
+        * these references resolve to the workaround's `A`, which receives a free-type-based WeakTypeTag. This avoids
+        * the need to rewrite tree nodes (which is fragile because showCodePretty uses TypeTree.original fields).
+        */
+      private def storeWithWorkaround(
+          expr: Tree,
+          tpe: Tree,
+          localRefs: Set[(Symbol, String)]
+      ): Tree = {
+        val sortedRefs = localRefs.toList.sortBy(_._2)
+        val workaroundName = freshName("workaround")
+
+        // Render the original expression as-is — references to local type params (e.g. `A`)
+        // will be resolved by the workaround method's own type params with the same names.
         val printedExpr = renderCode(expr)
-        val printedTpe = renderCode(tpe)
+
+        // Build the workaround method type params: [A: ctx.WeakTypeTag, ...]
+        // Using implicit WeakTypeTag context bounds so the expression's implicit lookups resolve.
+        val typeParamDecls = sortedRefs
+          .map { case (_, name) => s"$name: $ctx.WeakTypeTag" }
+          .mkString(", ")
+
+        // Build the type args for calling: [Any, Any, ...]
+        val typeArgs = sortedRefs.map(_ => "Any").mkString(", ")
+
+        // Build the free type arguments: one for each local type param
+        val freeTypeArgs = sortedRefs.map { case (_, name) => freeTypeCode(name) }.mkString(", ")
+
+        val workaroundStr = workaroundName.decodedName.toString
+
+        val code =
+          s"""$${ {
+             |  def $workaroundStr[$typeParamDecls] = {
+             |    $printedExpr
+             |  }
+             |  $workaroundStr[$typeArgs]($freeTypeArgs).asInstanceOf[$ctx.Expr[Any]]
+             |} }""".stripMargin
+
+        log(
+          s"""Cross-quotes ${paintExclDot(Console.BLUE)("Expr.splice")} workaround for local type params:
+             |Type params: ${sortedRefs.map(_._2).mkString(", ")}
+             |Code: ${indent(code)}""".stripMargin
+        )
 
         val stub = Ident(freshName("expressionStub"))
-        caches += (stub.toString() -> s"$${ {$printedExpr}.asInstanceOf[$ctx.Expr[$printedTpe]] }")
+        caches += (stub.toString() -> code)
         stub
       }
 
@@ -1104,6 +1212,17 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
     private val WildcardStar = typeNames.WILDCARD_STAR
 
     override def transform(tree: Tree): Tree = tree match {
+      /* Track local type params from DefDef nodes inside the quote body. */
+      case dd: DefDef if dd.tparams.nonEmpty =>
+        val newParams = dd.tparams.flatMap { tp =>
+          if (tp.symbol != null) Some(tp.symbol -> tp.name.decodedName.toString)
+          else None
+        }.toMap
+        val oldScope = localTypeParamsInScope
+        localTypeParamsInScope = oldScope ++ newParams
+        try super.transform(tree)
+        finally localTypeParamsInScope = oldScope
+
       /* Replaces:
        *   Expr.splice[Seq[A]](a): _*
        * with:

--- a/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
+++ b/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
@@ -328,6 +328,15 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
 
     val candidates: List[(Type, String)] = importedUnderlyingTypes ++ enclosingMethodImplicitTypes
     val excludingSet: Set[String] = excluding.view.map(_.decodedName.toString).toSet
+
+    // Separate HKT candidates (type constructors from Type.CtorN) from *-kinded types.
+    // HKT types can't use WeakTypeTag[F] but need substituteTypes post-processing.
+    // Only include candidates whose enclosing method implicit is actually Type.CtorN.Bounded[..., HKT],
+    // NOT arbitrary HKT types like DirectStyle[F].
+    val hktCandidates: List[(Type, String)] = enclosingMethodCtorHKTTypes.filterNot { case (_, renamed) =>
+      excludingSet(renamed)
+    }
+
     val importedUnderlying = candidates.view
       .filterNot { case (_, renamed) => excludingSet(renamed) }
       .flatMap { case (tpeToReplace, renamed) =>
@@ -342,133 +351,169 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
 
           Iterable((paramDef, paramVal, tpeToReplace, weakTypeTagValue))
         } catch {
-          // If there is no such implicit, we aren't creating a workaround for it.
-          case e: Throwable if e.getClass.getName == "scala.reflect.macros.TypecheckException" => Iterable.empty
-          // If there are other errors, we should probably report them.
+          // HKT types (F[_] from Type.CtorN[F]) can't be handled by the workaround mechanism
+          // because WeakTypeTag doesn't support higher-kinded types in Scala 2.
+          // These are handled separately via substituteTypes post-processing below.
+          case e: Throwable if e.getClass.getName == "scala.reflect.macros.TypecheckException" =>
+            Iterable.empty
         }
       }
       .toSeq
 
+    def wrapWithHKTSubstitution(baseResult: c.Tree): c.Tree =
+      if (hktCandidates.isEmpty) baseResult
+      else {
+        // For each HKT candidate, generate a runtime substituteTypes call.
+        // At runtime, FC.asUntyped provides the concrete type constructor (e.g., Option).
+        // We find F's symbol in the raw type by name and substitute it.
+        val ctxSub = freshName("ctxSub")
+        val rawTpe = freshName("rawTpe")
+        val fixedTpe = freshName("fixedTpe")
+
+        val substitutionSteps: List[Tree] = hktCandidates.flatMap { case (hktTpe, implicitName) =>
+          val symName = Literal(Constant(hktTpe.typeSymbol.name.toString))
+          val implRef = Ident(TermName(implicitName))
+          val symVar = freshName("hktSym")
+          List(
+            q"var $symVar: $ctxSub.universe.Symbol = $ctxSub.universe.NoSymbol",
+            q"""$rawTpe.foreach { (t: $ctxSub.universe.Type) =>
+              if (t.typeSymbol.name.toString == $symName && !t.typeSymbol.isClass) $symVar = t.typeSymbol
+            }""",
+            q"""if ($symVar != $ctxSub.universe.NoSymbol)
+              $fixedTpe = $fixedTpe.substituteTypes($symVar :: _root_.scala.Nil, $implRef.asUntyped.asInstanceOf[$ctxSub.universe.Type] :: _root_.scala.Nil)"""
+          )
+        }
+
+        q"""{
+          val $ctxSub = CrossQuotes.ctx[_root_.scala.reflect.macros.blackbox.Context]
+          val $rawTpe = ($baseResult).asInstanceOf[$ctxSub.WeakTypeTag[_]].tpe
+          var $fixedTpe: $ctxSub.universe.Type = $rawTpe
+          ..$substitutionSteps
+          $ctxSub.WeakTypeTag($fixedTpe).asInstanceOf[Type[$weakTypeTagOf]]
+        }"""
+      }
+
     if (importedUnderlying.isEmpty) {
-      noInjectResult
-    } else {
-      var skipWorkaround = true
+      wrapWithHKTSubstitution(noInjectResult)
+    } else
+      {
+        var skipWorkaround = true
 
-      val workaround: TermName = freshName("workaround")
-      val paramDefs: Seq[TypeDef] = importedUnderlying.map(_._1)
-      val paramVals: Seq[ValDef] = importedUnderlying.map(_._2)
-      val tpesToReplace: Seq[Type] = importedUnderlying.map(_._3)
-      val weakTypeTagValues: Seq[Tree] = importedUnderlying.map(_._4)
+        val workaround: TermName = freshName("workaround")
+        val paramDefs: Seq[TypeDef] = importedUnderlying.map(_._1)
+        val paramVals: Seq[ValDef] = importedUnderlying.map(_._2)
+        val tpesToReplace: Seq[Type] = importedUnderlying.map(_._3)
+        val weakTypeTagValues: Seq[Tree] = importedUnderlying.map(_._4)
 
-      // If macros were sane, this would be almost enough.
-      //
-      // We would just need to apply the fix to `weakTypeTagOf` in `$ctx2.weakTypeTag[$weakTypeTagOf].asInstanceOf[Type[$weakTypeTagOf]]`.
-      //
-      // So, why I put `null` instead of `$ctx2.weakTypeTag[$weakTypeTagOf]`? As a matter of the fact, why I created new $ctx2?
-      val uncheckedResultPrototype = q"""
+        // If macros were sane, this would be almost enough.
+        //
+        // We would just need to apply the fix to `weakTypeTagOf` in `$ctx2.weakTypeTag[$weakTypeTagOf].asInstanceOf[Type[$weakTypeTagOf]]`.
+        //
+        // So, why I put `null` instead of `$ctx2.weakTypeTag[$weakTypeTagOf]`? As a matter of the fact, why I created new $ctx2?
+        val uncheckedResultPrototype = q"""
       val $ctx2 = CrossQuotes.ctx[_root_.scala.reflect.macros.blackbox.Context]
       import $ctx2.universe.{ TypeRef, TypeRefTag }
       def $workaround[..$paramDefs](implicit ..$paramVals): Type[$weakTypeTagOf] = null.asInstanceOf[Type[$weakTypeTagOf]]
       $workaround[..$tpesToReplace](..$weakTypeTagValues)
       """
 
-      // To fix the `weakTypeTagOf` tree, we have to have c.Type or Symbol or each type parameter, so that we could replace params with them.
-      //
-      // And this requires typechecking.
-      //
-      // So, we have to create a stub, that typechecks (ctx would not, since it's defined outside of that snippet), that we will modify later on.
-      def fixWorkaroundBody(patchBody: DefDef => c.Tree): c.Tree = {
-        val Block(List(ctxVal, ctxImport, unpatchedDef: DefDef), callDef) = c.typecheck(uncheckedResultPrototype)
-        val patchedDef = treeCopy.DefDef(
-          unpatchedDef,
-          unpatchedDef.mods,
-          unpatchedDef.name,
-          unpatchedDef.tparams,
-          unpatchedDef.vparamss,
-          unpatchedDef.tpt,
-          patchBody(unpatchedDef)
-        )
-        if (skipWorkaround) noInjectResult
-        // We also have to c.untypecheck the result, because otherwise we're getting errors from mixing typed and untyped trees.
-        // Literally, NullPoinerExceptions, from Symbols on typechecking:
-        //   Cannot invoke "scala.reflect.internal.Types$Type.typeSymbol()" because "tp" is null
-        // So we have to untypecheck the result, to avoid this problem.
-        else c.untypecheck(Block(List(ctxVal, ctxImport, patchedDef), callDef))
-      }
-
-      fixWorkaroundBody { unpatchedDef =>
-        // Replaces the Tree with the Type representation that could miss some value.Underlying,
-        // with Tree using Types from type parameters - because they would get picked up. SMH.
-        object typePatcher extends Transformer {
-
-          // To obtain these we had to typecheck the Tree above, because we need them to be able to recursively replace
-          // e.g. somevalue.Underlying with SomeValueTypeParameter (substituteTypes and substituteSymbols seem to not work
-          // and only replacing the top level Type in TypeTree is not enough).
-          private val paramTpes = unpatchedDef.symbol.asMethod.typeParams.map(_.asType.toType)
-          def patchTpe(tpe: Type): Type = tpe.map { oldType =>
-            val index = tpesToReplace.indexWhere(oldType =:= _)
-            if (index < 0) oldType
-            else {
-              skipWorkaround = false
-              paramTpes(index)
-            }
-          }
-
-          // We need to reify the type as a Tree, because otherwise it won't survive the c.untypecheck(result)
-          // (and we need to untypecheck the result, because otherwise we're getting errors from mixing typed and untyped trees).
-          //
-          // If we skipped this... then e.g.:
-          //   weakTypeTag[Option[B1]] // B1 is type paremeter
-          // on c.untypecheck becomes
-          //   weakTypeTag
-          // which on later (re)typechecking becomes
-          //   weakTypeTag[B1] // ??
-          // which is not what we want. We need to preserve the type during untypechecking... which requires reifying it as a Tree.
-          private def pkgRef(sym: Symbol): Tree = {
-            // sym is a package *class* symbol
-            val parts = sym.fullName.split('.')
-            parts.foldLeft[Tree](Ident(termNames.ROOTPKG)) { case (acc, part) =>
-              Select(acc, TermName(part))
-            }
-          }
-          def typeToTree(t: Type): Tree = t.dealias match {
-            case TypeRef(pre, sym, args) =>
-              val base: Tree = pre match {
-                // unqualified simple type (e.g. List, MyType)
-                case NoPrefix => Ident(sym.name.toTypeName)
-                // *** THIS IS THE IMPORTANT BIT ***
-                // Option[B1] often has pre = ThisType(scala.package)
-                case ThisType(pkg) if pkg.isPackageClass => Select(pkgRef(pkg), sym.name.toTypeName)
-                // other prefixes (path-dependent types etc.)
-                case _ => Select(typeToTree(pre), sym.name.toTypeName)
-              }
-              if (args.isEmpty) base
-              else AppliedTypeTree(base, args.map(typeToTree))
-            case SingleType(pre, sym) =>
-              pre match {
-                case ThisType(pkg) if pkg.isPackageClass => Select(pkgRef(pkg), sym.name.toTermName)
-                case _                                   => Select(typeToTree(pre), sym.name.toTermName)
-              }
-            case ThisType(sym) if sym.isPackageClass => pkgRef(sym)
-            case ThisType(sym)                       => This(sym.name.toTypeName)
-            case ConstantType(c)                     => Literal(c)
-            case AnnotatedType(_, underlying)        => typeToTree(underlying)
-            case ExistentialType(_, underlying)      => typeToTree(underlying)
-            case other                               => TypeTree(other) // fallback
-          }
-
-          override def transform(tree: Tree): Tree = tree match {
-            case tpeTree: TypeTree if tpeTree.tpe != null =>
-              val patchedType = patchTpe(tpeTree.tpe)
-              if (patchedType =:= tpeTree.tpe) tpeTree
-              else typeToTree(patchedType)
-            case _ => super.transform(tree)
-          }
+        // To fix the `weakTypeTagOf` tree, we have to have c.Type or Symbol or each type parameter, so that we could replace params with them.
+        //
+        // And this requires typechecking.
+        //
+        // So, we have to create a stub, that typechecks (ctx would not, since it's defined outside of that snippet), that we will modify later on.
+        def fixWorkaroundBody(patchBody: DefDef => c.Tree): c.Tree = {
+          val Block(List(ctxVal, ctxImport, unpatchedDef: DefDef), callDef) = c.typecheck(uncheckedResultPrototype)
+          val patchedDef = treeCopy.DefDef(
+            unpatchedDef,
+            unpatchedDef.mods,
+            unpatchedDef.name,
+            unpatchedDef.tparams,
+            unpatchedDef.vparamss,
+            unpatchedDef.tpt,
+            patchBody(unpatchedDef)
+          )
+          if (skipWorkaround) noInjectResult
+          // We also have to c.untypecheck the result, because otherwise we're getting errors from mixing typed and untyped trees.
+          // Literally, NullPoinerExceptions, from Symbols on typechecking:
+          //   Cannot invoke "scala.reflect.internal.Types$Type.typeSymbol()" because "tp" is null
+          // So we have to untypecheck the result, to avoid this problem.
+          else c.untypecheck(Block(List(ctxVal, ctxImport, patchedDef), callDef))
         }
 
-        q"""$ctx2.weakTypeTag[${typePatcher.transform(weakTypeTagOf)}].asInstanceOf[Type[$weakTypeTagOf]]"""
-      }
-    }
+        fixWorkaroundBody { unpatchedDef =>
+          // Replaces the Tree with the Type representation that could miss some value.Underlying,
+          // with Tree using Types from type parameters - because they would get picked up. SMH.
+          object typePatcher extends Transformer {
+
+            // To obtain these we had to typecheck the Tree above, because we need them to be able to recursively replace
+            // e.g. somevalue.Underlying with SomeValueTypeParameter (substituteTypes and substituteSymbols seem to not work
+            // and only replacing the top level Type in TypeTree is not enough).
+            private val paramTpes = unpatchedDef.symbol.asMethod.typeParams.map(_.asType.toType)
+            def patchTpe(tpe: Type): Type = tpe.map { oldType =>
+              val index = tpesToReplace.indexWhere(oldType =:= _)
+              if (index < 0) oldType
+              else {
+                skipWorkaround = false
+                paramTpes(index)
+              }
+            }
+
+            // We need to reify the type as a Tree, because otherwise it won't survive the c.untypecheck(result)
+            // (and we need to untypecheck the result, because otherwise we're getting errors from mixing typed and untyped trees).
+            //
+            // If we skipped this... then e.g.:
+            //   weakTypeTag[Option[B1]] // B1 is type paremeter
+            // on c.untypecheck becomes
+            //   weakTypeTag
+            // which on later (re)typechecking becomes
+            //   weakTypeTag[B1] // ??
+            // which is not what we want. We need to preserve the type during untypechecking... which requires reifying it as a Tree.
+            private def pkgRef(sym: Symbol): Tree = {
+              // sym is a package *class* symbol
+              val parts = sym.fullName.split('.')
+              parts.foldLeft[Tree](Ident(termNames.ROOTPKG)) { case (acc, part) =>
+                Select(acc, TermName(part))
+              }
+            }
+            def typeToTree(t: Type): Tree = t.dealias match {
+              case TypeRef(pre, sym, args) =>
+                val base: Tree = pre match {
+                  // unqualified simple type (e.g. List, MyType)
+                  case NoPrefix => Ident(sym.name.toTypeName)
+                  // *** THIS IS THE IMPORTANT BIT ***
+                  // Option[B1] often has pre = ThisType(scala.package)
+                  case ThisType(pkg) if pkg.isPackageClass => Select(pkgRef(pkg), sym.name.toTypeName)
+                  // other prefixes (path-dependent types etc.)
+                  case _ => Select(typeToTree(pre), sym.name.toTypeName)
+                }
+                if (args.isEmpty) base
+                else AppliedTypeTree(base, args.map(typeToTree))
+              case SingleType(pre, sym) =>
+                pre match {
+                  case ThisType(pkg) if pkg.isPackageClass => Select(pkgRef(pkg), sym.name.toTermName)
+                  case _                                   => Select(typeToTree(pre), sym.name.toTermName)
+                }
+              case ThisType(sym) if sym.isPackageClass => pkgRef(sym)
+              case ThisType(sym)                       => This(sym.name.toTypeName)
+              case ConstantType(c)                     => Literal(c)
+              case AnnotatedType(_, underlying)        => typeToTree(underlying)
+              case ExistentialType(_, underlying)      => typeToTree(underlying)
+              case other                               => TypeTree(other) // fallback
+            }
+
+            override def transform(tree: Tree): Tree = tree match {
+              case tpeTree: TypeTree if tpeTree.tpe != null =>
+                val patchedType = patchTpe(tpeTree.tpe)
+                if (patchedType =:= tpeTree.tpe) tpeTree
+                else typeToTree(patchedType)
+              case _ => super.transform(tree)
+            }
+          }
+
+          q"""$ctx2.weakTypeTag[${typePatcher.transform(weakTypeTagOf)}].asInstanceOf[Type[$weakTypeTagOf]]"""
+        }
+      }.pipe(wrapWithHKTSubstitution)
   }
 
   /** Collects names imported from *.Underlying patterns in the macro expansion's enclosings.
@@ -580,6 +625,18 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
     result.toList
   } catch { case _: Throwable => Nil }
 
+  /** Extracts the HKT (last type arg) from a `Type.CtorN.Bounded[L1, U1, ..., LN, UN, HKT]` type.
+    *
+    * Returns `Some(HKT)` if the type (after dealiasing) matches the pattern, `None` otherwise.
+    */
+  private def extractCtorHKT(tpe: Type): Option[Type] = tpe.dealias match {
+    case TypeRef(_, sym, args) if args.nonEmpty =>
+      if (sym.name.toString == "Bounded" && sym.owner.name.toString.startsWith("Ctor"))
+        Some(args.last)
+      else None
+    case _ => None
+  }
+
   /** Collects implicit vals of type Type[X] from the enclosing method body, where X is a type parameter.
     *
     * Unlike `sameClassImplicitTypes`, these are local variables without `ThisType` prefixes, so they can safely be fed
@@ -614,9 +671,51 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
                   case TypeRef(_, _, List(innerType)) if !innerType.typeSymbol.isClass => innerType
                 }
               }
+              .orElse(scala.util.Try {
+                // Fallback: detect Type.CtorN[F] and extract the HKT F
+                extractCtorHKT(vd.symbol.info).filter(!_.typeSymbol.isClass).get
+              })
               .toOption
               .foreach { tpeToReplace =>
                 result += (tpeToReplace -> vd.name.decodedName.toString)
+              }
+          case _ => super.traverse(tree)
+        }
+      }
+      finder.traverse(enclosingMethod)
+    }
+
+    result.toList
+  } catch { case _: Throwable => Nil }
+
+  /** Collects HKT types from Type.CtorN implicit vals in the enclosing method.
+    *
+    * Returns (hktType, implicitValName) pairs where hktType is the extracted type constructor (e.g. F from
+    * Type.Ctor1[F]) and implicitValName is the val's name (e.g. "FC"). Only includes candidates from Type.CtorN, not
+    * arbitrary HKT types.
+    */
+  private def enclosingMethodCtorHKTTypes: List[(Type, String)] = try {
+    val result = scala.collection.mutable.ListBuffer[(Type, String)]()
+    val expansionPos = c.enclosingPosition
+
+    def isBeforeExpansionPoint(pos: Position): Boolean =
+      pos != NoPosition &&
+        (pos.line < expansionPos.line ||
+          (pos.line == expansionPos.line && pos.column < expansionPos.column))
+
+    @scala.annotation.nowarn
+    val enclosingMethod = c.enclosingMethod
+    if (enclosingMethod != EmptyTree) {
+      object finder extends Traverser {
+        override def traverse(tree: Tree): Unit = tree match {
+          case vd: ValDef
+              if vd.mods.hasFlag(Flag.IMPLICIT) &&
+                isBeforeExpansionPoint(vd.pos) &&
+                vd.symbol != null =>
+            extractCtorHKT(vd.symbol.info)
+              .filter(!_.typeSymbol.isClass)
+              .foreach { hktTpe =>
+                result += (hktTpe -> vd.name.decodedName.toString)
               }
           case _ => super.traverse(tree)
         }
@@ -692,6 +791,7 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
                |""".stripMargin
           )
         }
+
       }
       .pipe(c.parse(_))
       .tap { tree =>
@@ -753,6 +853,29 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
         //   None
         case _: Exception => None
       }
+
+      /** Creates a Cache for an HKT (higher-kinded type) from a Type.CtorN implicit.
+        *
+        * Since `Type[F]` is invalid when F has kind `* -> *`, we construct a WeakTypeTag at runtime from the CtorN's
+        * `.asUntyped` method, which provides the raw `c.Type`.
+        */
+      def forHKTType(implicitValName: String, hktTpe: Type): Option[Cache] = try {
+        val stub = freshTypeName("TypeStub")
+        val originalSymbol = hktTpe.typeSymbol
+        @scala.annotation.nowarn
+        val symbol = c.universe.internal.newTypeSymbol(
+          owner = originalSymbol.owner,
+          name = stub,
+          pos = originalSymbol.pos,
+          flags = c.internal.flags(originalSymbol)
+        )
+        val ttag = c.parse(
+          s"$ctx.universe.Ident($implicitValName.asUntyped.asInstanceOf[$ctx.universe.Type].typeSymbol)"
+        )
+        _root_.scala.Some(Cache(stub, symbol, ttag))
+      } catch {
+        case _: Exception => None
+      }
     }
 
     object AbstractTypes {
@@ -761,6 +884,9 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
       def find(name: String): Option[Cache] = caches.getOrElseUpdate(name, Cache.forTypeName(name))
       def find(name: Name): Option[Cache] = find(name.toString)
       def find(symbol: Symbol): Option[Cache] = find(symbol.name.toString)
+
+      /** Register an HKT type so that Ident(TypeName("F")) resolves to its stub. */
+      def register(name: String, cache: Cache): Unit = caches(name) = Some(cache)
 
       def toReplace = caches.view.collect { case (_, Some(Cache(stub, _, weakTypeTag))) =>
         val printedWeakTypeTag = renderCode(weakTypeTag)
@@ -785,10 +911,21 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
           catch {
             case _: Throwable => None
           }
-          byType.orElse(byName).map { cache =>
+          // For HKT types (type constructors like F[_] from Type.CtorN[F]),
+          // Cache.forTypeName fails because Type[F] is a kind error.
+          // Instead, construct a WeakTypeTag from the CtorN's .asUntyped at runtime.
+          def byHKT =
+            if (tpe.typeParams.nonEmpty) Cache.forHKTType(name, tpe)
+            else None
+          byType.orElse(byName).orElse(byHKT).map { cache =>
             cachesAliases += (name -> cache)
             cachesAliases += (s"$name.type" -> cache)
             cachesAliases += (renderCode(tpe) -> cache)
+            // For HKT types, also register in AbstractTypes so that
+            // Ident(TypeName("F")) is resolved when F appears in the tree.
+            if (tpe.typeParams.nonEmpty) {
+              AbstractTypes.register(tpe.typeSymbol.name.toString, cache)
+            }
             tpe -> cache
           }
       }.toMap
@@ -814,6 +951,10 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
         name -> stub.toString
       }.toMap
     }
+
+    // Force ImportedTypes initialization before traversal so that HKT types
+    // registered via AbstractTypes.register are available before AbstractTypes.find is called.
+    locally { ImportedTypes; () }
 
     override def transform(tree: Tree): Tree = tree match {
       // Transform references like someValue.Underlying to Ident(ImportStub).

--- a/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
+++ b/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
@@ -74,6 +74,43 @@ import scala.util.chaining.*
   *     represented by `Type[A]` - this is the most fragile part of the whole macro.
   *
   * The result while not perfect, should be robust enough for most cases.
+  *
+  *   4. When `Expr.splice` inside `Expr.quote` references type parameters from methods defined inside the quote body
+  *      (''local type params''), these type params don't exist at macro-expansion time. For example:
+  *
+  * {{{
+  * Expr.quote {
+  *   def helper[A]: String = Expr.splice {
+  *     hearth.fp.ignore(Type.of[A]) // A is from helper, not available at macro time
+  *     Expr("ok")
+  *   }
+  *   Data(helper[Int])
+  * }
+  * }}}
+  *
+  * The `SpliceReplacer` detects local type param references and wraps the splice body in a workaround method:
+  *
+  * {{{
+  * ${ {
+  *   def workaround[A: ctx.WeakTypeTag] = {
+  *     <original splice body, unchanged>
+  *   }
+  *   workaround[Any]({
+  *     val __ctx = CrossQuotes.ctx[blackbox.Context]
+  *     val __sym = __ctx.universe.internal.reificationSupport.newFreeType("A")
+  *     __ctx.WeakTypeTag(__ctx.internal.typeRef(__ctx.universe.NoPrefix, __sym, Nil))
+  *       .asInstanceOf[ctx.WeakTypeTag[Any]]
+  *   }).asInstanceOf[ctx.Expr[Any]]
+  * } }
+  * }}}
+  *
+  * Key insight: the workaround method uses the '''same''' type param names as the originals. `showCodePretty` renders
+  * the tree with `A` references — by defining a type param `A` on the workaround, these references resolve to the
+  * workaround's `A`. The free type (`newFreeType("A")`) is resolved by name during quasiquote expansion, connecting to
+  * the actual type param in the generated code.
+  *
+  * '''Limitation:''' Nested `Expr.quote` inside `Expr.splice` that references local type params is not yet supported —
+  * the inner quote's own expansion cannot handle type params from the outer quote's method definitions.
   */
 final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettyScala2 with CrossQuotesMacrosCtorMethods {
 
@@ -1067,7 +1104,16 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
     }
   }
 
-  /** Handles type parameters inside Expr.splice: Expr.splice[A](a)
+  /** Handles `Expr.splice[A](a)` inside `Expr.quote` bodies.
+    *
+    * For simple splices (no local type param references), renders the splice expression and wraps it in `$${ ... }` for
+    * quasiquote interpolation.
+    *
+    * For splices that reference local type params (from `DefDef` nodes in the quote body), generates a workaround
+    * method that provides the type params as implicit `WeakTypeTag` context bounds, with free-type-based values that
+    * the quasiquote system resolves by name. See the class-level Scaladoc for details.
+    *
+    * Also tracks `DefDef` type params during tree traversal to build the local type param scope.
     */
   private class SpliceReplacer(ctx: TermName) extends Transformer {
 

--- a/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
+++ b/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
@@ -109,8 +109,10 @@ import scala.util.chaining.*
   * workaround's `A`. The free type (`newFreeType("A")`) is resolved by name during quasiquote expansion, connecting to
   * the actual type param in the generated code.
   *
-  * '''Limitation:''' Nested `Expr.quote` inside `Expr.splice` that references local type params is not yet supported —
-  * the inner quote's own expansion cannot handle type params from the outer quote's method definitions.
+  * Nested `Expr.quote` inside `Expr.splice` also works with local type params. The inner `quoteImpl` expands first and
+  * produces typechecked code where `WeakTypeTag` resolutions are already baked in. The outer `SpliceReplacer` then
+  * wraps the entire splice body (including the inner expansion) in the workaround method, and the free types resolve
+  * correctly through the quasiquote system.
   */
 final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettyScala2 with CrossQuotesMacrosCtorMethods {
 

--- a/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
+++ b/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
@@ -9,7 +9,9 @@ import scala.util.chaining.*
 /** These macros are responsible for rewriting Expr.quote/Expr.splice into native quotes
   * ([[scala.reflect.macros.blackbox.Context.Expr]]/[[scala.reflect.macros.blackbox.Context.Type]]) in Scala 2.
   *
-  *   1. The first thing that it does is to replace:
+  * ==1. Type.of[A]==
+  *
+  * Replaces:
   *
   * {{{
   * Type.of[A]
@@ -22,11 +24,13 @@ import scala.util.chaining.*
   * import ctx.universe.{Type => _, internal => _, _}
   * implicit def convertProvidedTypesForCrossQuotes[B](implicit B: Type[B]): ctx.WeakTypeTag[B] =
   *   B.asInstanceOf[ctx.WeakTypeTag[B]]
-  * _root_.hearth.fp.ignore(convertProvidedTypesForCrossQuotes[Any](_: Type[Any])) // supress warnings
-  * weakTypeTag[A].asInstanceOf[Type[A}]]
+  * _root_.hearth.fp.ignore(convertProvidedTypesForCrossQuotes[Any](_: Type[Any])) // suppress warnings
+  * weakTypeTag[A].asInstanceOf[Type[A]]
   * }}}
   *
-  * and:
+  * ==2. Expr.quote[A](expr)==
+  *
+  * Replaces:
   *
   * {{{
   * Expr.quote[A](expr)
@@ -42,7 +46,9 @@ import scala.util.chaining.*
   * ).asInstanceOf[Expr[A]]
   * }}}
   *
-  * and
+  * ==3. Expr.splice[A](expr)==
+  *
+  * Replaces:
   *
   * {{{
   * Expr.splice[A](expr)
@@ -51,16 +57,18 @@ import scala.util.chaining.*
   * with:
   *
   * {{{
-  * ${ expr.asInstanceOf[c.Expr[A]] } // interpolation within q""
+  * $${ expr.asInstanceOf[c.Expr[A]] } // interpolation within q""
   * }}}
   *
-  * It uses intermediate fresh name to create a stub and replace it with the actual expression unsing Regex.
+  * It uses intermediate fresh name to create a stub and replace it with the actual expression using Regex.
   *
   * Same for: Type.Ctor1.of[HKT], Type.Ctor2.of[HKT], Type.Ctor3.of[HKT], ..., Type.Ctor22.of[HKT].
   *
+  * ==Code printing challenges==
+  *
   * The challenges here are:
   *   - `expr.toString` and `showCode(expr)` does not always print the correct Scala code:
-  *     - `def <init>` is correct AST... but parser does not understand it, similarly many `<synthethic>` methods
+  *     - `def <init>` is correct AST... but parser does not understand it, similarly many `<synthetic>` methods
   *       (`expr.toString` prints it `showCode(expr)` has it fixed)
   *     - `final class $anon` + `new $anon()` could break the interpolation (and looks odd in the printed code)
   *   - applied type parameter [A] makes sense outside the code... in the AST it's just an abstract type that doesn't
@@ -75,8 +83,10 @@ import scala.util.chaining.*
   *
   * The result while not perfect, should be robust enough for most cases.
   *
-  *   4. When `Expr.splice` inside `Expr.quote` references type parameters from methods defined inside the quote body
-  *      (''local type params''), these type params don't exist at macro-expansion time. For example:
+  * ==4. Local type params in Expr.splice inside Expr.quote==
+  *
+  * When `Expr.splice` inside `Expr.quote` references type parameters from methods defined inside the quote body
+  * (''local type params''), these type params don't exist at macro-expansion time. For example:
   *
   * {{{
   * Expr.quote {
@@ -91,7 +101,7 @@ import scala.util.chaining.*
   * The `SpliceReplacer` detects local type param references and wraps the splice body in a workaround method:
   *
   * {{{
-  * ${ {
+  * $${ {
   *   def workaround[A: ctx.WeakTypeTag] = {
   *     <original splice body, unchanged>
   *   }
@@ -109,10 +119,49 @@ import scala.util.chaining.*
   * workaround's `A`. The free type (`newFreeType("A")`) is resolved by name during quasiquote expansion, connecting to
   * the actual type param in the generated code.
   *
+  * ==5. Nested Expr.quote inside Expr.splice==
+  *
   * Nested `Expr.quote` inside `Expr.splice` also works with local type params. The inner `quoteImpl` expands first and
   * produces typechecked code where `WeakTypeTag` resolutions are already baked in. The outer `SpliceReplacer` then
   * wraps the entire splice body (including the inner expansion) in the workaround method, and the free types resolve
   * correctly through the quasiquote system.
+  *
+  * ==6. Outer enclosing method implicits==
+  *
+  * When `Expr.splice` is nested inside `Expr.quote` and the nearest enclosing method (e.g. `map[A, B]`) is NOT the
+  * method that provides `Type.CtorN[F]`, the standard `enclosingMethodImplicitTypes` only inspects the nearest
+  * `c.enclosingMethod` and misses the outer method's implicit params.
+  *
+  * `outerEnclosingMethodImplicitTypes` walks the full owner chain via `c.internal.enclosingOwner` to find implicit
+  * params from all enclosing methods (skipping the nearest, already covered). This is used ONLY in
+  * `ImplicitTypeReferenceReplacer` (the `Expr.quote`/`convert` code-generation path), NOT in
+  * `TypeWithUnderlyingInjected` (the standalone `Type.of` path). Adding it to `TypeWithUnderlyingInjected` caused
+  * regressions in library code using `Type.of` with existential types (e.g. `Type.of[java.lang.Enum[?]]`).
+  *
+  * ==Gotchas and limitations (Scala 2)==
+  *
+  *   - '''Self-referential implicit Type:''' `implicit val A: Type[A] = Type.of[A]` generates
+  *     `implicit val A: Type[A] = A` (infinite recursion), because `weakTypeTag[A]` picks up the implicit in scope. Use
+  *     a non-implicit val or assign the result in a different scope.
+  *   - '''Self-referential implicit Type.CtorN initialization:''' Similarly, `implicit val F: Type.Ctor1[F] =
+  *     Type.Ctor1.of[F]` can cause circular initialization when the Scala 3 plugin injects a `given` that references
+  *     the val being initialized. Create the value outside the block:
+  *     `val optCtor = makeOptionCtor; implicit val OptionCtor: Type.Ctor1[Option] = optCtor`.
+  *   - '''Type.of with local type params — avoid implicit val:''' Inside `Expr.splice`, writing
+  *     `implicit val evA: Type[A] = Type.of[A]` triggers a forward reference error because `Type.of[A]`'s expansion
+  *     finds the `evA` being defined (via `enclosingMethodImplicitTypes`'s position check). Instead, use non-implicit
+  *     vals: `val tpeA = Type.of[A]` and pass them explicitly to helper methods.
+  *   - '''Extracted methods cannot use Expr.quote with local free types:''' A helper method defined outside the quote
+  *     that creates its own `Expr.quote` will produce a separate quasiquote. Free types from the outer `SpliceReplacer`
+  *     workaround do NOT resolve across separate quasiquote boundaries — they only resolve within the quasiquote
+  *     pattern string where they were created. Keep `Expr.quote` calls inline in the splice body. Helper methods can do
+  *     computation (e.g. build `Expr[String]` via `Expr(...)`) but must not create their own quasiquotes referencing
+  *     local type params.
+  *   - '''`Type.of[A]` in standalone context is unaffected by outer enclosing method implicits:'''
+  *     `outerEnclosingMethodImplicitTypes` is deliberately excluded from `TypeWithUnderlyingInjected` (used by
+  *     `typeOfImpl` for standalone `Type.of` calls). Only `ImplicitTypeReferenceReplacer` (used by `convert`/
+  *     `quoteImpl` for `Expr.quote` code generation) includes it. This prevents regressions where walking the owner
+  *     chain from unrelated `Type.of` call sites interferes with existential or wildcard type resolution.
   */
 final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettyScala2 with CrossQuotesMacrosCtorMethods {
 
@@ -365,16 +414,19 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
     lazy val noInjectResult = q"""$ctx.weakTypeTag[$weakTypeTagOf].asInstanceOf[Type[$weakTypeTagOf]]"""
     lazy val ctx2 = freshName("ctx2")
 
-    val candidates: List[(Type, String)] = importedUnderlyingTypes ++ enclosingMethodImplicitTypes
+    val candidates: List[(Type, String)] =
+      importedUnderlyingTypes ++ enclosingMethodImplicitTypes
     val excludingSet: Set[String] = excluding.view.map(_.decodedName.toString).toSet
 
     // Separate HKT candidates (type constructors from Type.CtorN) from *-kinded types.
     // HKT types can't use WeakTypeTag[F] but need substituteTypes post-processing.
     // Only include candidates whose enclosing method implicit is actually Type.CtorN.Bounded[..., HKT],
     // NOT arbitrary HKT types like DirectStyle[F].
-    val hktCandidates: List[(Type, String)] = enclosingMethodCtorHKTTypes.filterNot { case (_, renamed) =>
-      excludingSet(renamed)
-    }
+    // Also check outer enclosing methods for nested macro scenarios.
+    val hktCandidates: List[(Type, String)] =
+      enclosingMethodCtorHKTTypes.filterNot { case (_, renamed) =>
+        excludingSet(renamed)
+      }
 
     val importedUnderlying = candidates.view
       .filterNot { case (_, renamed) => excludingSet(renamed) }
@@ -765,6 +817,55 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
     result.toList
   } catch { case _: Throwable => Nil }
 
+  /** Collects implicit params of type `Type[X]` or `Type.CtorN[F]` from OUTER enclosing methods.
+    *
+    * `enclosingMethodImplicitTypes` and `enclosingMethodCtorHKTTypes` only inspect the nearest `c.enclosingMethod`.
+    * When macros are nested (e.g., inner `Expr.quote` inside `Expr.splice` inside outer `Expr.quote`), the inner
+    * macro's nearest enclosing method might not have the relevant implicits — they could be on an outer method higher
+    * up the call chain.
+    *
+    * This method walks the owner chain via `c.internal.enclosingOwner` to find implicit params from all enclosing
+    * methods, skipping the nearest one (already covered by the other methods).
+    */
+  private def outerEnclosingMethodImplicitTypes: List[(Type, String)] = try {
+    val result = scala.collection.mutable.ListBuffer[(Type, String)]()
+
+    // Find the nearest enclosing method's symbol so we can skip it
+    @scala.annotation.nowarn
+    val nearestMethodSym: Symbol = c.enclosingMethod match {
+      case dd: DefDef if dd.symbol != null => dd.symbol
+      case _                               => NoSymbol
+    }
+
+    var owner = c.internal.enclosingOwner
+    while (owner != NoSymbol) {
+      if (owner.isMethod && owner != nearestMethodSym) {
+        for {
+          params <- owner.asMethod.paramLists
+          param <- params
+          if param.isImplicit
+        }
+          // Type[X] pattern — same as enclosingMethodImplicitTypes
+          scala.util
+            .Try {
+              param.info match {
+                case TypeRef(_, _, List(innerType)) if !innerType.typeSymbol.isClass => innerType
+              }
+            }
+            .orElse(scala.util.Try {
+              extractCtorHKT(param.info).filter(!_.typeSymbol.isClass).get
+            })
+            .toOption
+            .foreach { tpeToReplace =>
+              result += (tpeToReplace -> param.name.decodedName.toString)
+            }
+      }
+      owner = owner.owner
+    }
+
+    result.toList
+  } catch { case _: Throwable => Nil }
+
   // Expr utilities
 
   private def convert(ctx: TermName)(tree: c.Tree): c.Tree = {
@@ -942,32 +1043,33 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
       // Combine imported types with same-class implicit vals (issue #168).
       // Same-class implicit vals are only used here (not in TypeWithUnderlyingInjected) because
       // their ThisType prefixes cause issues in the WeakTypeTag workaround mechanism.
-      private val caches = (importedUnderlyingTypes ++ enclosingMethodImplicitTypes ++ sameClassImplicitTypes).flatMap {
-        case (tpe, name) =>
-          def byName = Cache.forTypeName(name)
-          def byType = try
-            Cache.forTypeName(renderCode(tpe))
-          catch {
-            case _: Throwable => None
-          }
-          // For HKT types (type constructors like F[_] from Type.CtorN[F]),
-          // Cache.forTypeName fails because Type[F] is a kind error.
-          // Instead, construct a WeakTypeTag from the CtorN's .asUntyped at runtime.
-          def byHKT =
-            if (tpe.typeParams.nonEmpty) Cache.forHKTType(name, tpe)
-            else None
-          byType.orElse(byName).orElse(byHKT).map { cache =>
-            cachesAliases += (name -> cache)
-            cachesAliases += (s"$name.type" -> cache)
-            cachesAliases += (renderCode(tpe) -> cache)
-            // For HKT types, also register in AbstractTypes so that
-            // Ident(TypeName("F")) is resolved when F appears in the tree.
-            if (tpe.typeParams.nonEmpty) {
-              AbstractTypes.register(tpe.typeSymbol.name.toString, cache)
+      private val caches =
+        (importedUnderlyingTypes ++ enclosingMethodImplicitTypes ++ sameClassImplicitTypes ++ outerEnclosingMethodImplicitTypes).flatMap {
+          case (tpe, name) =>
+            def byName = Cache.forTypeName(name)
+            def byType = try
+              Cache.forTypeName(renderCode(tpe))
+            catch {
+              case _: Throwable => None
             }
-            tpe -> cache
-          }
-      }.toMap
+            // For HKT types (type constructors like F[_] from Type.CtorN[F]),
+            // Cache.forTypeName fails because Type[F] is a kind error.
+            // Instead, construct a WeakTypeTag from the CtorN's .asUntyped at runtime.
+            def byHKT =
+              if (tpe.typeParams.nonEmpty) Cache.forHKTType(name, tpe)
+              else None
+            byType.orElse(byName).orElse(byHKT).map { cache =>
+              cachesAliases += (name -> cache)
+              cachesAliases += (s"$name.type" -> cache)
+              cachesAliases += (renderCode(tpe) -> cache)
+              // For HKT types, also register in AbstractTypes so that
+              // Ident(TypeName("F")) is resolved when F appears in the tree.
+              if (tpe.typeParams.nonEmpty) {
+                AbstractTypes.register(tpe.typeSymbol.name.toString, cache)
+              }
+              tpe -> cache
+            }
+        }.toMap
 
       // It's riddiculous but:
       //  - we have both: someValue.Underlying (type Underlying = ...)

--- a/hearth-cross-quotes/src/main/scala-3/hearth/cq/CrossQuotesPlugin.scala
+++ b/hearth-cross-quotes/src/main/scala-3/hearth/cq/CrossQuotesPlugin.scala
@@ -145,6 +145,12 @@ final class CrossQuotesPlugin extends StandardPlugin {
   *   }
   * }
   * }}}
+  *
+  *   4. Local type params from methods defined inside `'{ ... }` (e.g. `def helper[A]`) are handled natively by Scala
+  *      3's staging system. When `Type.of[A]` is used inside `$${ ... }`, the plugin transforms it to
+  *      `CrossQuotes.typeQuotesToCross(scala.quoted.Type.of[A])`, and the staging system automatically provides
+  *      `scala.quoted.Type[A]` for type params from enclosing `'{ ... }` blocks. No workaround is needed on Scala 3 —
+  *      this is a Scala 2-only limitation.
   */
 final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolean) extends PluginPhase {
   override def runsAfter: Set[String] = Set(Parser.name)

--- a/hearth-cross-quotes/src/main/scala-3/hearth/cq/CrossQuotesPlugin.scala
+++ b/hearth-cross-quotes/src/main/scala-3/hearth/cq/CrossQuotesPlugin.scala
@@ -253,6 +253,33 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
         }
       }
 
+      // Test if TypeDef has a context bound like [F[_]: Type.Ctor1], defending against changes across Scala versions.
+      private object CtxBoundsCtorTypeTree {
+
+        def unapply(tree: untpd.Tree): Option[(Name, Name, Option[TermName])] = tree match {
+          // Scala 3.3 representation: AppliedTypeTree(Select(Ident("Type"), "Ctor1"), List(Ident("F")))
+          case AppliedTypeTree(Select(Ident(tpeName), ctorName), List(Ident(hktName)))
+              if tpeName.show == "Type" && isCtor(ctorName.show) =>
+            Some((ctorName, hktName, None))
+          // Scala 3.7 representation: ContextBoundTypeTree(Select(Ident("Type"), "Ctor1"), F, evidence$N)
+          // using reflection to keep compiling on Scala 3.3
+          case contextBoundTypeTree
+              if contextBoundTypeTree.productPrefix == "ContextBoundTypeTree" &&
+                contextBoundTypeTree.productArity == 3 &&
+                contextBoundTypeTree.productElement(0).isInstanceOf[Select] &&
+                contextBoundTypeTree.productElement(1).isInstanceOf[TypeName] &&
+                contextBoundTypeTree.productElement(2).isInstanceOf[TermName] =>
+            val Select(Ident(tpeName), ctorName) =
+              (contextBoundTypeTree.productElement(0).asInstanceOf[Select]: @unchecked)
+            if tpeName.show == "Type" && isCtor(ctorName.show) then {
+              val hktName = contextBoundTypeTree.productElement(1).asInstanceOf[Name]
+              val evidenceName = contextBoundTypeTree.productElement(2).asInstanceOf[TermName]
+              Some((ctorName, hktName, Some(evidenceName)))
+            } else None
+          case _ => None
+        }
+      }
+
       // Helper to extract Type[A] from AppliedTypeTree
       private object TypeAppliedTypeTree {
         def unapply(tree: untpd.Tree): Option[untpd.Tree] = tree match {
@@ -413,6 +440,17 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
                 if /* tpe.show == "Type" && */ name.show == name2.show =>
               Some(makeGiven(name.mangledString, untpd.Ident(name)))
 
+            // [F[_]: Type.Ctor1] context bound (Scala 3.7 with evidence)
+            case TypeDef(name, untpd.ContextBounds(_, List(CtxBoundsCtorTypeTree(_ /*ctorName*/, name2, evidenceOpt))))
+                if name.show == name2.show =>
+              evidenceOpt match {
+                case Some(evidenceName) =>
+                  Some(makeGivenFromUntyped(name.mangledString, untpd.Ident(name), untpd.Ident(evidenceName)))
+                case None =>
+                  // Scala 3.3: the evidence is a desugared ValDef, handled in the ValDef case below
+                  None
+              }
+
             /* If parameters is
              *   [A](implicit a: Type[A])
              * or
@@ -421,11 +459,20 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
              *   given castedA: scala.quoted.Type[A] = Type[A].asInstanceOf[scala.quoted.Type[A]]
              */
             case vd: untpd.ValDef if vd.isImplicit =>
-              TypeAppliedTypeTree.unapply(vd.tpt).map { innerType =>
-                // Use the parameter name for the given name, but reference the inner type
-                val paramName = vd.name.show
-                makeGiven(paramName, innerType)
-              }
+              TypeAppliedTypeTree
+                .unapply(vd.tpt)
+                .map { innerType =>
+                  // Use the parameter name for the given name, but reference the inner type
+                  val paramName = vd.name.show
+                  makeGiven(paramName, innerType)
+                }
+                .orElse(
+                  // Handle (implicit FC: Type.CtorN[F]) parameter
+                  TypeCtorAppliedTypeTree.unapply(vd.tpt).map { hkt =>
+                    val name = vd.name.show
+                    makeGivenFromUntyped(name, hkt, untpd.Ident(termName(name)))
+                  }
+                )
 
             case _ => None
           }

--- a/hearth-cross-quotes/src/main/scala-3/hearth/cq/CrossQuotesPlugin.scala
+++ b/hearth-cross-quotes/src/main/scala-3/hearth/cq/CrossQuotesPlugin.scala
@@ -43,7 +43,9 @@ final class CrossQuotesPlugin extends StandardPlugin {
 /** This plugin is responsible for rewriting Type.of/Expr.quote/Expr.splice into native quotes
   * ([[scala.quoted.Expr]]/[[scala.quoted.Type]]) in Scala 3.
   *
-  *   1. The first thing that it does is to replace:
+  * ==1. Type.of[A]==
+  *
+  * Replaces:
   *
   * {{{
   * Type.of[A]
@@ -55,7 +57,9 @@ final class CrossQuotesPlugin extends StandardPlugin {
   * scala.quoted.Type.of[A]
   * }}}
   *
-  * and:
+  * ==2. Expr.quote[A](expr)==
+  *
+  * Replaces:
   *
   * {{{
   * Expr.quote[A](expr)
@@ -67,7 +71,9 @@ final class CrossQuotesPlugin extends StandardPlugin {
   * '{ expr }
   * }}}
   *
-  * and:
+  * ==3. Expr.splice { expr }==
+  *
+  * Replaces:
   *
   * {{{
   * Expr.splice { expr }
@@ -79,15 +85,17 @@ final class CrossQuotesPlugin extends StandardPlugin {
   * ${ expr }
   * }}}
   *
-  * But since, both of these operations are need to use [[scala.quoted.Quotes]] we need to inject a given for it:
+  * Since both of these operations need [[scala.quoted.Quotes]], we inject a given for it:
   *
   * {{{
-  * // given is prepeded before the first ourermost Expr.quote/Expr.splice
+  * // given is prepended before the first outermost Expr.quote/Expr.splice
   * given scala.quoted.Quotes = CrossQuotes.ctx
   * // the rest of the code
   * }}}
   *
-  *   2. However, if there are type bounds like:
+  * ==4. Type context bounds==
+  *
+  * If there are type bounds like:
   *
   * {{{
   * [A: Type, B: Type]
@@ -101,7 +109,9 @@ final class CrossQuotesPlugin extends StandardPlugin {
   * ...
   * }}}
   *
-  *   3. Finally, if the whole expression building is decomposed into several steps, e.g.:
+  * ==5. Nested Quotes context management==
+  *
+  * If the whole expression building is decomposed into several steps, e.g.:
   *
   * {{{
   * def intToString(expr: Expr[Int]): Expr[String] = Expr.quote {
@@ -125,7 +135,7 @@ final class CrossQuotesPlugin extends StandardPlugin {
   * }
   * }}}
   *
-  * so we need to keep trace of the current level of nested quotes and inject a given for [[scala.quoted.Quotes]] only
+  * so we need to keep track of the current level of nested quotes and inject a given for [[scala.quoted.Quotes]] only
   * at the top level.
   *
   * {{{
@@ -141,16 +151,42 @@ final class CrossQuotesPlugin extends StandardPlugin {
   *     // inside ${} we are creating a new Quotes context (q.Nested)
   *     CrossQuotes.nestedCtx { // updates CrossQuotes.ctx
   *       intToString('{ a })
-  *     } // resotres previous CrossQuotes.ctx value
+  *     } // restores previous CrossQuotes.ctx value
   *   }
   * }
   * }}}
   *
-  *   4. Local type params from methods defined inside `'{ ... }` (e.g. `def helper[A]`) are handled natively by Scala
-  *      3's staging system. When `Type.of[A]` is used inside `$${ ... }`, the plugin transforms it to
-  *      `CrossQuotes.typeQuotesToCross(scala.quoted.Type.of[A])`, and the staging system automatically provides
-  *      `scala.quoted.Type[A]` for type params from enclosing `'{ ... }` blocks. No workaround is needed on Scala 3 —
-  *      this is a Scala 2-only limitation.
+  * ==6. Local type params and HKT type constructors==
+  *
+  * Local type params from methods defined inside `'{ ... }` (e.g. `def helper[A]`) are handled natively by Scala 3's
+  * staging system. When `Type.of[A]` is used inside `$${ ... }`, the plugin transforms it to
+  * `CrossQuotes.typeQuotesToCross(scala.quoted.Type.of[A])`, and the staging system automatically provides
+  * `scala.quoted.Type[A]` for type params from enclosing `'{ ... }` blocks. No workaround is needed on Scala 3 — the
+  * free type + workaround method mechanism is a Scala 2-only limitation.
+  *
+  * For HKT type constructors (`Type.Ctor1[F]`, `Type.Ctor2[F]`, etc.), the plugin uses two mechanisms to inject
+  * `given`s:
+  *
+  *   - `boundGivenCandidates`: inspects `[F[_]: Type.Ctor1]` context bounds and explicit `implicit` params (e.g.
+  *     `implicit FC: Type.Ctor1[F]`) on enclosing method signatures.
+  *   - `blockGivenCandidates`: inspects `implicit val`/`def` declarations in the enclosing block body (e.g.
+  *     `implicit val FC: Type.Ctor1[Option] = ...`).
+  *
+  * ==Gotchas and limitations (Scala 3)==
+  *
+  *   - '''Self-referential implicit Type:''' `implicit val A: Type[A] = Type.of[A]` generates an infinite loop, because
+  *     `scala.quoted.Type.of[A]` picks up the `given` in scope. Use a non-implicit val or assign in a different scope.
+  *   - '''Self-referential implicit Type.CtorN initialization:''' `implicit val F: Type.Ctor1[F] = Type.Ctor1.of[F]`
+  *     can cause circular initialization when the plugin injects a `given` that references the val being initialized.
+  *     Create the value outside the block:
+  *     `val optCtor = makeOptionCtor; implicit val OptionCtor: Type.Ctor1[Option] = optCtor`.
+  *   - '''`Type.of[A]` requires a parameterless given:''' `scala.quoted.Type.of[A]` and `'{ ... }: Expr[A]` ignore
+  *     `Type[A]` values that require implicit resolution to obtain. Only `implicit val`/parameterless `given`
+  *     definitions are picked up. The plugin uses a best-effort approach to detect such cases and create local
+  *     `given`s, but passing `Type[A]` as a context bound on a `def` is more reliable.
+  *   - '''Mixing native quotes with Cross Quotes is undefined behavior:''' Using `scala.quoted.Type.of` directly
+  *     alongside Cross Quotes' `Type.of` will likely crash the compiler. The plugin rewrites based on untyped tree
+  *     patterns and cannot distinguish between Cross Quotes and native quotes.
   */
 final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolean) extends PluginPhase {
   override def runsAfter: Set[String] = Set(Parser.name)

--- a/hearth-tests/src/main/scala/hearth/crossquotes/CrossCtorInjectionFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/CrossCtorInjectionFixturesImpl.scala
@@ -247,4 +247,42 @@ trait CrossCtorInjectionFixturesImpl extends CrossCtorInjectionFixturesImplGen {
       Data(functor.map(List(1, 2, 3))(_.toString).mkString(", "))
     }
 
+  /** Test: Type.Ctor1[F] composes with an extracted body method that takes Type context bounds for local type params.
+    *
+    * Verifies that HKT type constructors (F from Type.Ctor1) compose with local type params (A, B from Type context
+    * bounds on a helper method) and nested Expr.quote. The extracted `mapBody` uses Type.of and Type.Ctor1 to build
+    * type evidence, while the nested Expr.quote that constructs the actual code is inline in the splice body (required
+    * because free types from the outer workaround don't cross quasiquote boundaries into separately-created
+    * quasiquotes).
+    */
+  def testFunctorDerivationWithCtor[F[_]](implicit FC: Type.Ctor1[F]): Expr[Data] = {
+    hearth.fp.ignore(FC)
+
+    /** Extracted body method: receives local type params as Type context bounds and returns a description combining HKT
+      * (F from Type.Ctor1) with the local type params.
+      */
+    def describeMapping[A, B](implicit A: Type[A], B: Type[B]): Expr[String] = {
+      val fOfA = FC.apply[A](using A)
+      val fOfB = FC.apply[B](using B)
+      Expr(s"${fOfA.plainPrint} => ${fOfB.plainPrint}")
+    }
+
+    Expr.quote {
+      val functor: hearth.fp.Functor[F] = new hearth.fp.Functor[F] {
+        def map[A, B](fa: F[A])(f: A => B): F[B] = Expr.splice {
+          val tpeA = Type.of[A]
+          val tpeB = Type.of[B]
+          // Verify describeMapping composes Type.Ctor1[F] with local A, B
+          val desc: Expr[String] = describeMapping[A, B](tpeA, tpeB)
+          // Use nested inline Expr.quote for the actual map implementation
+          Expr.quote {
+            hearth.fp.ignore(Expr.splice(desc))
+            Expr.splice(Expr.quote(fa)).asInstanceOf[List[A]].map(Expr.splice(Expr.quote(f))).asInstanceOf[F[B]]
+          }
+        }
+      }
+      Data(functor.map(List(1, 2, 3).asInstanceOf[F[Int]])(_.toString).asInstanceOf[List[String]].mkString(", "))
+    }
+  }
+
 }

--- a/hearth-tests/src/main/scala/hearth/crossquotes/CrossCtorInjectionFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/CrossCtorInjectionFixturesImpl.scala
@@ -144,15 +144,68 @@ trait CrossCtorInjectionFixturesImpl extends CrossCtorInjectionFixturesImplGen {
       Data(combine[Int, String])
     }
 
-  /** Test: Functor-like type class derivation combining HKT (Type.Ctor1) with local type params (A, B).
+  /** Test: Nested Expr.quote inside Expr.splice without type params.
     *
-    * This is the "proof by construction" that Hearth can generate type class instances with HKT type constructors where
-    * methods have their own type parameters. The splice body verifies that Type.of[A], Type.of[B], and Type.Ctor1[F]
-    * are all available. The actual map implementation is a dummy (null cast) — the point is to verify the code
-    * generation compiles and the macro plumbing works, not to produce a correct Functor derivation.
+    * Verifies that inner Expr.quote expansions work correctly when nested inside Expr.splice inside an outer
+    * Expr.quote. This is the simplest nested quote case — no local type params involved.
+    */
+  def testNestedQuoteNoTypeParams: Expr[Data] =
+    Expr.quote {
+      val greeting: String = Expr.splice {
+        Expr.quote("hello")
+      }
+      Data(greeting)
+    }
+
+  /** Test: Nested Expr.quote inside Expr.splice with a local type param.
     *
-    * Note: nested `Expr.quote` inside `Expr.splice` (required for a real implementation) is not yet supported because
-    * the inner quote's expansion cannot handle local type params from the outer quote's method definitions.
+    * Verifies that inner Expr.quote can handle types that reference local type params from DefDef nodes in the outer
+    * quote body. The inner quote needs to produce a WeakTypeTag for a type containing `A` — a type param that only
+    * exists in the generated code.
+    */
+  def testNestedQuoteWithTypeParam: Expr[Data] =
+    Expr.quote {
+      def identity[A](a: A): A = Expr.splice {
+        Expr.quote(a)
+      }
+      Data(identity("hello"))
+    }
+
+  /** Test: Nested Expr.quote with applied types using local type params.
+    *
+    * Tests that inner Expr.quote(Option(a)) works where a: A and A is a local type param. The inner quote needs
+    * WeakTypeTag[Option[A]] which combines a concrete type constructor with a local type param.
+    */
+  def testNestedQuoteWithAppliedType: Expr[Data] =
+    Expr.quote {
+      def wrapInOption[A](a: A): Option[A] = Expr.splice {
+        Expr.quote(Option(a))
+      }
+      Data(wrapInOption("hello").toString)
+    }
+
+  /** Test: Nested Expr.quote + Expr.splice composition (quote-splice-quote-splice-quote).
+    *
+    * Tests the pattern needed for type class derivation: the outer splice body contains multiple inner quotes, and the
+    * innermost quote splices in values from the outer quote's scope.
+    */
+  def testNestedQuoteSpliceComposition: Expr[Data] =
+    Expr.quote {
+      def applyFn[A, B](a: A, f: A => B): B = Expr.splice {
+        val aExpr: Expr[A] = Expr.quote(a)
+        val fExpr: Expr[A => B] = Expr.quote(f)
+        Expr.quote {
+          Expr.splice(fExpr)(Expr.splice(aExpr))
+        }
+      }
+      Data(applyFn("hello", (s: String) => s.length).toString)
+    }
+
+  /** Test: Type class skeleton combining HKT (Type.Ctor1) with local type params (A, B).
+    *
+    * Verifies that Type.of[A], Type.of[B], and Type.Ctor1[F] are all accessible inside Expr.splice within Expr.quote
+    * where A, B are local type params from methods inside the quote body. Uses a dummy map implementation — see
+    * testFunctorDerivation for a real working Functor derivation.
     */
   def testFunctorSkeleton[F[_]](implicit FC: Type.Ctor1[F]): Expr[Data] = {
     hearth.fp.ignore(FC)
@@ -171,5 +224,27 @@ trait CrossCtorInjectionFixturesImpl extends CrossCtorInjectionFixturesImplGen {
       Data("ok")
     }
   }
+
+  /** Test: Real Functor derivation using nested Expr.quote inside Expr.splice.
+    *
+    * Demonstrates a fully working Functor[List] derivation using the quote-splice-quote pattern. The map implementation
+    * uses nested Expr.quote to capture `fa` and `f`, then splices them into a new quote that calls `.map`.
+    *
+    * This proves that Hearth's cross-quotes support the full pattern needed for type class derivation with HKT types
+    * and local type params.
+    */
+  def testFunctorDerivation: Expr[Data] =
+    Expr.quote {
+      val functor: hearth.fp.Functor[List] = new hearth.fp.Functor[List] {
+        def map[A, B](fa: List[A])(f: A => B): List[B] = Expr.splice {
+          val faExpr: Expr[List[A]] = Expr.quote(fa)
+          val fExpr: Expr[A => B] = Expr.quote(f)
+          Expr.quote {
+            Expr.splice(faExpr).map(Expr.splice(fExpr))
+          }
+        }
+      }
+      Data(functor.map(List(1, 2, 3))(_.toString).mkString(", "))
+    }
 
 }

--- a/hearth-tests/src/main/scala/hearth/crossquotes/CrossCtorInjectionFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/CrossCtorInjectionFixturesImpl.scala
@@ -79,4 +79,46 @@ trait CrossCtorInjectionFixturesImpl extends CrossCtorInjectionFixturesImplGen {
   /** Factory for Either ctor — outside the test block to avoid circular initialization. */
   protected def makeEitherCtor: Type.Ctor2[Either] = Type.Ctor2.of[Either]
 
+  /** Test: Type.of resolves types when Type.Ctor1 is provided as a context bound / implicit parameter on the enclosing
+    * method.
+    *
+    * On Scala 3, this exercises the `CtxBoundsCtorTypeTree` extractor and the `TypeCtorAppliedTypeTree` fallback in
+    * `CrossQuotesPlugin.boundGivenCandidates`. On Scala 2, it exercises `extractCtorHKT` in
+    * `enclosingMethodImplicitTypes`.
+    */
+  def testTypeOfWithCtor1ContextBound[F[_]](implicit FC: Type.Ctor1[F]): Expr[Data] = {
+    hearth.fp.ignore(FC)
+    Expr(
+      Data.map(
+        "fOfInt" -> Data(FC.apply[Int](using Type.of[Int]).plainPrint),
+        "fOfString" -> Data(FC.apply[String](using Type.of[String]).plainPrint)
+      )
+    )
+  }
+
+  /** Test: Expr.quote works with F from Type.Ctor1 context bound in type positions. */
+  def testExprQuoteWithCtor1Param[F[_]](implicit FC: Type.Ctor1[F]): Expr[Data] = {
+    hearth.fp.ignore(FC)
+    Expr.quote {
+      val container: Container[F] = new Container[F] {
+        override def value: F[String] = null.asInstanceOf[F[String]]
+      }
+      Data(container.getClass.getSimpleName)
+    }
+  }
+
+  /** Test: Type.of[F[Int]] works when F comes from Type.Ctor1 context bound. */
+  def testTypeOfWithCtorHKTApplied[F[_]](implicit FC: Type.Ctor1[F]): Expr[Data] = {
+    hearth.fp.ignore(FC)
+    val fOfInt = Type.of[F[Int]]
+    Expr(Data(fOfInt.plainPrint))
+  }
+
+  /** Test: Type.of[F[A]] works when F comes from Type.Ctor1 and A from Type. */
+  def testTypeOfWithCtorHKTAndTypeParam[F[_], A](implicit FC: Type.Ctor1[F], A: Type[A]): Expr[Data] = {
+    hearth.fp.ignore(FC)
+    val fOfA = Type.of[F[A]]
+    Expr(Data(fOfA.plainPrint))
+  }
+
 }

--- a/hearth-tests/src/main/scala/hearth/crossquotes/CrossCtorInjectionFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/CrossCtorInjectionFixturesImpl.scala
@@ -121,4 +121,14 @@ trait CrossCtorInjectionFixturesImpl extends CrossCtorInjectionFixturesImplGen {
     Expr(Data(fOfA.plainPrint))
   }
 
+  /** Test: Type.of[A] inside Expr.splice inside Expr.quote, where A is a local type param. */
+  def testTypeOfLocalParamInSplice: Expr[Data] =
+    Expr.quote {
+      def helper[A]: String = Expr.splice {
+        hearth.fp.ignore(Type.of[A]) // verify Type.of[A] is obtainable for local type param
+        Expr("ok")
+      }
+      Data(helper[Int])
+    }
+
 }

--- a/hearth-tests/src/main/scala/hearth/crossquotes/CrossCtorInjectionFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/CrossCtorInjectionFixturesImpl.scala
@@ -131,4 +131,45 @@ trait CrossCtorInjectionFixturesImpl extends CrossCtorInjectionFixturesImplGen {
       Data(helper[Int])
     }
 
+  /** Test: Multiple local type params (A, B) inside Expr.splice inside Expr.quote.
+    *
+    * Extends the single-param test to verify the workaround handles multiple type params simultaneously.
+    */
+  def testSpliceWithMultipleLocalParams: Expr[Data] =
+    Expr.quote {
+      def combine[A, B]: String = Expr.splice {
+        hearth.fp.ignore(Type.of[A], Type.of[B])
+        Expr("ok")
+      }
+      Data(combine[Int, String])
+    }
+
+  /** Test: Functor-like type class derivation combining HKT (Type.Ctor1) with local type params (A, B).
+    *
+    * This is the "proof by construction" that Hearth can generate type class instances with HKT type constructors where
+    * methods have their own type parameters. The splice body verifies that Type.of[A], Type.of[B], and Type.Ctor1[F]
+    * are all available. The actual map implementation is a dummy (null cast) — the point is to verify the code
+    * generation compiles and the macro plumbing works, not to produce a correct Functor derivation.
+    *
+    * Note: nested `Expr.quote` inside `Expr.splice` (required for a real implementation) is not yet supported because
+    * the inner quote's expansion cannot handle local type params from the outer quote's method definitions.
+    */
+  def testFunctorSkeleton[F[_]](implicit FC: Type.Ctor1[F]): Expr[Data] = {
+    hearth.fp.ignore(FC)
+    Expr.quote {
+      val functor: hearth.fp.Functor[F] = new hearth.fp.Functor[F] {
+        def map[A, B](fa: F[A])(f: A => B): F[B] = {
+          val _evidence: String = Expr.splice {
+            hearth.fp.ignore(Type.of[A], Type.of[B])
+            Expr("ok")
+          }
+          hearth.fp.ignore(_evidence)
+          null.asInstanceOf[F[B]] // dummy impl — real impl would require nested Expr.quote support
+        }
+      }
+      hearth.fp.ignore(functor)
+      Data("ok")
+    }
+  }
+
 }

--- a/project/CrossCtorTestGen.scala
+++ b/project/CrossCtorTestGen.scala
@@ -643,6 +643,13 @@ object CrossCtorTestGen {
     sb ++= "  def testSpliceWithMultipleLocalParamsImpl: c.Expr[Data] = testSpliceWithMultipleLocalParams\n\n"
     sb ++= "  def testFunctorSkeletonImpl: c.Expr[Data] = testFunctorSkeleton[List](Type.Ctor1.of[List])\n\n"
 
+    // Nested quote tests
+    sb ++= "  def testNestedQuoteNoTypeParamsImpl: c.Expr[Data] = testNestedQuoteNoTypeParams\n\n"
+    sb ++= "  def testNestedQuoteWithTypeParamImpl: c.Expr[Data] = testNestedQuoteWithTypeParam\n\n"
+    sb ++= "  def testNestedQuoteWithAppliedTypeImpl: c.Expr[Data] = testNestedQuoteWithAppliedType\n\n"
+    sb ++= "  def testNestedQuoteSpliceCompositionImpl: c.Expr[Data] = testNestedQuoteSpliceComposition\n\n"
+    sb ++= "  def testFunctorDerivationImpl: c.Expr[Data] = testFunctorDerivation\n\n"
+
     sb ++= "}\n\n"
 
     // Companion object
@@ -691,6 +698,13 @@ object CrossCtorTestGen {
     sb ++= "  def testTypeOfLocalParamInSplice: Data = macro CrossCtorInjectionFixtures.testTypeOfLocalParamInSpliceImpl\n\n"
     sb ++= "  def testSpliceWithMultipleLocalParams: Data = macro CrossCtorInjectionFixtures.testSpliceWithMultipleLocalParamsImpl\n\n"
     sb ++= "  def testFunctorSkeleton: Data = macro CrossCtorInjectionFixtures.testFunctorSkeletonImpl\n\n"
+
+    // Nested quote tests
+    sb ++= "  def testNestedQuoteNoTypeParams: Data = macro CrossCtorInjectionFixtures.testNestedQuoteNoTypeParamsImpl\n\n"
+    sb ++= "  def testNestedQuoteWithTypeParam: Data = macro CrossCtorInjectionFixtures.testNestedQuoteWithTypeParamImpl\n\n"
+    sb ++= "  def testNestedQuoteWithAppliedType: Data = macro CrossCtorInjectionFixtures.testNestedQuoteWithAppliedTypeImpl\n\n"
+    sb ++= "  def testNestedQuoteSpliceComposition: Data = macro CrossCtorInjectionFixtures.testNestedQuoteSpliceCompositionImpl\n\n"
+    sb ++= "  def testFunctorDerivation: Data = macro CrossCtorInjectionFixtures.testFunctorDerivationImpl\n\n"
 
     sb ++= "}\n"
     sb.toString
@@ -857,6 +871,13 @@ object CrossCtorTestGen {
     sb ++= genScala3InlineSplice("testTypeOfLocalParamInSplice")
     sb ++= genScala3InlineSplice("testSpliceWithMultipleLocalParams")
     sb ++= genScala3InlineSplice("testFunctorSkeleton")
+
+    // Nested quote tests
+    sb ++= genScala3InlineSplice("testNestedQuoteNoTypeParams")
+    sb ++= genScala3InlineSplice("testNestedQuoteWithTypeParam")
+    sb ++= genScala3InlineSplice("testNestedQuoteWithAppliedType")
+    sb ++= genScala3InlineSplice("testNestedQuoteSpliceComposition")
+    sb ++= genScala3InlineSplice("testFunctorDerivation")
 
     sb ++= "}\n"
     sb.toString
@@ -1042,6 +1063,34 @@ object CrossCtorTestGen {
         |
         |      test("should generate a Functor skeleton combining HKT and local type params") {
         |        CrossCtorInjectionFixtures.testFunctorSkeleton <==> Data("ok")
+        |      }
+        |
+        |    }
+        |""".stripMargin
+    sb ++= "\n"
+
+    // Group 14: Nested quote tests
+    sb ++=
+      """    group("for nested Expr.quote inside Expr.splice inside Expr.quote") {
+        |
+        |      test("should handle nested Expr.quote without type params") {
+        |        CrossCtorInjectionFixtures.testNestedQuoteNoTypeParams <==> Data("hello")
+        |      }
+        |
+        |      test("should handle nested Expr.quote with local type param") {
+        |        CrossCtorInjectionFixtures.testNestedQuoteWithTypeParam <==> Data("hello")
+        |      }
+        |
+        |      test("should handle nested Expr.quote with applied type using local type param") {
+        |        CrossCtorInjectionFixtures.testNestedQuoteWithAppliedType <==> Data("Some(hello)")
+        |      }
+        |
+        |      test("should handle nested quote-splice-quote-splice-quote composition") {
+        |        CrossCtorInjectionFixtures.testNestedQuoteSpliceComposition <==> Data("5")
+        |      }
+        |
+        |      test("should derive a working Functor[List] using nested quotes") {
+        |        CrossCtorInjectionFixtures.testFunctorDerivation <==> Data("1, 2, 3")
         |      }
         |
         |    }

--- a/project/CrossCtorTestGen.scala
+++ b/project/CrossCtorTestGen.scala
@@ -640,6 +640,8 @@ object CrossCtorTestGen {
 
     // Local type param in splice tests
     sb ++= "  def testTypeOfLocalParamInSpliceImpl: c.Expr[Data] = testTypeOfLocalParamInSplice\n\n"
+    sb ++= "  def testSpliceWithMultipleLocalParamsImpl: c.Expr[Data] = testSpliceWithMultipleLocalParams\n\n"
+    sb ++= "  def testFunctorSkeletonImpl: c.Expr[Data] = testFunctorSkeleton[List](Type.Ctor1.of[List])\n\n"
 
     sb ++= "}\n\n"
 
@@ -687,6 +689,8 @@ object CrossCtorTestGen {
 
     // Local type param in splice tests
     sb ++= "  def testTypeOfLocalParamInSplice: Data = macro CrossCtorInjectionFixtures.testTypeOfLocalParamInSpliceImpl\n\n"
+    sb ++= "  def testSpliceWithMultipleLocalParams: Data = macro CrossCtorInjectionFixtures.testSpliceWithMultipleLocalParamsImpl\n\n"
+    sb ++= "  def testFunctorSkeleton: Data = macro CrossCtorInjectionFixtures.testFunctorSkeletonImpl\n\n"
 
     sb ++= "}\n"
     sb.toString
@@ -788,6 +792,10 @@ object CrossCtorTestGen {
     sb ++= "  def testTypeOfWithCtorHKTApplied: Expr[Data] = testTypeOfWithCtorHKTApplied[Option](using optionCtor1)\n\n"
     sb ++= "  def testTypeOfWithCtorHKTAndTypeParam[A: Type]: Expr[Data] = testTypeOfWithCtorHKTAndTypeParam[Option, A](using optionCtor1, summon[Type[A]])\n\n"
 
+    // Local type param in splice tests - class body methods for methods with type params
+    sb ++= "  private lazy val listCtor1: Type.Ctor1[List] = Type.Ctor1.of[List]\n\n"
+    sb ++= "  def testFunctorSkeleton: Expr[Data] = testFunctorSkeleton[List](using listCtor1)\n\n"
+
     sb ++= "}\n\n"
 
     // Companion object
@@ -847,6 +855,8 @@ object CrossCtorTestGen {
 
     // Local type param in splice tests
     sb ++= genScala3InlineSplice("testTypeOfLocalParamInSplice")
+    sb ++= genScala3InlineSplice("testSpliceWithMultipleLocalParams")
+    sb ++= genScala3InlineSplice("testFunctorSkeleton")
 
     sb ++= "}\n"
     sb.toString
@@ -1024,6 +1034,14 @@ object CrossCtorTestGen {
         |
         |      test("should resolve Type.of[A] where A is a local type param from a method inside the quote") {
         |        CrossCtorInjectionFixtures.testTypeOfLocalParamInSplice <==> Data("ok")
+        |      }
+        |
+        |      test("should resolve multiple local type params (A, B) inside a splice") {
+        |        CrossCtorInjectionFixtures.testSpliceWithMultipleLocalParams <==> Data("ok")
+        |      }
+        |
+        |      test("should generate a Functor skeleton combining HKT and local type params") {
+        |        CrossCtorInjectionFixtures.testFunctorSkeleton <==> Data("ok")
         |      }
         |
         |    }

--- a/project/CrossCtorTestGen.scala
+++ b/project/CrossCtorTestGen.scala
@@ -72,6 +72,7 @@ object CrossCtorTestGen {
     sb ++= genCtorResultContainerClass()
     sb ++= "\n"
     for (n <- 2 to maxArity) { sb ++= genCtorNResultContainerClass(n); sb ++= "\n" }
+    for (n <- 2 to maxArity) { sb ++= genTestTypeOfWithCtorNContextBound(n); sb ++= "\n" }
     sb ++= genTestCtorFromUntyped(maxArity)
     sb ++= "\n"
     for (n <- 1 to maxArity) { sb ++= genVerifyExtractedCtorN(n); sb ++= "\n" }
@@ -191,6 +192,26 @@ object CrossCtorTestGen {
        |    Expr(
        |      Data.map(
        |        "container${n}OfResult" -> Data(Type.of[$cn[Result]].plainPrint)
+       |      )
+       |    )
+       |  }
+       |""".stripMargin
+  }
+
+  // ---------------------------------------------------------------------------
+  // 3b. testTypeOfWithCtorNContextBound (N=2..22)
+  // ---------------------------------------------------------------------------
+
+  private def genTestTypeOfWithCtorNContextBound(n: Int): String = {
+    val t = typeName(n)
+    val cn = containerName(n)
+    val hktSlots = Seq.fill(n)("_").mkString(", ")
+    s"""  /** Test: Type.of resolves types when Type.Ctor$n is provided as a context bound. */
+       |  def testTypeOfWithCtor${n}ContextBound[F[$hktSlots]](implicit FC: Type.Ctor$n[F]): Expr[Data] = {
+       |    hearth.fp.ignore(FC)
+       |    Expr(
+       |      Data.map(
+       |        "fOfInts" -> Data(FC.apply[${ints(n)}](using ${typeOfInts(n)}).plainPrint)
        |      )
        |    )
        |  }
@@ -602,6 +623,21 @@ object CrossCtorTestGen {
       sb ++= s"  def testCtorSetMiddleAsUntyped${from}to${to}Impl: c.Expr[Data] = testCtorSetMiddleAsUntyped${from}to$to\n\n"
     }
 
+    // testTypeOfWithCtor1ContextBound - substantive method (uses Type.Ctor1.of)
+    sb ++= "  def testTypeOfWithCtor1ContextBoundImpl: c.Expr[Data] = testTypeOfWithCtor1ContextBound[Option](Type.Ctor1.of[Option])\n\n"
+
+    // testTypeOfWithCtorNContextBound - substantive methods for N=2..22
+    for (n <- 2 to maxArity) {
+      val t = typeName(n)
+      if (n >= 3) sb ++= s"  def testTypeOfWithCtor${n}ContextBoundImpl: c.Expr[Data] = {\n    import hearth.examples.kinds.$t\n    testTypeOfWithCtor${n}ContextBound[$t](Type.Ctor$n.of[$t])\n  }\n\n"
+      else sb ++= s"  def testTypeOfWithCtor${n}ContextBoundImpl: c.Expr[Data] = testTypeOfWithCtor${n}ContextBound[$t](Type.Ctor$n.of[$t])\n\n"
+    }
+
+    // Hand-written HKT tests
+    sb ++= "  def testExprQuoteWithCtor1ParamImpl: c.Expr[Data] = testExprQuoteWithCtor1Param[Option](Type.Ctor1.of[Option])\n\n"
+    sb ++= "  def testTypeOfWithCtorHKTAppliedImpl: c.Expr[Data] = testTypeOfWithCtorHKTApplied[Option](Type.Ctor1.of[Option])\n\n"
+    sb ++= "  def testTypeOfWithCtorHKTAndTypeParamImpl[A: c.WeakTypeTag]: c.Expr[Data] = testTypeOfWithCtorHKTAndTypeParam[Option, A](Type.Ctor1.of[Option], Type.of[A])\n\n"
+
     sb ++= "}\n\n"
 
     // Companion object
@@ -635,6 +671,16 @@ object CrossCtorTestGen {
     for ((from, to) <- Seq((3, 7), (8, 12), (13, 17), (18, 22))) {
       sb ++= s"  def testCtorSetMiddleAsUntyped${from}to$to: Data = macro CrossCtorInjectionFixtures.testCtorSetMiddleAsUntyped${from}to${to}Impl\n\n"
     }
+
+    sb ++= "  def testTypeOfWithCtor1ContextBound: Data = macro CrossCtorInjectionFixtures.testTypeOfWithCtor1ContextBoundImpl\n\n"
+    for (n <- 2 to maxArity) {
+      sb ++= s"  def testTypeOfWithCtor${n}ContextBound: Data = macro CrossCtorInjectionFixtures.testTypeOfWithCtor${n}ContextBoundImpl\n\n"
+    }
+
+    // Hand-written HKT tests
+    sb ++= "  def testExprQuoteWithCtor1Param: Data = macro CrossCtorInjectionFixtures.testExprQuoteWithCtor1ParamImpl\n\n"
+    sb ++= "  def testTypeOfWithCtorHKTApplied: Data = macro CrossCtorInjectionFixtures.testTypeOfWithCtorHKTAppliedImpl\n\n"
+    sb ++= "  def testTypeOfWithCtorHKTAndTypeParam[A]: Data = macro CrossCtorInjectionFixtures.testTypeOfWithCtorHKTAndTypeParamImpl[A]\n\n"
 
     sb ++= "}\n"
     sb.toString
@@ -721,6 +767,21 @@ object CrossCtorTestGen {
       sb ++= "\n"
     }
 
+    // testTypeOfWithCtorNContextBound methods (class body)
+    sb ++= genScala3CtorContextBoundMethod(1)
+    sb ++= "\n"
+    for (n <- 2 to maxArity) {
+      sb ++= genScala3CtorContextBoundMethod(n)
+      sb ++= "\n"
+    }
+
+    // Hand-written HKT tests - class body methods
+    // Use a local val for the ctor to avoid "Infinite loop" false positive in Scala 3 compiler
+    sb ++= "  private lazy val optionCtor1: Type.Ctor1[Option] = Type.Ctor1.of[Option]\n\n"
+    sb ++= "  def testExprQuoteWithCtor1Param: Expr[Data] = testExprQuoteWithCtor1Param[Option](using optionCtor1)\n\n"
+    sb ++= "  def testTypeOfWithCtorHKTApplied: Expr[Data] = testTypeOfWithCtorHKTApplied[Option](using optionCtor1)\n\n"
+    sb ++= "  def testTypeOfWithCtorHKTAndTypeParam[A: Type]: Expr[Data] = testTypeOfWithCtorHKTAndTypeParam[Option, A](using optionCtor1, summon[Type[A]])\n\n"
+
     sb ++= "}\n\n"
 
     // Companion object
@@ -764,7 +825,31 @@ object CrossCtorTestGen {
       sb ++= genScala3InlineSplice(s"testCtorSetMiddleAsUntyped${from}to$to")
     }
 
+    sb ++= genScala3InlineSplice("testTypeOfWithCtor1ContextBound")
+    for (n <- 2 to maxArity) {
+      sb ++= genScala3InlineSplice(s"testTypeOfWithCtor${n}ContextBound")
+    }
+
+    // Hand-written HKT tests
+    sb ++= genScala3InlineSplice("testExprQuoteWithCtor1Param")
+    sb ++= genScala3InlineSplice("testTypeOfWithCtorHKTApplied")
+
+    // testTypeOfWithCtorHKTAndTypeParam - special: has type parameter
+    sb ++= "  inline def testTypeOfWithCtorHKTAndTypeParam[A]: Data = ${ testTypeOfWithCtorHKTAndTypeParamImpl[A] }\n"
+    sb ++= "  private def testTypeOfWithCtorHKTAndTypeParamImpl[A: Type](using q: Quotes): Expr[Data] =\n"
+    sb ++= "    new CrossCtorInjectionFixtures(q).testTypeOfWithCtorHKTAndTypeParam[A]\n\n"
+
     sb ++= "}\n"
+    sb.toString
+  }
+
+  private def genScala3CtorContextBoundMethod(n: Int): String = {
+    val t = typeName(n)
+    val sb = new StringBuilder
+    sb ++= s"  def testTypeOfWithCtor${n}ContextBound: Expr[Data] = {\n"
+    if (n >= 3) sb ++= s"    import hearth.examples.kinds.$t\n"
+    sb ++= s"    testTypeOfWithCtor${n}ContextBound[$t](using Type.Ctor$n.of[$t])\n"
+    sb ++= s"  }\n"
     sb.toString
   }
 
@@ -898,6 +983,30 @@ object CrossCtorTestGen {
 
     // Group 10: testTypeOfWithDirectCtorValDef
     sb ++= genSpecDirectCtorValDef()
+    sb ++= "\n"
+
+    // Group 11: testTypeOfWithCtorNContextBound
+    sb ++= genSpecCtorContextBound(maxArity)
+    sb ++= "\n"
+
+    // Group 12: Hand-written HKT tests
+    sb ++=
+      """    group("for Expr.quote and Type.of with HKT type parameters") {
+        |
+        |      test("should work with Ctor1 context bound param in Expr.quote") {
+        |        CrossCtorInjectionFixtures.testExprQuoteWithCtor1Param
+        |      }
+        |
+        |      test("should resolve Type.of[F[Int]] with Ctor1 context bound") {
+        |        CrossCtorInjectionFixtures.testTypeOfWithCtorHKTApplied <==> Data("scala.Option[scala.Int]")
+        |      }
+        |
+        |      test("should resolve Type.of[F[A]] with Ctor1 and Type param") {
+        |        CrossCtorInjectionFixtures.testTypeOfWithCtorHKTAndTypeParam[Int] <==> Data("scala.Option[scala.Int]")
+        |      }
+        |
+        |    }
+        |""".stripMargin
     sb ++= "\n"
 
     sb ++= "  }\n\n"
@@ -1317,6 +1426,40 @@ object CrossCtorTestGen {
     val fqn = scala2Fqn(n)
     val remaining = (0 until n).filter(_ != setIdx).map(i => ArityGen.paramName(i)).mkString(", ")
     s"({type λ[$remaining] = $fqn})#λ"
+  }
+
+  private def genSpecCtorContextBound(maxArity: Int): String = {
+    val sb = new StringBuilder
+    sb ++= "    group(\"for Type.of with Type.CtorN context bound\") {\n\n"
+
+    // Ctor1 test is special (has fOfInt, fOfString)
+    sb ++=
+      s"""      test("should resolve types when F comes from Type.Ctor1 context bound") {
+         |        CrossCtorInjectionFixtures.testTypeOfWithCtor1ContextBound <==> Data.map(
+         |          "fOfInt" -> Data("scala.Option[scala.Int]"),
+         |          "fOfString" -> Data("scala.Option[java.lang.String]")
+         |        )
+         |      }
+         |
+         |""".stripMargin
+
+    // Ctor2..Ctor22
+    for (n <- 2 to maxArity) {
+      val fqn = scala3Fqn(n)
+      val allInts = Seq.fill(n)("scala.Int").mkString(", ")
+      val applyResult = s"$fqn[$allInts]"
+
+      sb ++= s"""      test("should resolve types when F comes from Type.Ctor$n context bound") {\n"""
+      sb ++= s"""        CrossCtorInjectionFixtures.testTypeOfWithCtor${n}ContextBound <==> Data.map(\n"""
+      sb ++= s"""          "fOfInts" -> Data(\n"""
+      sb ++= s"""            "$applyResult"\n"""
+      sb ++= s"""          )\n"""
+      sb ++= s"""        )\n"""
+      sb ++= s"""      }\n\n"""
+    }
+
+    sb ++= "    }\n"
+    sb.toString
   }
 
   private def genSpecCtorSetMiddleAsUntyped(maxArity: Int): String = {

--- a/project/CrossCtorTestGen.scala
+++ b/project/CrossCtorTestGen.scala
@@ -649,6 +649,7 @@ object CrossCtorTestGen {
     sb ++= "  def testNestedQuoteWithAppliedTypeImpl: c.Expr[Data] = testNestedQuoteWithAppliedType\n\n"
     sb ++= "  def testNestedQuoteSpliceCompositionImpl: c.Expr[Data] = testNestedQuoteSpliceComposition\n\n"
     sb ++= "  def testFunctorDerivationImpl: c.Expr[Data] = testFunctorDerivation\n\n"
+    sb ++= "  def testFunctorDerivationWithCtorImpl: c.Expr[Data] = testFunctorDerivationWithCtor[List](Type.Ctor1.of[List])\n\n"
 
     sb ++= "}\n\n"
 
@@ -705,6 +706,7 @@ object CrossCtorTestGen {
     sb ++= "  def testNestedQuoteWithAppliedType: Data = macro CrossCtorInjectionFixtures.testNestedQuoteWithAppliedTypeImpl\n\n"
     sb ++= "  def testNestedQuoteSpliceComposition: Data = macro CrossCtorInjectionFixtures.testNestedQuoteSpliceCompositionImpl\n\n"
     sb ++= "  def testFunctorDerivation: Data = macro CrossCtorInjectionFixtures.testFunctorDerivationImpl\n\n"
+    sb ++= "  def testFunctorDerivationWithCtor: Data = macro CrossCtorInjectionFixtures.testFunctorDerivationWithCtorImpl\n\n"
 
     sb ++= "}\n"
     sb.toString
@@ -809,6 +811,7 @@ object CrossCtorTestGen {
     // Local type param in splice tests - class body methods for methods with type params
     sb ++= "  private lazy val listCtor1: Type.Ctor1[List] = Type.Ctor1.of[List]\n\n"
     sb ++= "  def testFunctorSkeleton: Expr[Data] = testFunctorSkeleton[List](using listCtor1)\n\n"
+    sb ++= "  def testFunctorDerivationWithCtor: Expr[Data] = testFunctorDerivationWithCtor[List](using listCtor1)\n\n"
 
     sb ++= "}\n\n"
 
@@ -878,6 +881,7 @@ object CrossCtorTestGen {
     sb ++= genScala3InlineSplice("testNestedQuoteWithAppliedType")
     sb ++= genScala3InlineSplice("testNestedQuoteSpliceComposition")
     sb ++= genScala3InlineSplice("testFunctorDerivation")
+    sb ++= genScala3InlineSplice("testFunctorDerivationWithCtor")
 
     sb ++= "}\n"
     sb.toString
@@ -1091,6 +1095,10 @@ object CrossCtorTestGen {
         |
         |      test("should derive a working Functor[List] using nested quotes") {
         |        CrossCtorInjectionFixtures.testFunctorDerivation <==> Data("1, 2, 3")
+        |      }
+        |
+        |      test("should derive Functor with Type.Ctor1[F] and extracted body with Type context bounds") {
+        |        CrossCtorInjectionFixtures.testFunctorDerivationWithCtor <==> Data("1, 2, 3")
         |      }
         |
         |    }

--- a/project/CrossCtorTestGen.scala
+++ b/project/CrossCtorTestGen.scala
@@ -638,6 +638,9 @@ object CrossCtorTestGen {
     sb ++= "  def testTypeOfWithCtorHKTAppliedImpl: c.Expr[Data] = testTypeOfWithCtorHKTApplied[Option](Type.Ctor1.of[Option])\n\n"
     sb ++= "  def testTypeOfWithCtorHKTAndTypeParamImpl[A: c.WeakTypeTag]: c.Expr[Data] = testTypeOfWithCtorHKTAndTypeParam[Option, A](Type.Ctor1.of[Option], Type.of[A])\n\n"
 
+    // Local type param in splice tests
+    sb ++= "  def testTypeOfLocalParamInSpliceImpl: c.Expr[Data] = testTypeOfLocalParamInSplice\n\n"
+
     sb ++= "}\n\n"
 
     // Companion object
@@ -681,6 +684,9 @@ object CrossCtorTestGen {
     sb ++= "  def testExprQuoteWithCtor1Param: Data = macro CrossCtorInjectionFixtures.testExprQuoteWithCtor1ParamImpl\n\n"
     sb ++= "  def testTypeOfWithCtorHKTApplied: Data = macro CrossCtorInjectionFixtures.testTypeOfWithCtorHKTAppliedImpl\n\n"
     sb ++= "  def testTypeOfWithCtorHKTAndTypeParam[A]: Data = macro CrossCtorInjectionFixtures.testTypeOfWithCtorHKTAndTypeParamImpl[A]\n\n"
+
+    // Local type param in splice tests
+    sb ++= "  def testTypeOfLocalParamInSplice: Data = macro CrossCtorInjectionFixtures.testTypeOfLocalParamInSpliceImpl\n\n"
 
     sb ++= "}\n"
     sb.toString
@@ -838,6 +844,9 @@ object CrossCtorTestGen {
     sb ++= "  inline def testTypeOfWithCtorHKTAndTypeParam[A]: Data = ${ testTypeOfWithCtorHKTAndTypeParamImpl[A] }\n"
     sb ++= "  private def testTypeOfWithCtorHKTAndTypeParamImpl[A: Type](using q: Quotes): Expr[Data] =\n"
     sb ++= "    new CrossCtorInjectionFixtures(q).testTypeOfWithCtorHKTAndTypeParam[A]\n\n"
+
+    // Local type param in splice tests
+    sb ++= genScala3InlineSplice("testTypeOfLocalParamInSplice")
 
     sb ++= "}\n"
     sb.toString
@@ -1003,6 +1012,18 @@ object CrossCtorTestGen {
         |
         |      test("should resolve Type.of[F[A]] with Ctor1 and Type param") {
         |        CrossCtorInjectionFixtures.testTypeOfWithCtorHKTAndTypeParam[Int] <==> Data("scala.Option[scala.Int]")
+        |      }
+        |
+        |    }
+        |""".stripMargin
+    sb ++= "\n"
+
+    // Group 13: Local type param in splice tests
+    sb ++=
+      """    group("for Type.of with local type params inside Expr.splice inside Expr.quote") {
+        |
+        |      test("should resolve Type.of[A] where A is a local type param from a method inside the quote") {
+        |        CrossCtorInjectionFixtures.testTypeOfLocalParamInSplice <==> Data("ok")
         |      }
         |
         |    }


### PR DESCRIPTION
Followup/fixes missed issues from #206 