### PR TITLE
Fix DirectStyle state propagation for nested runSafe, redesign MLocal…

### DIFF
--- a/docs/user-guide/micro-fp.md
+++ b/docs/user-guide/micro-fp.md
@@ -1334,18 +1334,17 @@ and recombines them afterwards (via `join`). This is correct for truly independe
 However, for inherently shared/global state — like caches or deduplication maps — fork/join semantics cause problems:
 each branch independently builds the same entry, then `join` must reconcile duplicates.
 
-`MLocal.unsafeSharedParallel(initial)(join)` creates a shared-state local where parallel branches see each other's
+`MLocal.unsafeSharedParallel(initial)` creates a shared-state local where parallel branches see each other's
 modifications sequentially: branch B sees branch A's writes, branch C sees both, etc.
 
-A `join` function is still required because it is used both by `parMap2` (to combine branch results) and internally
-by `MIO`'s direct-style machinery. With shared-parallel fork semantics, branch B already includes branch A's writes,
-so `join` typically just needs to combine any independently-added entries (e.g. a cache merge).
+No `fork` or `join` function is needed — branch B always sees branch A's latest state, and after joining,
+the last branch's state is used directly.
 
 ```scala
 import hearth.fp.effect.*
 
 // Shared cache — parallel branches accumulate into the same map
-val cache = MLocal.unsafeSharedParallel(Map.empty[String, Int])(_ ++ _)
+val cache = MLocal.unsafeSharedParallel(Map.empty[String, Int])
 
 val branchA = cache.get.flatMap(m => cache.set(m.updated("a", 1)))
 val branchB = cache.get.flatMap(m => cache.set(m.updated("b", 2)))

--- a/hearth-micro-fp/src/main/scala/hearth/fp/effect/MIO.scala
+++ b/hearth-micro-fp/src/main/scala/hearth/fp/effect/MIO.scala
@@ -291,6 +291,18 @@ object MIO {
       }
     }
 
+  /** Allows the [[run]] loop to sync its accumulated state with [[DirectStyle]]'s `ongoingStates`, so that nested
+    * `runSafe` calls see up-to-date state and their changes are propagated back into the run loop.
+    *
+    * Without this, the run loop accumulates state internally while `runSafe` tracks state in a separate mutable map.
+    * When a nested `runSafe` is called from within a thunk evaluated by the run loop (e.g. `MIO(expr)` where `expr`
+    * calls `runSafe(innerMio)`), the inner call starts from stale state and its changes are lost.
+    */
+  private trait StateSync {
+    def write(state: MState): Unit
+    def read(): MState
+  }
+
   /** Stack-safety execution of MIO program.
     *
     * For each [[Impure]], [[FnNec.view]] rewrites a non-empty chain of functions e.g.
@@ -310,19 +322,32 @@ object MIO {
     * Since both [[FnNec.view]] and [[run]]ning the left-most function are tail-recursive, and all applied functions (in
     * practice: [[MIO.redeemWith]], [[MIO.orElse]] and [[MIO.parMap2]], everything else delegate to them) should compute
     * only 1 level of nesting (more levels should be lazily deferred), the whole process is stack-safe.
+    *
+    * @param stateSync
+    *   optional sync mechanism for DirectStyle. When non-null, the run loop writes its accumulated state before
+    *   evaluating each function (so nested `runSafe` starts from the correct state), and reads back after (to
+    *   incorporate any changes made by nested `runSafe`).
     */
   @scala.annotation.tailrec
-  private def run[A](io: MIO[A]): (MState, MResult[A]) = io match {
+  private def run[A](io: MIO[A], stateSync: StateSync = null): (MState, MResult[A]) = io match {
     case Impure(state, resultC, fnNecCToA) =>
       checkTermination(state, resultC, fnNecCToA)
-      run((fnNecCToA.view match {
+      // Sync accumulated state to DirectStyle before evaluating functions, so nested runSafe sees it.
+      if (stateSync ne null) stateSync.write(state)
+      val nextMio = fnNecCToA.view match {
         case FnNec.View.One(fnCToA)             => fnCToA(state, resultC)
         case FnNec.View.Cons(fnCToB, fnNecBToA) => fnCToB(state, resultC) :++ fnNecBToA
-      }) match {
-        // Previous methods could have created new Pure or Impure without merging states, so we have to do it here.
-        case Pure(state2, result)        => Pure(state ++ state2, result)
-        case Impure(state2, result, qab) => Impure(state ++ state2, result, qab)
-      })
+      }
+      // Read back from DirectStyle — nested runSafe may have modified the state.
+      val baseState = if (stateSync ne null) stateSync.read() else state
+      run(
+        nextMio match {
+          // Previous methods could have created new Pure or Impure without merging states, so we have to do it here.
+          case Pure(state2, result)        => Pure(baseState ++ state2, result)
+          case Impure(state2, result, qab) => Impure(baseState ++ state2, result, qab)
+        },
+        stateSync
+      )
     case Pure(state, resultA) => state -> resultA
   }
 
@@ -355,23 +380,29 @@ object MIO {
       case (initialState, Left(e)) => Pure(initialState, Left(e))
     }
     override protected def runUnsafe[A](owner: DirectStyle.ScopeOwner[MIO])(mio: => MIO[A]): A = {
-      val initialState = getState(owner) // We have to extract the state before we'll run the MIO.
+      // Sync mechanism: the run loop writes its accumulated state before each function evaluation, and reads back
+      // after, so that nested runSafe calls see up-to-date state and their changes are incorporated into the run loop.
+      val sync = new StateSync {
+        def write(state: MState): Unit = setState(owner, state)
+        def read(): MState = getState(owner)
+      }
 
       // We're running the MIO in a virtual thread, to avoid StackOverflowError when using recursive MIO with direct style.
       val (computedState, result) = DirectStyleExecutor {
-        // We're merging the state here because the MIO might have been run in a nested direct style operation.
-        run(mio match {
-          case Pure(state, result)      => Pure(initialState ++ state, result)
-          case Impure(state, result, q) => Impure(initialState ++ state, result, q)
-        })
+        // Evaluate the by-name MIO first — it may call nested runSafe which modifies ongoingStates(owner).
+        // Then re-read the current state AFTER evaluation, so we start the run loop from up-to-date state.
+        val evaluatedMio = mio
+        val currentState = getState(owner)
+        run(
+          evaluatedMio match {
+            case Pure(state, result)      => Pure(currentState ++ state, result)
+            case Impure(state, result, q) => Impure(currentState ++ state, result, q)
+          },
+          sync
+        )
       }
 
-      // This could have been overriden by nested direct style operations, so we have to merge the state here.
-      val intermediateState = getState(owner)
-      // We use merge instead of ++... as a workaround basically. We could have lost continuity of passing state around
-      // in nested .scoped, intermediateState can still have it, while returned new state could have been overriden.
-      val newState = intermediateState join computedState
-      setState(owner, newState)
+      setState(owner, computedState)
 
       result match {
         case Right(a) => a

--- a/hearth-micro-fp/src/main/scala/hearth/fp/effect/MLocal.scala
+++ b/hearth-micro-fp/src/main/scala/hearth/fp/effect/MLocal.scala
@@ -12,24 +12,40 @@ package effect
   *   - when using the "parallel" semantics ([[MIO.parMap2]], [[MIO.parTuple]]), we are able to modify value for each
   *     "fiber", and provide a reasonable way of combining values from 2 different "fibers" back into a single value
   *
+  * There are two variants:
+  *   - [[MLocal.ForkJoinParallel]] — each parallel branch gets an independent copy via `fork`, results are combined
+  *     with `join`
+  *   - [[MLocal.SequentialOnParallel]] — parallel branches share the same state sequentially (branch B sees branch A's
+  *     writes)
+  *
   * @since 0.1.0
   */
-final class MLocal[A] private (
-    private[effect] val initial: A,
-    private[effect] val fork: A => A,
-    private[effect] val join: (A, A) => A,
-    private[effect] val isShared: Boolean
-) {
+sealed trait MLocal[A] extends Product with Serializable {
+
+  private[effect] val initial: A
 
   def get: MIO[A] = MIO.get(this)
 
   def set(a: A): MIO[Unit] = MIO.set(this, a)
-
-  private val version = new java.util.concurrent.atomic.AtomicLong(1L)
-  private[effect] def nextVersion: Long = version.getAndIncrement()
 }
 
 object MLocal {
+
+  final private[effect] case class ForkJoinParallel[A](
+      initial: A,
+      fork: A => A,
+      join: (A, A) => A
+  ) extends MLocal[A] {
+    private val version = new java.util.concurrent.atomic.AtomicLong(1L)
+    private[effect] def nextVersion: Long = version.getAndIncrement()
+  }
+
+  final private[effect] case class SequentialOnParallel[A](
+      initial: A
+  ) extends MLocal[A] {
+    private val version = new java.util.concurrent.atomic.AtomicLong(1L)
+    private[effect] def nextVersion: Long = version.getAndIncrement()
+  }
 
   /** Creates a new [[MLocal]] value - each value, even if initialized the same way! - would be a separate instance.
     *
@@ -45,7 +61,7 @@ object MLocal {
     * @since 0.1.0
     */
   def apply[A](initial: A)(fork: A => A)(join: (A, A) => A): MLocal[A] =
-    new MLocal(initial, fork, join, isShared = false)
+    new ForkJoinParallel(initial, fork, join)
 
   /** Creates a new [[MLocal]] with shared-parallel semantics.
     *
@@ -63,8 +79,8 @@ object MLocal {
     * '''Unsafe''' because it breaks branch independence — the second branch depends on the first branch's execution
     * order. Not suitable for state where fork isolation matters (error counters, independent accumulators, etc.).
     *
-    * @since 0.9.0
+    * @since 0.3.0
     */
-  def unsafeSharedParallel[A](initial: A)(join: (A, A) => A): MLocal[A] =
-    new MLocal(initial, fork = identity, join = join, isShared = true)
+  def unsafeSharedParallel[A](initial: A): MLocal[A] =
+    new SequentialOnParallel(initial)
 }

--- a/hearth-micro-fp/src/main/scala/hearth/fp/effect/MState.scala
+++ b/hearth-micro-fp/src/main/scala/hearth/fp/effect/MState.scala
@@ -48,14 +48,24 @@ final case class MState private[effect] (
     else MState(joinLocals(locals, state.locals), combineLogs(logs, state.logs))
 
   private[effect] def get[A](local: MLocal[A]): A = locals.get(local).fold(local.initial)(_.as[A])
-  private[effect] def set[A](local: MLocal[A], a: A): MState =
-    MState(locals + (local -> Value(a, local.nextVersion)), logs)
+  private[effect] def set[A](local: MLocal[A], a: A): MState = {
+    val ver = local match {
+      case fjp: MLocal.ForkJoinParallel[A @unchecked]     => fjp.nextVersion
+      case sop: MLocal.SequentialOnParallel[A @unchecked] => sop.nextVersion
+    }
+    MState(locals + (local -> Value(a, ver)), logs)
+  }
 
   private[effect] def log(log: Log): MState = MState(locals, logs :+ log)
   private[effect] def nameLogsScope(name: String, start: Log.Timestamp, end: Log.Timestamp, previous: MState): MState =
     MState(locals, recursiveNestedLogsMerge(previous.logs, logs, name, start, end))
 
   // ----------------------------------------------- MLocal operations ------------------------------------------------
+
+  private def nextVersionOf(local: MLocal[?]): Long = local match {
+    case fjp: MLocal.ForkJoinParallel[?]     => fjp.nextVersion
+    case sop: MLocal.SequentialOnParallel[?] => sop.nextVersion
+  }
 
   private def appendLocals(locals1: Map[MLocal[?], Value], locals2: Map[MLocal[?], Value]): Map[MLocal[?], Value] =
     if (locals1 eq locals2) locals1
@@ -76,20 +86,21 @@ final case class MState private[effect] (
     else
       handleLocalsCasting(locals.keySet, explicitlyRewind.locals.keySet) {
         _.map { local =>
-          if (local.asInstanceOf[MLocal[Any]].isShared) {
-            // Shared: take latest value without forking. Prefer explicitlyRewind (branch A's result).
-            val fromRewind = explicitlyRewind.locals.get(local.asInstanceOf[MLocal[?]])
-            val fromCurrent = locals.get(local.asInstanceOf[MLocal[?]])
-            local -> (fromRewind orElse fromCurrent).getOrElse(Value(local.initial, local.nextVersion))
-          } else {
-            locals.get(local.asInstanceOf[MLocal[?]]) match {
-              case Some(a) => local -> Value(local.asInstanceOf[MLocal[Any]].fork(a.value), local.nextVersion)
-              case None    =>
-                local -> Value(
-                  local.initial,
-                  local.nextVersion
-                ) // We do this so that None won't fall back on value from another computation.
-            }
+          local match {
+            case _: MLocal.SequentialOnParallel[?] =>
+              // Shared: take latest value without forking. Prefer explicitlyRewind (branch A's result).
+              val fromRewind = explicitlyRewind.locals.get(local.asInstanceOf[MLocal[?]])
+              val fromCurrent = locals.get(local.asInstanceOf[MLocal[?]])
+              local -> (fromRewind orElse fromCurrent).getOrElse(Value(local.initial, nextVersionOf(local)))
+            case fjp: MLocal.ForkJoinParallel[Any @unchecked] =>
+              locals.get(local.asInstanceOf[MLocal[?]]) match {
+                case Some(a) => local -> Value(fjp.fork(a.value), fjp.nextVersion)
+                case None    =>
+                  local -> Value(
+                    local.initial,
+                    fjp.nextVersion
+                  ) // We do this so that None won't fall back on value from another computation.
+              }
           }
         }.toMap
       }
@@ -100,10 +111,17 @@ final case class MState private[effect] (
       handleLocalsCasting(locals1.keySet, locals2.keySet) {
         _.map { local =>
           (locals1.get(local), locals2.get(local)) match {
-            case (Some(a), Some(b)) => local -> Value(local.join(a.value, b.value), local.nextVersion)
-            case (Some(a), None)    => local -> a
-            case (None, Some(b))    => local -> b
-            case (None, None)       => local -> Value(local.initial, local.nextVersion)
+            case (Some(a), Some(b)) =>
+              local match {
+                case fjp: MLocal.ForkJoinParallel[Any @unchecked] =>
+                  local -> Value(fjp.join(a.value, b.value), fjp.nextVersion)
+                case _: MLocal.SequentialOnParallel[?] =>
+                  // Sequential: always prefer the second argument (branch B ran after A, has latest state)
+                  local -> b
+              }
+            case (Some(a), None) => local -> a
+            case (None, Some(b)) => local -> b
+            case (None, None)    => local -> Value(local.initial, nextVersionOf(local))
           }
         }.toMap
       }

--- a/hearth-tests/src/main/scala-2/hearth/MioIntegrationsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/MioIntegrationsFixtures.scala
@@ -12,6 +12,7 @@ final private class MioIntegrationsFixtures(val c: blackbox.Context)
   def testValDefBuilderBuildCachedWithMIOImpl: c.Expr[Data] = testValDefBuilderBuildCachedWithMIO
   def testExtensionLoadingResultToMIOImpl: c.Expr[Data] = testExtensionLoadingResultToMIO
   def testValDefsCacheParMap2MergeBugImpl: c.Expr[Data] = testValDefsCacheParMap2MergeBug
+  def testValDefsCacheParMap2DuplicateBuildErrorImpl: c.Expr[Data] = testValDefsCacheParMap2DuplicateBuildError
 }
 
 object MioIntegrationsFixtures {
@@ -19,4 +20,6 @@ object MioIntegrationsFixtures {
   def testValDefBuilderBuildCachedWithMIO: Data = macro MioIntegrationsFixtures.testValDefBuilderBuildCachedWithMIOImpl
   def testExtensionLoadingResultToMIO: Data = macro MioIntegrationsFixtures.testExtensionLoadingResultToMIOImpl
   def testValDefsCacheParMap2MergeBug: Data = macro MioIntegrationsFixtures.testValDefsCacheParMap2MergeBugImpl
+  def testValDefsCacheParMap2DuplicateBuildError: Data =
+    macro MioIntegrationsFixtures.testValDefsCacheParMap2DuplicateBuildErrorImpl
 }

--- a/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
@@ -68,8 +68,6 @@ final private class ExprsFixtures(val c: blackbox.Context) extends MacroCommonsS
 
   def testValDefBuilderBuildCachedVarGetterSetterImpl: c.Expr[Data] = testValDefBuilderBuildCachedVarGetterSetter
 
-  def testValDefsCacheMergeImpl: c.Expr[Unit] = testValDefsCacheMerge
-
   def testLambdaBuilderOfNAndBuildImpl: c.Expr[Data] = testLambdaBuilderOfNAndBuild
 
   def testLambdaBuilderBuildWithImpl: c.Expr[Data] = testLambdaBuilderBuildWith
@@ -201,8 +199,6 @@ object ExprsFixtures {
 
   def testValDefBuilderBuildCachedVarGetterSetter: Data =
     macro ExprsFixtures.testValDefBuilderBuildCachedVarGetterSetterImpl
-
-  def testValDefsCacheMerge: Unit = macro ExprsFixtures.testValDefsCacheMergeImpl
 
   def testLambdaBuilderOfNAndBuild: Data = macro ExprsFixtures.testLambdaBuilderOfNAndBuildImpl
 

--- a/hearth-tests/src/main/scala-3/hearth/MioIntegrationsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/MioIntegrationsFixtures.scala
@@ -26,4 +26,10 @@ object MioIntegrationsFixtures {
   private def testValDefsCacheParMap2MergeBugImpl(using q: Quotes): Expr[Data] = new MioIntegrationsFixtures(
     q
   ).testValDefsCacheParMap2MergeBug
+
+  inline def testValDefsCacheParMap2DuplicateBuildError: Data = ${
+    testValDefsCacheParMap2DuplicateBuildErrorImpl
+  }
+  private def testValDefsCacheParMap2DuplicateBuildErrorImpl(using q: Quotes): Expr[Data] =
+    new MioIntegrationsFixtures(q).testValDefsCacheParMap2DuplicateBuildError
 }

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
@@ -130,10 +130,6 @@ object ExprsFixtures {
   private def testValDefBuilderBuildCachedVarGetterSetterImpl(using q: Quotes): Expr[Data] =
     new ExprsFixtures(q).testValDefBuilderBuildCachedVarGetterSetter
 
-  inline def testValDefsCacheMerge: Unit = ${ testValDefsCacheMergeImpl }
-  private def testValDefsCacheMergeImpl(using q: Quotes): Expr[Unit] =
-    new ExprsFixtures(q).testValDefsCacheMerge
-
   inline def testLambdaBuilderOfNAndBuild: Data = ${ testLambdaBuilderOfNAndBuildImpl }
   private def testLambdaBuilderOfNAndBuildImpl(using q: Quotes): Expr[Data] =
     new ExprsFixtures(q).testLambdaBuilderOfNAndBuild

--- a/hearth-tests/src/main/scala/hearth/MioIntegrationsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/MioIntegrationsFixturesImpl.scala
@@ -787,11 +787,8 @@ trait MioIntegrationsFixturesImpl { this: hearth.MacroTypedCommons =>
     * With `MLocal.unsafeSharedParallel`, the ValDefsCache is shared across parallel branches:
     *   - Branch A builds the cached entry (via `buildCachedWith`)
     *   - Branch B sees branch A's entry already in the cache (via shared state)
-    *   - The idempotent `set` in ValDefsCache skips the update if the key is already fully built
-    *   - No duplicate definitions, no `$$dup$$` keys — single `lazy val` in the output
-    *
-    * Previously, with fork/join semantics, each branch independently created a fresh TermName, which required the
-    * `$$dup$$` workaround in merge to keep both definitions.
+    *   - Branch B checks the cache before building, finds it, and reuses it
+    *   - No duplicate definitions — single `lazy val` in the output
     */
   @scala.annotation.nowarn
   def testValDefsCacheParMap2MergeBug: Expr[Data] = {
@@ -799,19 +796,28 @@ trait MioIntegrationsFixturesImpl { this: hearth.MacroTypedCommons =>
 
     val cacheLocal = ValDefsCache.mlocal
 
-    // Both branches build the same cached lazy val. With shared-parallel semantics,
-    // branch B sees branch A's entry and the idempotent `set` skips the duplicate build.
+    // Branch A builds the cached lazy val.
     val branchA: MIO[Expr[Int]] = for {
       _ <- cacheLocal.buildCachedWith("shared-lazy-int", ValDefBuilder.ofLazy[Int]("lazyInt"))(_ => Expr.quote(42))
       value <- cacheLocal.get0Ary[Int]("shared-lazy-int").map(_.fold(runtimeFail[Int])(identity))
     } yield value
 
+    // Branch B checks the cache first — with shared-parallel semantics, it sees branch A's entry.
     val branchB: MIO[Expr[Int]] = for {
-      _ <- cacheLocal.buildCachedWith("shared-lazy-int", ValDefBuilder.ofLazy[Int]("lazyInt"))(_ => Expr.quote(42))
-      value <- cacheLocal.get0Ary[Int]("shared-lazy-int").map(_.fold(runtimeFail[Int])(identity))
+      existing <- cacheLocal.get0Ary[Int]("shared-lazy-int")
+      value <- existing match {
+        case Some(v) => MIO.pure(v)
+        case None    =>
+          for {
+            _ <- cacheLocal.buildCachedWith("shared-lazy-int", ValDefBuilder.ofLazy[Int]("lazyInt"))(_ =>
+              Expr.quote(42)
+            )
+            v <- cacheLocal.get0Ary[Int]("shared-lazy-int").map(_.fold(runtimeFail[Int])(identity))
+          } yield v
+      }
     } yield value
 
-    // With shared-parallel: branch B sees A's cache, idempotent set skips duplicate, single lazy val in output.
+    // With shared-parallel: branch B sees A's cache, checks it, and reuses the existing entry.
     val result = for {
       values <- branchA.parMap2(branchB)((a, b) => (a, b))
       cache <- cacheLocal.get
@@ -820,6 +826,42 @@ trait MioIntegrationsFixturesImpl { this: hearth.MacroTypedCommons =>
     }
 
     result.runToExprOrFail("testValDefsCacheParMap2MergeBug")((_, _) => "")
+  }
+
+  /** Test that calling `buildCachedWith` for an already-built key+signature produces a [[HearthRequirementError]].
+    *
+    * With shared-parallel semantics, if two branches both blindly call `buildCachedWith` for the same key, the second
+    * call detects that the key is already fully built and fails. Users should check the cache (via `get*` methods)
+    * before building.
+    */
+  @scala.annotation.nowarn
+  def testValDefsCacheParMap2DuplicateBuildError: Expr[Data] = {
+    implicit val intType: Type[Int] = IntType
+
+    val cacheLocal = ValDefsCache.mlocal
+
+    // Both branches blindly build the same key — branch B should fail.
+    val branchA: MIO[Expr[Int]] = for {
+      _ <- cacheLocal.buildCachedWith("dup-key", ValDefBuilder.ofLazy[Int]("dupVal"))(_ => Expr.quote(1))
+      value <- cacheLocal.get0Ary[Int]("dup-key").map(_.fold(runtimeFail[Int])(identity))
+    } yield value
+
+    val branchB: MIO[Expr[Int]] = for {
+      _ <- cacheLocal.buildCachedWith("dup-key", ValDefBuilder.ofLazy[Int]("dupVal"))(_ => Expr.quote(1))
+      value <- cacheLocal.get0Ary[Int]("dup-key").map(_.fold(runtimeFail[Int])(identity))
+    } yield value
+
+    val result = branchA
+      .parMap2(branchB)((_, _) => ())
+      .redeem(_ => Data("no-error"))(errors =>
+        Data(
+          if (errors.toList.exists(_.getMessage.contains("buildCachedWith('dup-key')"))) "duplicate-build-detected"
+          else "wrong-error"
+        )
+      )
+
+    val (_, outcome) = result.unsafe.runSync
+    Expr(outcome.getOrElse(Data("mio-failed")))
   }
 
   // types using in fixtures

--- a/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
@@ -634,35 +634,6 @@ trait ExprsFixturesImpl { this: MacroTypedCommons & hearth.untyped.UntypedMethod
     }
   }
 
-  def testValDefsCacheMerge: Expr[Unit] = {
-    implicit val intType: Type[Int] = IntType
-    implicit val unitType: Type[Unit] = UnitType
-    val defBuilder = ValDefBuilder.ofDef1[Int, Int]("example", "a")
-
-    val forwarded = defBuilder.forwardDeclare(ValDefsCache.empty, "example")
-    val build = defBuilder.buildCachedWith(ValDefsCache.empty, "example")(_ => Expr.quote(100))
-
-    // We expect the following to be equal:
-    val forwardedThenBuild = ValDefsCache.merge(forwarded, build)
-    val buildThenForwarded = ValDefsCache.merge(build, forwarded)
-    val emptyThenBuild = ValDefsCache.merge(ValDefsCache.empty, build)
-    val buildThenEmpty = ValDefsCache.merge(build, ValDefsCache.empty)
-
-    // None of these should throw an error with forwarded but undefined declaration
-    val expr1 = forwardedThenBuild.toValDefs.use(_ => Expr(()))
-    val expr2 = buildThenForwarded.toValDefs.use(_ => Expr(()))
-    val expr3 = emptyThenBuild.toValDefs.use(_ => Expr(()))
-    val expr4 = buildThenEmpty.toValDefs.use(_ => Expr(()))
-
-    // We expect the following to compile
-    Expr.quote {
-      Expr.splice(expr1)
-      Expr.splice(expr2)
-      Expr.splice(expr3)
-      Expr.splice(expr4)
-    }
-  }
-
   // LambdaBuilder methods
 
   def testLambdaBuilderOfNAndBuild: Expr[Data] = {

--- a/hearth-tests/src/test/scala/hearth/MioIntegrationsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/MioIntegrationsSpec.scala
@@ -48,13 +48,19 @@ final class MioIntegrationsSpec extends MacroSuite {
 
     group("ValDefsCache merge with parMap2") {
 
-      // Tests shared-parallel ValDefsCache semantics with parMap2: two branches both call
-      // buildCachedWith for the same key. With MLocal.unsafeSharedParallel, branch B sees
-      // branch A's entry already built and the idempotent `set` skips the duplicate.
-      // Result is 42 + 42 = 84 because both branches reference the same cached Expr.quote(42).
+      // Tests shared-parallel ValDefsCache semantics with parMap2: branch A builds, branch B checks
+      // cache and reuses the entry. Result is 42 + 42 = 84 because both branches reference the same
+      // cached Expr.quote(42).
       test("should merge caches from parMap2 branches that cache the same key") {
         import MioIntegrationsFixtures.testValDefsCacheParMap2MergeBug
         testValDefsCacheParMap2MergeBug <==> Data(84)
+      }
+
+      // Tests that calling buildCachedWith for an already-built key+signature produces an error.
+      // Users should check the cache (via get* methods) before building.
+      test("should fail when both branches blindly buildCachedWith for the same key") {
+        import MioIntegrationsFixtures.testValDefsCacheParMap2DuplicateBuildError
+        testValDefsCacheParMap2DuplicateBuildError <==> Data("duplicate-build-detected")
       }
     }
 

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -376,13 +376,6 @@ final class ExprsSpec extends MacroSuite {
         )
       }
 
-      test("methods ValDefsCache.merge should allow merging ValDefsCache") {
-        import ExprsFixtures.testValDefsCacheMerge
-
-        @scala.annotation.nowarn // suppress "unused method" errors - we want to check whether these compile, not use them
-        val result = testValDefsCacheMerge
-        result ==> ()
-      }
     }
 
     group("type LambdaBuilder") {

--- a/hearth-tests/src/test/scalajvm/hearth/fp/effect/MLocalSpec.scala
+++ b/hearth-tests/src/test/scalajvm/hearth/fp/effect/MLocalSpec.scala
@@ -62,7 +62,7 @@ final class MLocalSpec extends ScalaCheckSuite {
   group("MLocal.unsafeSharedParallel") {
 
     test("sequential semantics unchanged") {
-      val shared = MLocal.unsafeSharedParallel(0)((_, b) => b)
+      val shared = MLocal.unsafeSharedParallel(0)
 
       val program = for {
         _ <- shared.set(1)
@@ -74,7 +74,7 @@ final class MLocalSpec extends ScalaCheckSuite {
     }
 
     test("branch B sees branch A's writes") {
-      val shared = MLocal.unsafeSharedParallel(0)((_, b) => b)
+      val shared = MLocal.unsafeSharedParallel(0)
 
       val branchA = shared.set(42)
       val branchB = shared.get
@@ -86,7 +86,7 @@ final class MLocalSpec extends ScalaCheckSuite {
     }
 
     test("latest write wins after join") {
-      val shared = MLocal.unsafeSharedParallel(0)((_, b) => b)
+      val shared = MLocal.unsafeSharedParallel(0)
 
       val branchA = shared.set(1)
       val branchB = shared.set(2)
@@ -100,7 +100,7 @@ final class MLocalSpec extends ScalaCheckSuite {
     test("no fork applied") {
       // For a regular MLocal, fork would transform the value.
       // For shared, the value should pass through unchanged.
-      val shared = MLocal.unsafeSharedParallel(100)((_, b) => b)
+      val shared = MLocal.unsafeSharedParallel(100)
 
       val branchA = shared.get
       val branchB = shared.get
@@ -114,7 +114,7 @@ final class MLocalSpec extends ScalaCheckSuite {
     }
 
     test("mixed shared + forked locals") {
-      val shared = MLocal.unsafeSharedParallel(0)((_, b) => b)
+      val shared = MLocal.unsafeSharedParallel(0)
       val forked = MLocal(0)(identity)(_ + _)
 
       val branchA = shared.set(10) >> forked.get.flatMap(a => forked.set(a + 1))
@@ -132,7 +132,7 @@ final class MLocalSpec extends ScalaCheckSuite {
     }
 
     test("nested parMap2") {
-      val shared = MLocal.unsafeSharedParallel(0)((_, b) => b)
+      val shared = MLocal.unsafeSharedParallel(0)
 
       val innerA = shared.get.flatMap(v => shared.set(v + 1))
       val innerB = shared.get.flatMap(v => shared.set(v + 10))
@@ -148,7 +148,7 @@ final class MLocalSpec extends ScalaCheckSuite {
     }
 
     test("map accumulation across branches") {
-      val shared = MLocal.unsafeSharedParallel(Map.empty[String, Int])(_ ++ _)
+      val shared = MLocal.unsafeSharedParallel(Map.empty[String, Int])
 
       val branchA = shared.get.flatMap(m => shared.set(m.updated("a", 1)))
       val branchB = shared.get.flatMap(m => shared.set(m.updated("b", 2)))
@@ -160,7 +160,7 @@ final class MLocalSpec extends ScalaCheckSuite {
     }
 
     test("works with .scoped (DirectStyle)") {
-      val shared = MLocal.unsafeSharedParallel(0)((_, b) => b)
+      val shared = MLocal.unsafeSharedParallel(0)
 
       val program = for {
         _ <- MIO.scoped { runSafe =>
@@ -172,8 +172,41 @@ final class MLocalSpec extends ScalaCheckSuite {
       program.unsafe.runSync._2 === Right(42)
     }
 
+    test("nested runSafe inside MIO thunk propagates state to outer run loop") {
+      // This tests the scenario where buildCachedWith calls f inside MIO(...),
+      // and f calls runSafe(helper(...)) which modifies the MLocal cache.
+      // The outer run loop must see the inner state changes.
+      val shared = MLocal.unsafeSharedParallel(Map.empty[String, Int])
+
+      def append(name: String, value: Int) = for {
+        m <- shared.get
+        _ <- shared.set(m.updated(name, value))
+      } yield ()
+
+      // Simulates buildCachedWith pattern:
+      // 1. Forward declare (set state)
+      // 2. MIO(f(value)) where f calls runSafe(innerMio) that modifies state
+      // 3. Read state — should see inner changes
+      def reproduction(name: String)(value: MIO[Int]) = for {
+        _ <- append(s"forward-declare-$name", 1)
+        _ <- MIO.scoped { runSafe =>
+          runSafe {
+            append(s"define-$name", runSafe(value))
+          }
+        }
+      } yield ()
+
+      val program = reproduction("a") {
+        reproduction("b")(MIO(10)).as(5)
+      } >> shared.get
+
+      program.unsafe.runSync._2 === Right(
+        Map("forward-declare-a" -> 1, "define-a" -> 5, "forward-declare-b" -> 1, "define-b" -> 10)
+      )
+    }
+
     test("untouched shared local preserves value") {
-      val shared = MLocal.unsafeSharedParallel(99)((_, b) => b)
+      val shared = MLocal.unsafeSharedParallel(99)
 
       val branchA = MIO(1)
       val branchB = MIO(2)
@@ -184,7 +217,7 @@ final class MLocalSpec extends ScalaCheckSuite {
     }
 
     test("error aggregation still works") {
-      val shared = MLocal.unsafeSharedParallel(0)((_, b) => b)
+      val shared = MLocal.unsafeSharedParallel(0)
       val errors = MLocal(Vector.empty[String])(identity)(_ ++ _)
 
       val branchA = for {
@@ -203,7 +236,7 @@ final class MLocalSpec extends ScalaCheckSuite {
     }
 
     test("branch B reads shared local that A created and modified") {
-      val shared = MLocal.unsafeSharedParallel(0)((_, b) => b)
+      val shared = MLocal.unsafeSharedParallel(0)
 
       // Neither branch has set the value before parMap2.
       // A initializes it, B should see A's value.
@@ -216,7 +249,7 @@ final class MLocalSpec extends ScalaCheckSuite {
     }
 
     test("chained parMap2 with shared local accumulation") {
-      val shared = MLocal.unsafeSharedParallel(Map.empty[String, Int])(_ ++ _)
+      val shared = MLocal.unsafeSharedParallel(Map.empty[String, Int])
 
       def addEntry(key: String, value: Int): MIO[Unit] =
         shared.get.flatMap(m => shared.set(m.updated(key, value)))

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -867,6 +867,8 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
       def buildCached(cache: ValDefsCache, key: String, body: Expr[Returned]): ValDefsCache
 
       def forwardDeclare(cache: ValDefsCache, key: String): ValDefsCache
+
+      def isBuilt(cache: ValDefsCache, key: String): Boolean
     }
 
     final private[typed] class MkValDef[Signature, Returned] private[typed] (
@@ -883,6 +885,9 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
 
       def forwardDeclare(cache: ValDefsCache, key: String): ValDefsCache =
         cache.forwardDeclare(mkKey(key), signature)
+
+      def isBuilt(cache: ValDefsCache, key: String): Boolean =
+        cache.isBuilt(mkKey(key))
     }
 
     final private[typed] class MkVar[Signature, Returned] private[typed] (
@@ -903,6 +908,9 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
 
       def forwardDeclare(cache: ValDefsCache, key: String): ValDefsCache =
         cache.forwardDeclare(mkGetterKey(key), getter).forwardDeclare(mkSetterKey(key), setter)
+
+      def isBuilt(cache: ValDefsCache, key: String): Boolean =
+        cache.isBuilt(mkGetterKey(key))
     }
 
     override def ofVal[Returned: Type](
@@ -2053,6 +2061,13 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
     ): ValDefsCache =
       builder.mk.forwardDeclare(cache, key)
 
+    override def isBuilt[Signature, Returned, Value](
+        cache: ValDefsCache,
+        key: String,
+        builder: ValDefBuilder[Signature, Returned, Value]
+    ): Boolean =
+      builder.mk.isBuilt(cache, key)
+
     override def partition[Signature, Returned, A, B, C](
         builder: ValDefBuilder[Signature, Returned, A]
     )(f: A => Either[B, C]): Either[ValDefBuilder[Signature, Returned, B], ValDefBuilder[Signature, Returned, C]] =
@@ -2129,6 +2144,9 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
           new ValDefsCache(definitions.updated(key, new ValDefsCache.Value(signature, Some(definition))))
       }
 
+    private[typed] def isBuilt(key: ValDefsCache.Key): Boolean =
+      definitions.get(key).exists(_.definition.isDefined)
+
     private[typed] def get[Signature](key: ValDefsCache.Key): Option[Signature] =
       definitions.get(key).map(_.signature.asInstanceOf[Signature])
   }
@@ -2158,62 +2176,6 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
     final private[typed] case class Value(signature: Any, definition: Option[ValOrDefDef])
 
     override def empty: ValDefsCache = new ValDefsCache(ListMap.empty)
-
-    override def merge(cache1: ValDefsCache, cache2: ValDefsCache): ValDefsCache = {
-      val keys = scala.collection.immutable.ListSet.from(cache1.definitions.keys ++ cache2.definitions.keys)
-      val usedNames = scala.collection.mutable.Set.from(keys.iterator.map(_.name))
-      var dupIdx = 0
-      val result = keys.toSeq.flatMap { key =>
-        (cache1.definitions.get(key), cache2.definitions.get(key)) match {
-          case (Some(value1), Some(value2)) if value1.signature != value2.signature =>
-            // Legacy path: with fork/join MLocal semantics, parallel branches independently created this
-            // entry with different signatures (each ofLazy generates a fresh TermName). With the current
-            // MLocal.unsafeSharedParallel default, this path should not be triggered because branch B sees
-            // branch A's entry and the idempotent `set` skips duplicate builds. Retained for backwards
-            // compatibility and custom MLocal configurations.
-            //
-            // We keep BOTH definitions because each branch's result code references its own TermName.
-            // The secondary entry is stored under a synthetic alias key ("name$dup$N") so that toValDefs
-            // emits both declarations.
-            val (primary, secondary) =
-              if (value1.definition.isEmpty && value2.definition.isDefined)
-                (value2, value1)
-              else (value1, value2)
-            secondary.definition match {
-              case Some(_) =>
-                dupIdx += 1
-                var aliasName = s"${key.name}$$dup$$$dupIdx"
-                while (usedNames.contains(aliasName)) { dupIdx += 1; aliasName = s"${key.name}$$dup$$$dupIdx" }
-                usedNames += aliasName
-                Seq((key, primary), (new Key(aliasName, key.args, key.returned), secondary))
-              case None =>
-                Seq((key, primary))
-            }
-          case (Some(value1), Some(value2)) =>
-            (value1.definition, value2.definition) match {
-              // Forwarding after declaration should be a safe no-op
-              case (Some(_), None) => Seq((key, value1))
-              // Declaration after forwarding should keep declaration
-              case (None, Some(_)) => Seq((key, value2))
-              case _               =>
-                // $COVERAGE-OFF$
-                if (value1.definition != value2.definition) {
-                  hearthRequirementFailed(
-                    s"Def with key $key already exists with different definition, you probably created it twice in 2 branches, without noticing"
-                  )
-                }
-                // $COVERAGE-ON$
-                Seq((key, value1))
-            }
-          case (Some(value), None) => Seq((key, value))
-          case (None, Some(value)) => Seq((key, value))
-          // $COVERAGE-OFF$
-          case (None, None) => ??? // impossible
-          // $COVERAGE-ON$
-        }
-      }
-      new ValDefsCache(ListMap.from(result))
-    }
 
     // format: off
     override def get0Ary[Returned: Type](cache: ValDefsCache, key: String): Option[Expr[Returned]] =

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -879,6 +879,8 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       def buildCached(cache: ValDefsCache, key: String, body: Expr[Returned]): ValDefsCache
 
       def forwardDeclare(cache: ValDefsCache, key: String): ValDefsCache
+
+      def isBuilt(cache: ValDefsCache, key: String): Boolean
     }
 
     final private[typed] class MkValDef[Signature, Returned] private[typed] (
@@ -895,6 +897,9 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
 
       def forwardDeclare(cache: ValDefsCache, key: String): ValDefsCache =
         cache.forwardDeclare(mkKey(key), signature)
+
+      def isBuilt(cache: ValDefsCache, key: String): Boolean =
+        cache.isBuilt(mkKey(key))
     }
 
     final private[typed] class MkVar[Signature, Returned] private[typed] (
@@ -913,6 +918,9 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
 
       def forwardDeclare(cache: ValDefsCache, key: String): ValDefsCache =
         cache.forwardDeclare(mkGetterKey(key), getter).forwardDeclare(mkSetterKey(key), setter)
+
+      def isBuilt(cache: ValDefsCache, key: String): Boolean =
+        cache.isBuilt(mkGetterKey(key))
     }
 
     override def ofVal[Returned: Type](
@@ -3370,6 +3378,13 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
     ): ValDefsCache =
       builder.mk.forwardDeclare(cache, key)
 
+    override def isBuilt[Signature, Returned, Value](
+        cache: ValDefsCache,
+        key: String,
+        builder: ValDefBuilder[Signature, Returned, Value]
+    ): Boolean =
+      builder.mk.isBuilt(cache, key)
+
     override def partition[Signature, Returned, A, B, C](
         builder: ValDefBuilder[Signature, Returned, A]
     )(f: A => Either[B, C]): Either[ValDefBuilder[Signature, Returned, B], ValDefBuilder[Signature, Returned, C]] =
@@ -3431,6 +3446,9 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
           new ValDefsCache(definitions.updated(key, new ValDefsCache.Value(signature, None)))
       }
 
+    private[typed] def isBuilt(key: ValDefsCache.Key): Boolean =
+      definitions.get(key).exists(_.definition.isDefined)
+
     private[typed] def set(
         key: ValDefsCache.Key,
         signature: Any,
@@ -3479,58 +3497,6 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
     final private[typed] case class Value(signature: Any, definition: Option[Statement])
 
     override def empty: ValDefsCache = new ValDefsCache(ListMap.empty)
-
-    override def merge(cache1: ValDefsCache, cache2: ValDefsCache): ValDefsCache = {
-      val keys = scala.collection.immutable.ListSet.from(cache1.definitions.keys ++ cache2.definitions.keys)
-      val usedNames = scala.collection.mutable.Set.from(keys.iterator.map(_.name))
-      var dupIdx = 0
-      val result = keys.toSeq.flatMap { key =>
-        (cache1.definitions.get(key), cache2.definitions.get(key)) match {
-          case (Some(value1), Some(value2)) if value1.signature != value2.signature =>
-            // Legacy path: with fork/join MLocal semantics, parallel branches independently created this
-            // entry with different signatures (each ofLazy generates a fresh TermName). With the current
-            // MLocal.unsafeSharedParallel default, this path should not be triggered because branch B sees
-            // branch A's entry and the idempotent `set` skips duplicate builds. Retained for backwards
-            // compatibility and custom MLocal configurations.
-            //
-            // We keep BOTH definitions because each branch's result code references its own TermName.
-            // The secondary entry is stored under a synthetic alias key ("name$dup$N") so that toValDefs
-            // emits both declarations.
-            val (primary, secondary) =
-              if value1.definition.isEmpty && value2.definition.isDefined then (value2, value1) else (value1, value2)
-            secondary.definition match {
-              case Some(_) =>
-                dupIdx += 1
-                var aliasName = s"${key.name}$$dup$$$dupIdx"
-                while usedNames.contains(aliasName) do { dupIdx += 1; aliasName = s"${key.name}$$dup$$$dupIdx" }
-                usedNames += aliasName
-                Seq((key, primary), (new Key(aliasName, key.args, key.returned), secondary))
-              case None =>
-                Seq((key, primary))
-            }
-          case (Some(value1), Some(value2)) =>
-            (value1.definition, value2.definition) match {
-              // Forwarding after declaration should be a safe no-op
-              case (Some(_), None) => Seq((key, value1))
-              // Declaration after forwarding should keep declaration
-              case (None, Some(_)) => Seq((key, value2))
-              case _               =>
-                // $COVERAGE-OFF$
-                if value1.definition != value2.definition then {
-                  hearthRequirementFailed(
-                    s"Def with key $key already exists with different definition, you probably created it twice in 2 branches, without noticing"
-                  )
-                }
-                // $COVERAGE-ON$
-                Seq((key, value1))
-            }
-          case (Some(value), None) => Seq((key, value))
-          case (None, Some(value)) => Seq((key, value))
-          case (None, None)        => ??? // impossible
-        }
-      }
-      new ValDefsCache(ListMap.from(result))
-    }
 
     // format: off
     override def get0Ary[Returned: Type](cache: ValDefsCache, key: String): Option[Expr[Returned]] =

--- a/hearth/src/main/scala/hearth/MIOIntegrations.scala
+++ b/hearth/src/main/scala/hearth/MIOIntegrations.scala
@@ -112,6 +112,15 @@ trait MIOIntegrations { this: MacroTypedCommons =>
       }
     else None
 
+  private def failBuildCachedWith(key: String): Nothing = throw HearthRequirementError(
+    s"buildCachedWith('$key'): key+signature already built. " +
+      "This is likely a mistake — check the cache before building (e.g. use get* methods to verify the key is not already present).",
+    hearthVersion = HearthVersion.byHearthLibrary,
+    scalaVersion = Environment.currentScalaVersion,
+    platform = Environment.currentPlatform,
+    jdkVersion = Environment.currentJDKVersion
+  )
+
   implicit final class MLocalCacheOps(private val cache: MLocal[ValDefsCache]) {
 
     def forwardDeclare[Signature, Returned, Value](
@@ -128,8 +137,22 @@ trait MIOIntegrations { this: MacroTypedCommons =>
         builder: ValDefBuilder[Signature, Returned, Value]
     )(f: Value => Expr[Returned]): MIO[Unit] = for {
       cache1 <- cache.get
-      cache2 = builder.buildCachedWith(cache1, key)(f)
-      _ <- cache.set(cache2)
+      _ <-
+        if (builder.isBuilt(cache1, key))
+          MIO(failBuildCachedWith(key))
+        else
+          for {
+            // 1. Forward declare — recursive calls from f will see the declaration.
+            _ <- cache.set(builder.forwardDeclare(cache1, key))
+            // 2. Map builder with f — eagerly calls f(value), which may trigger MLocal side effects
+            //    via runSafe (e.g. nested helper() calls that add their own cache entries).
+            //    DirectStyle's state sync ensures the run loop sees these changes.
+            mapped <- MIO(ValDefBuilder.traverse[Signature, Returned].map(builder)(f))
+            // 3. Read fresh cache — includes entries added by f's side effects.
+            cache2 <- cache.get
+            // 4. Build on the fresh cache — no stale snapshot, no overwritten entries.
+            _ <- cache.set(mapped.buildCached(cache2, key))
+          } yield ()
     } yield ()
 
     def buildCached[Signature, Returned](

--- a/hearth/src/main/scala/hearth/typed/Exprs.scala
+++ b/hearth/src/main/scala/hearth/typed/Exprs.scala
@@ -963,6 +963,12 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
         builder: ValDefBuilder[Signature, Returned, Value]
     ): ValDefsCache
 
+    def isBuilt[Signature, Returned, Value](
+        cache: ValDefsCache,
+        key: String,
+        builder: ValDefBuilder[Signature, Returned, Value]
+    ): Boolean
+
     def partition[Signature, Returned, A, B, C](builder: ValDefBuilder[Signature, Returned, A])(
         f: A => Either[B, C]
     ): Either[ValDefBuilder[Signature, Returned, B], ValDefBuilder[Signature, Returned, C]]
@@ -1009,6 +1015,9 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
 
     def forwardDeclare(cache: ValDefsCache, key: String): ValDefsCache =
       ValDefBuilder.forwardDeclare(cache, key, builder)
+
+    def isBuilt(cache: ValDefsCache, key: String): Boolean =
+      ValDefBuilder.isBuilt(cache, key, builder)
 
     def buildCachedWith(cache: ValDefsCache, key: String)(f: A => Expr[Returned]): ValDefsCache =
       ValDefBuilder.buildCached(cache, key, builder.map(f))
@@ -1074,25 +1083,7 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
 
     def empty: ValDefsCache
 
-    def mlocal: fp.effect.MLocal[ValDefsCache] = fp.effect.MLocal.unsafeSharedParallel(empty)(merge)
-
-    /** Merges two caches. Available for manual cache merging, but no longer used by default for parallel branches.
-      *
-      * Since `mlocal` now uses [[fp.effect.MLocal.unsafeSharedParallel]], parallel branches share state directly:
-      * branch B sees branch A's writes, and the idempotent `set` method skips entries that are already fully built.
-      * This eliminates the need for merge-time reconciliation of duplicate entries in the standard
-      * `parMap2`/`parMatchOn` workflow.
-      *
-      * ==Legacy: duplicate key handling with different signatures==
-      *
-      * When used with fork/join semantics (the previous default), two parallel branches could independently call
-      * `buildCachedWith` for the same key using fresh [[ValDefBuilder]] instances, each generating a different
-      * `TermName`. Rather than failing, merge keeps '''both''' definitions: the primary under the original key, and the
-      * secondary under a synthetic alias key (`"originalName$$dup$$N"`). This ensures that `toValDefs` emits both
-      * val/def declarations so references from both branches remain valid. This path is retained for backwards
-      * compatibility and for any custom `MLocal` configurations that still use fork/join semantics.
-      */
-    def merge(cache1: ValDefsCache, cache2: ValDefsCache): ValDefsCache
+    def mlocal: fp.effect.MLocal[ValDefsCache] = fp.effect.MLocal.unsafeSharedParallel(empty)
 
     // format: off
     def get0Ary[Returned: Type](cache: ValDefsCache, key: String): Option[Expr[Returned]]


### PR DESCRIPTION
… as ADT

DirectStyle bug: when evaluating a by-name MIO that calls nested runSafe, the run loop started from stale state captured before the inner runSafe modified ongoingStates. The first sync.write then overwrote inner changes.

Fix: (1) evaluate the by-name MIO before reading currentState, so the run loop starts from up-to-date state; (2) add StateSync to the run loop so that runSafe calls within function evaluations (e.g. MIO { runSafe(...) }) are also properly synced.

Also redesigns MLocal as a sealed trait ADT with two variants:
- ForkJoinParallel: existing fork/join semantics for parallel branches
- SequentialOnParallel: shared state flows through without fork/join

Removes the join parameter from unsafeSharedParallel. Updates MState to differentiate fork/join behavior by MLocal variant. Restructures buildCachedWith to wrap the eager map(builder)(f) call in MIO so that DirectStyle's state sync mechanism can track side effects from f.

Proper fix to https://github.com/MateuszKubuszok/hearth/pull/235 workaround