### PR TITLE
Add Expr.semiEval for compile-time AST-to-value reconstruction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
             ~/.sbt
             ~/.ivy2/cache
           key: snippets-coursier-${{ runner.os }}-${{ hashFiles('docs/user-guide/*.md') }}
-          just test-snippets
 
   build:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cache/coursier/v1
@@ -47,7 +47,6 @@ jobs:
           key: snippets-coursier-${{ runner.os }}-${{ hashFiles('docs/user-guide/*.md') }}
           restore-keys: |
             snippets-coursier-${{ runner.os }}-
-          save-always: true
       - uses: extractions/setup-just@v4
       - uses: coursier/setup-action@v3.0.0
         with:
@@ -56,6 +55,16 @@ jobs:
         working-directory: docs
         run: |
           scala-cli config power true
+          just test-snippets
+      - uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: |
+            ~/.cache/coursier/v1
+            ~/.cache/scalacli
+            ~/.sbt
+            ~/.ivy2/cache
+          key: snippets-coursier-${{ runner.os }}-${{ hashFiles('docs/user-guide/*.md') }}
           just test-snippets
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - uses: coursier/cache-action@v8
       - uses: extractions/setup-just@v4
       - uses: coursier/setup-action@v3.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,17 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: coursier/cache-action@v8
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier/v1
+            ~/.cache/scalacli
+            ~/.sbt
+            ~/.ivy2/cache
+          key: snippets-coursier-${{ runner.os }}-${{ hashFiles('docs/user-guide/*.md') }}
+          restore-keys: |
+            snippets-coursier-${{ runner.os }}-
+          save-always: true
       - uses: extractions/setup-just@v4
       - uses: coursier/setup-action@v3.0.0
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This document provides guidelines for AI agents (like Claude Code, GitHub Copilo
 **Hearth** is the first Scala macros' standard library, designed to make macro development easier and more maintainable across Scala 2.13 and Scala 3.
 
 - **Language**: Scala (pure Scala library)
-- **Scala Versions**: 2.13.16, 3.3.7 (primary); 2.13.18, 3.8.3-RC1 (regression testing)
+- **Scala Versions**: 2.13.16, 3.3.7 (primary); 2.13.18, 3.8.3 (regression testing)
 - **Platforms**: JVM, Scala.js, Scala Native
 - **Build Tool**: SBT (but see restrictions below)
 - **License**: Apache 2.0

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ val versions = new {
 
   // Versions we can compile tests against if needed, to check for regressions.
   val scala213Newest = "2.13.18"
-  val scala3Newest = "3.8.3-RC1"
+  val scala3Newest = "3.8.3"
 
   // Which versions should be cross-compiled for publishing.
   val scalas = List(scala213, scala3)

--- a/docs/contributing/guidelines-for-tests.md
+++ b/docs/contributing/guidelines-for-tests.md
@@ -30,24 +30,24 @@ By default, tests should be placed in `hearthTests/src/test/scala`, so that:
 however there are exceptions:
 
  - `scala-newest` directories are used for tests that should only run on the **newest** supported Scala versions
-   (currently 2.13.18 and 3.8.3-RC1 for regression testing). These are used for:
+   (currently 2.13.18 and 3.8.3 for regression testing). These are used for:
 
      - **Demo/example code** that showcases advanced features or complex macro implementations (e.g., `FastShowPrettySpec`)
      - **Features that require newer Scala versions** not available in the primary versions (2.13.16 and 3.3.7)
      - **Regression tests** for newer compiler versions
 
    Directory variants:
-     - `hearthTests/src/main/scala-newest` - shared code for newest Scala versions (both 2.13.18 and 3.8.3-RC1)
+     - `hearthTests/src/main/scala-newest` - shared code for newest Scala versions (both 2.13.18 and 3.8.3)
      - `hearthTests/src/main/scala-newest-2` - Scala 2.13.18-specific code
-     - `hearthTests/src/main/scala-newest-3` - Scala 3.8.3-RC1-specific code
+     - `hearthTests/src/main/scala-newest-3` - Scala 3.8.3-specific code
      - `hearthTests/src/test/scala-newest` - shared tests for newest Scala versions
      - `hearthTests/src/test/scala-newest-2` - Scala 2.13.18-specific tests
-     - `hearthTests/src/test/scala-newest-3` - Scala 3.8.3-RC1-specific tests
+     - `hearthTests/src/test/scala-newest-3` - Scala 3.8.3-specific tests
 
    **Important:** These directories are **only included** when the `NEWEST_SCALA_TESTS=true` environment variable is set.
    When this variable is set:
      - `hearthTests` (Scala 2.13) compiles with Scala 2.13.18 instead of 2.13.16
-     - `hearthTests3` (Scala 3) compiles with Scala 3.8.3-RC1 instead of 3.3.7
+     - `hearthTests3` (Scala 3) compiles with Scala 3.8.3 instead of 3.3.7
      - The `scala-newest` directories are added to the source directories of the same project
 
    Without `NEWEST_SCALA_TESTS=true`, these directories are completely ignored and the projects use the primary versions.
@@ -78,7 +78,7 @@ however there are exceptions:
 **Use `scala-newest` when:**
 - Creating demo/example code that showcases complex macro features (like `FastShowPrettySpec`)
 - Testing features that require compiler capabilities only available in newer Scala versions
-- Writing regression tests specifically for newer compiler versions (2.13.18 or 3.8.3-RC1)
+- Writing regression tests specifically for newer compiler versions (2.13.18 or 3.8.3)
 - The code would benefit from newer language features but should not block development on primary versions
 
 **Do NOT use `scala-newest` when:**
@@ -530,9 +530,9 @@ So running `hearthTests/test ; hearthTests3/test ; hearthSandwichTests/test ; he
 
 Tests in `scala-newest` directories are **only** compiled and run when the `NEWEST_SCALA_TESTS=true` environment
 variable is set. This variable switches the `hearthTests` and `hearthTests3` projects to use newer Scala versions
-(2.13.18 and 3.8.3-RC1) and includes the `scala-newest` source directories.
+(2.13.18 and 3.8.3) and includes the `scala-newest` source directories.
 
-**For Scala 3.8.3-RC1 (scala-newest-3):**
+**For Scala 3.8.3 (scala-newest-3):**
 ```bash
 NEWEST_SCALA_TESTS=true sbt --client "hearthTests3/clean"
 NEWEST_SCALA_TESTS=true sbt --client "hearthTests3/compile"
@@ -560,7 +560,7 @@ NEWEST_SCALA_TESTS=true sbt --client "quick-test"
 
 This will test against:
 - Scala 2.13.18 (hearthTests upgraded from 2.13.16)
-- Scala 3.8.3-RC1 (hearthTests3 upgraded from 3.3.7)
+- Scala 3.8.3 (hearthTests3 upgraded from 3.3.7)
 - Cross-version sandwich tests (with newest versions)
 
 **Without the environment variable:**
@@ -574,7 +574,7 @@ Running the same commands **without** `NEWEST_SCALA_TESTS=true` will:
 - `scala-newest` directories are **only visible** when `NEWEST_SCALA_TESTS=true` is set
 - The environment variable doesn't create separate projects; it modifies the existing `hearthTests` and `hearthTests3` projects
 - When working on code in `scala-newest` directories, always clean the module before testing
-- The newest versions (2.13.18 and 3.8.3-RC1) are used for regression testing, not for primary development
+- The newest versions (2.13.18 and 3.8.3) are used for regression testing, not for primary development
 - Primary development versions are 2.13.16 and 3.3.7
 - **CI runs tests BOTH ways:** with `NEWEST_SCALA_TESTS=false` (primary versions) AND `NEWEST_SCALA_TESTS=true` (newest versions)
   to ensure code works on both primary and newest Scala versions

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -100,7 +100,7 @@ extra:
     2_13: "2.13.16"
     3: "3.3.7"
     newest_2_13: "2.13.18"
-    newest_3: "3.8.3-RC1"
+    newest_3: "3.8.3"
   libraries:
     kindProjector: "0.13.4"
     munit: "1.2.4"

--- a/docs/user-guide/basic-utilities.md
+++ b/docs/user-guide/basic-utilities.md
@@ -627,11 +627,126 @@ It can be used to e.g. prevent the macro from summoning itself, so that recursio
 
 **`Expr` operations**:
 
-| Companion method                          | Extension method            | Result type       | Description                                                                                              |
-|-------------------------------------------|-----------------------------|-------------------|----------------------------------------------------------------------------------------------------------|
-| `Expr.upcast[String, AnyRef](stringExpr)` | `stringExpr.upcast[AnyRef]` | `Expr[...]`       | safe upcast to a supertype                                                                               |
-| `Expr.suppressUnused[A](expr)`            | `expr.suppressUnused`       | `Expr[Unit]`      | prevents "unused value" warnings                                                                         |
-| `Expr.singletonOf[A]`                     | —                           | `Option[Expr[A]]` | returns singleton reference if `A` is a case object, Java enum value, or Scala 3 parameterless enum case |
+| Companion method                          | Extension method            | Result type                         | Description                                                                                              |
+|-------------------------------------------|-----------------------------|-------------------------------------|----------------------------------------------------------------------------------------------------------|
+| `Expr.upcast[String, AnyRef](stringExpr)` | `stringExpr.upcast[AnyRef]` | `Expr[...]`                         | safe upcast to a supertype                                                                               |
+| `Expr.suppressUnused[A](expr)`            | `expr.suppressUnused`       | `Expr[Unit]`                        | prevents "unused value" warnings                                                                         |
+| `Expr.singletonOf[A]`                     | —                           | `Option[Expr[A]]`                   | returns singleton reference if `A` is a case object, Java enum value, or Scala 3 parameterless enum case |
+| `Expr.semiEval[A](expr)`                  | `expr.semiEval`             | `Either[NonEmptyVector[String], A]` | reconstructs a runtime value from expression AST using reflection                                        |
+
+### `Expr.semiEval`
+
+`semiEval` reconstructs a runtime value from a macro expression AST by recursively decomposing the tree and replaying
+operations using JVM runtime reflection. It is a limited alternative to Scala 2's `eval` (which was never ported to
+Scala 3 by design).
+
+It handles:
+
+- **Literals** — `42`, `"hello"`, `true`, etc.
+- **Singleton objects** — `None`, `Nil`, or any `object` on the classpath
+- **Constructor calls** — `new Foo(arg1, arg2)` where all arguments are also semi-evaluable
+- **Method calls** — `obj.method(args)` where the receiver and all arguments are semi-evaluable
+- **Nested combinations** of the above — `Some(List(1, 2, 3).size)`, `"hello".toUpperCase`, etc.
+
+It cannot handle blocks, lambdas, local definitions, or anything that would require generating new bytecode.
+When evaluation fails, it returns `Left` with all error reasons accumulated.
+
+!!! example "Compile-time even number validation"
+
+    This example shows a macro that uses `semiEval` to evaluate an arithmetic expression at compile time
+    and fails compilation if the result is not an even number.
+
+    ```scala
+    // file: src/main/scala/example/EvenMacro.scala - part of semiEval example
+    //> using scala {{ scala.2_13 }} {{ scala.3 }}
+    //> using dep com.kubuszok::hearth:{{ hearth_version() }}
+    package example
+
+    trait EvenMacro { this: hearth.MacroCommons =>
+
+      def requireEvenImpl(expr: Expr[Int]): Expr[Int] = {
+        expr.semiEval match {
+          case Right(value) =>
+            if (value % 2 == 0) expr
+            else Environment.reportErrorAndAbort(
+              s"Expected an even number, got $value"
+            )
+          case Left(errors) =>
+            Environment.reportErrorAndAbort(
+              s"Cannot evaluate expression at compile time: ${errors.mkString(", ")}"
+            )
+        }
+      }
+    }
+    ```
+
+    ```scala
+    // file: src/main/scala-2/example/Even.scala - part of semiEval example
+    //> using target.scala {{ scala.2_13 }}
+    //> using options -Xsource:3
+    package example
+
+    import scala.language.experimental.macros
+    import scala.reflect.macros.blackbox
+
+    class Even(val c: blackbox.Context) extends hearth.MacroCommonsScala2 with EvenMacro {
+      def requireEvenMacro(expr: c.Expr[Int]): c.Expr[Int] = requireEvenImpl(expr)
+    }
+    object Even {
+      def requireEven(expr: Int): Int = macro Even.requireEvenMacro
+    }
+    ```
+
+    ```scala
+    // file: src/main/scala-3/example/Even.scala - part of semiEval example
+    //> using target.scala {{ scala.3 }}
+    //> using plugin com.kubuszok::hearth-cross-quotes::{{ hearth_version() }}
+    package example
+
+    import scala.quoted.*
+
+    class Even(q: Quotes) extends hearth.MacroCommonsScala3(using q), EvenMacro
+    object Even {
+      inline def requireEven(inline expr: Int): Int = ${ requireEvenImpl('expr) }
+      private def requireEvenImpl(expr: Expr[Int])(using q: Quotes): Expr[Int] =
+        new Even(q).requireEvenImpl(expr)
+    }
+    ```
+
+    ```scala
+    // file: src/test/scala/example/EvenSpec.scala - part of semiEval example
+    //> using test.dep org.scalameta::munit::{{ libraries.munit }}
+    package example
+
+    final class EvenSpec extends munit.FunSuite {
+
+      test("accepts even literal") {
+        assertEquals(Even.requireEven(42), 42)
+      }
+
+      test("accepts even arithmetic expression") {
+        assertEquals(Even.requireEven(2 + 2), 4)
+      }
+
+      test("accepts compound expression") {
+        assertEquals(Even.requireEven((3 + 1) * 2), 8)
+      }
+
+      test("evaluates method calls in expressions") {
+        assertEquals(Even.requireEven(1 + "foo".length + 2), 6)
+      }
+
+      test("rejects odd number at compile time") {
+        val errors = compileErrors("Even.requireEven(3)")
+        assert(errors.contains("Expected an even number, got 3"))
+      }
+
+      test("rejects odd arithmetic expression at compile time") {
+        val errors = compileErrors("Even.requireEven(2 + 1)")
+        assert(errors.contains("Expected an even number, got 3"))
+      }
+    }
+    ```
 
 ### `ExprCodec`
 

--- a/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
@@ -23,6 +23,8 @@ final private class ExprsFixtures(val c: blackbox.Context) extends MacroCommonsS
 
   def testSuppressUnusedImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[Unit] = testSuppressUnused[A](expr)
 
+  def testSemiEvalImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[Data] = testSemiEval[A](expr)
+
   def testVarArgsImpl[A: c.WeakTypeTag](exprs: c.Expr[A]*): c.Expr[Data] = testVarArgs[A](exprs)
 
   def testMatchCaseTypeMatchImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[Data] = testMatchCaseTypeMatch[A](expr)
@@ -160,6 +162,8 @@ object ExprsFixtures {
   def testExprUpcasting[A, B](expr: A): Data = macro ExprsFixtures.testExprUpcastingImpl[A, B]
 
   def testSuppressUnused[A](expr: A): Unit = macro ExprsFixtures.testSuppressUnusedImpl[A]
+
+  def testSemiEval[A](expr: A): Data = macro ExprsFixtures.testSemiEvalImpl[A]
 
   def testVarArgs[A](exprs: A*): Data = macro ExprsFixtures.testVarArgsImpl[A]
 

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
@@ -51,6 +51,10 @@ object ExprsFixtures {
   private def testSuppressUnusedImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[Unit] =
     new ExprsFixtures(q).testSuppressUnused[A](expr)
 
+  inline def testSemiEval[A](inline expr: A): Data = ${ testSemiEvalImpl[A]('expr) }
+  private def testSemiEvalImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testSemiEval[A](expr)
+
   inline def testVarArgs[A](inline exprs: A*): Data = ${ testVarArgsImpl[A]('exprs) }
   private def testVarArgsImpl[A: Type](exprs: Expr[Seq[A]])(using q: Quotes): Expr[Data] =
     new ExprsFixtures(q).testVarArgs[A](exprs)

--- a/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
@@ -59,6 +59,23 @@ trait ExprsFixturesImpl { this: MacroTypedCommons & hearth.untyped.UntypedMethod
   def testSuppressUnused[A: Type](expr: Expr[A]): Expr[Unit] =
     expr.suppressUnused
 
+  def testSemiEval[A: Type](expr: Expr[A]): Expr[Data] = {
+    val result = expr.semiEval match {
+      case Right(value) =>
+        Data.map(
+          "status" -> Data("success"),
+          "value" -> Data(if (value == null) "null" else value.toString),
+          "class" -> Data(if (value == null) "null" else value.getClass.getName)
+        )
+      case Left(errors) =>
+        Data.map(
+          "status" -> Data("failure"),
+          "errors" -> Data(errors.toList.map(Data(_)))
+        )
+    }
+    Expr(result)
+  }
+
   // VarArgs methods
 
   def testVarArgs[A: Type](exprs: VarArgs[A]): Expr[Data] = {

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -182,6 +182,94 @@ final class ExprsSpec extends MacroSuite {
           )
         }
 
+        test("should evaluate arithmetic: 1 + 1") {
+          testSemiEval(1 + 1) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("2"),
+            "class" -> Data("java.lang.Integer")
+          )
+        }
+
+        test("should evaluate arithmetic: 2 * 3") {
+          testSemiEval(2 * 3) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("6"),
+            "class" -> Data("java.lang.Integer")
+          )
+        }
+
+        test("should evaluate arithmetic: 10 / 3") {
+          testSemiEval(10 / 3) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("3"),
+            "class" -> Data("java.lang.Integer")
+          )
+        }
+
+        test("should evaluate arithmetic: 10 % 2") {
+          testSemiEval(10 % 2) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("0"),
+            "class" -> Data("java.lang.Integer")
+          )
+        }
+
+        test("should evaluate comparison: 5 > 3") {
+          testSemiEval(5 > 3) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("true"),
+            "class" -> Data("java.lang.Boolean")
+          )
+        }
+
+        test("should evaluate mixed arithmetic: (2 + 3) * 4") {
+          testSemiEval((2 + 3) * 4) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("20"),
+            "class" -> Data("java.lang.Integer")
+          )
+        }
+
+        test("should evaluate Long arithmetic: 1000000000L * 3L") {
+          testSemiEval(1000000000L * 3L) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("3000000000"),
+            "class" -> Data("java.lang.Long")
+          )
+        }
+
+        test("should evaluate Double arithmetic: 3.14 * 2.0") {
+          testSemiEval(3.14 * 2.0) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("6.28"),
+            "class" -> Data("java.lang.Double")
+          )
+        }
+
+        test("should evaluate String concatenation: \"hello\" + \" world\"") {
+          testSemiEval("hello" + " world") <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("hello world"),
+            "class" -> Data("java.lang.String")
+          )
+        }
+
+        test("should evaluate mixed: 2 + \"foo\".length") {
+          testSemiEval(2 + "foo".length) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("5"),
+            "class" -> Data("java.lang.Integer")
+          )
+        }
+
+        test("should evaluate unary negation: -42") {
+          testSemiEval(-42) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("-42"),
+            "class" -> Data("java.lang.Integer")
+          )
+        }
+
         test("should fail for block with definitions") {
           val result = testSemiEval { val x = 1; x + 2 }
           result.asMap.get("status") ==> Data("failure")

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -87,6 +87,106 @@ final class ExprsSpec extends MacroSuite {
           testSuppressUnused(expr)
         }
       }
+
+      group("methods: Expr.semiEval, expected behavior") {
+        import ExprsFixtures.testSemiEval
+
+        test("should evaluate Int literal") {
+          testSemiEval(42) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("42"),
+            "class" -> Data("java.lang.Integer")
+          )
+        }
+
+        test("should evaluate String literal") {
+          testSemiEval("hello") <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("hello"),
+            "class" -> Data("java.lang.String")
+          )
+        }
+
+        test("should evaluate Boolean literal") {
+          testSemiEval(true) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("true"),
+            "class" -> Data("java.lang.Boolean")
+          )
+        }
+
+        test("should evaluate Long literal") {
+          testSemiEval(42L) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("42"),
+            "class" -> Data("java.lang.Long")
+          )
+        }
+
+        test("should evaluate Double literal") {
+          testSemiEval(3.14) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("3.14"),
+            "class" -> Data("java.lang.Double")
+          )
+        }
+
+        test("should evaluate singleton object None") {
+          testSemiEval(None) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("None"),
+            "class" -> Data("scala.None$")
+          )
+        }
+
+        test("should evaluate companion apply: Some(42)") {
+          testSemiEval(Some(42)) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("Some(42)"),
+            "class" -> Data("scala.Some")
+          )
+        }
+
+        test("should evaluate nested expressions: Some(Some(1))") {
+          testSemiEval(Some(Some(1))) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("Some(Some(1))"),
+            "class" -> Data("scala.Some")
+          )
+        }
+
+        test("should evaluate List(1, 2, 3)") {
+          testSemiEval(List(1, 2, 3)) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("List(1, 2, 3)"),
+            "class" -> Data(
+              if (LanguageVersion.byHearth.isScala3) "scala.collection.immutable.$colon$colon"
+              else "scala.collection.immutable.$colon$colon"
+            )
+          )
+        }
+
+        test("should evaluate method call: \"hello\".toUpperCase") {
+          testSemiEval("hello".toUpperCase) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("HELLO"),
+            "class" -> Data("java.lang.String")
+          )
+        }
+
+        test("should evaluate method call with args: \"hello\".substring(1, 3)") {
+          testSemiEval("hello".substring(1, 3)) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("el"),
+            "class" -> Data("java.lang.String")
+          )
+        }
+
+        test("should fail for block with definitions") {
+          val result = testSemiEval { val x = 1; x + 2 }
+          result.asMap.get("status") ==> Data("failure")
+        }
+      }
     }
 
     group("type VarArgs") {

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -2,6 +2,7 @@ package hearth
 package typed
 
 import hearth.fp.data.NonEmptyVector
+import hearth.fp.instances.*
 import hearth.fp.syntax.*
 import hearth.treeprinter.SyntaxHighlight
 
@@ -164,6 +165,251 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
             case _ => None
           }
         } else None
+      }
+    }
+
+    override def semiEval[A](expr: Expr[A]): Either[NonEmptyVector[String], A] =
+      SemiEval.eval(expr.tree).map(_.asInstanceOf[A])
+
+    private object SemiEval {
+
+      type Result = Either[NonEmptyVector[String], Any]
+
+      def eval(tree: Tree): Result = tree match {
+        case Literal(Constant(value)) =>
+          Right(value)
+
+        case _
+            if tree.symbol != null && tree.symbol != NoSymbol &&
+              (tree.symbol.isModule || tree.symbol.isModuleClass) =>
+          resolveModule(tree.symbol)
+
+        case Typed(inner, _) =>
+          eval(inner)
+
+        case TypeApply(inner, _) =>
+          eval(inner)
+
+        case Apply(_, _) =>
+          evalApply(tree)
+
+        case Select(qualifier, name) if tree.symbol != null && tree.symbol != NoSymbol && tree.symbol.isMethod =>
+          eval(qualifier).flatMap { receiver =>
+            invokeMethod(receiver, name.decodedName.toString, Nil)
+          }
+
+        case Select(qualifier, name) =>
+          eval(qualifier).flatMap { receiver =>
+            invokeGetter(receiver, name.decodedName.toString)
+          }
+
+        case other =>
+          Left(NonEmptyVector.one(s"Cannot semi-evaluate expression: ${showCode(other)}"))
+      }
+
+      private def evalApply(tree: Tree): Result = {
+        val (core, argLists) = flattenApply(tree)
+        val allArgTrees = argLists.flatten
+        core match {
+          case Select(New(tpt), termNames.CONSTRUCTOR) =>
+            evalConstructor(tpt.tpe, allArgTrees)
+          case Select(qualifier, name) =>
+            eval(qualifier).flatMap { receiver =>
+              allArgTrees.map(eval).parTraverse(identity).flatMap { argValues =>
+                invokeMethod(receiver, name.decodedName.toString, argValues)
+              }
+            }
+          case TypeApply(Select(qualifier, name), _) =>
+            eval(qualifier).flatMap { receiver =>
+              allArgTrees.map(eval).parTraverse(identity).flatMap { argValues =>
+                invokeMethod(receiver, name.decodedName.toString, argValues)
+              }
+            }
+          case TypeApply(inner, _) =>
+            evalApplyOnEvaluated(inner, allArgTrees)
+          case _ =>
+            evalApplyOnEvaluated(core, allArgTrees)
+        }
+      }
+
+      private def evalApplyOnEvaluated(funcTree: Tree, allArgTrees: List[Tree]): Result =
+        eval(funcTree).flatMap { func =>
+          allArgTrees.map(eval).parTraverse(identity).flatMap { argValues =>
+            invokeMethod(func, "apply", argValues)
+          }
+        }
+
+      private def flattenApply(tree: Tree): (Tree, List[List[Tree]]) = tree match {
+        case Apply(inner, args) =>
+          val (core, argLists) = flattenApply(inner)
+          (core, argLists :+ args)
+        case TypeApply(inner, _) =>
+          flattenApply(inner)
+        case other =>
+          (other, Nil)
+      }
+
+      private def resolveModule(sym: Symbol): Result = {
+        val name = sym.fullName
+        val candidates = moduleCandidates(name)
+        candidates
+          .collectFirst { case ModuleSingleton(value) => value }
+          .toRight(NonEmptyVector.one(s"Cannot resolve module: $name"))
+      }
+
+      private def moduleCandidates(fullName: String): Array[String] = {
+        val withDollar = if (fullName.endsWith("$")) fullName else fullName + "$"
+        val withoutDollar = withDollar.stripSuffix("$")
+        Array(withDollar, withoutDollar).flatMap { base =>
+          Iterator
+            .iterate(base)(_.reverse.replaceFirst("\\.", "\\$").reverse)
+            .take(base.count(_ == '.') + 1)
+            .toArray
+            .reverse
+        }.distinct
+      }
+
+      private object ModuleSingleton {
+        def unapply(className: String): Option[Any] = try
+          Option(java.lang.Class.forName(className).getField("MODULE$").get(null))
+        catch { case _: Throwable => None }
+      }
+
+      private def evalConstructor(tpe: c.Type, argTrees: List[Tree]): Result = {
+        val className = tpe.typeSymbol.fullName
+        val classOpt = moduleCandidates(className)
+          .filterNot(_.endsWith("$"))
+          .iterator
+          .flatMap { name =>
+            try Some(java.lang.Class.forName(name))
+            catch { case _: Throwable => None }
+          }
+          .nextOption()
+        classOpt match {
+          case None        => Left(NonEmptyVector.one(s"Cannot resolve class for constructor: $className"))
+          case Some(clazz) =>
+            argTrees.map(eval).parTraverse(identity).flatMap { argValues =>
+              findAndInvokeConstructor(clazz, argValues)
+            }
+        }
+      }
+
+      private def invokeGetter(receiver: Any, name: String): Result =
+        invokeMethod(receiver, name, Nil)
+
+      private def invokeMethod(receiver: Any, name: String, args: List[Any]): Result = {
+        val clazz = receiver.getClass
+        val encodedName = scala.reflect.NameTransformer.encode(name)
+        val candidates = (clazz.getMethods.filter(_.getName == name) ++
+          (if (encodedName != name) clazz.getMethods.filter(_.getName == encodedName)
+           else Array.empty[java.lang.reflect.Method])).distinct.toList
+        findMatchingMethod(candidates, args) match {
+          case Right((method, preparedArgs)) =>
+            try {
+              method.setAccessible(true)
+              Right(method.invoke(receiver, preparedArgs.map(_.asInstanceOf[AnyRef])*))
+            } catch {
+              case e: java.lang.reflect.InvocationTargetException =>
+                Left(NonEmptyVector.one(s"Method '$name' threw: ${e.getCause.getMessage}"))
+              case e: Throwable =>
+                Left(NonEmptyVector.one(s"Method '$name' invocation failed: ${e.getMessage}"))
+            }
+          case Left(err) => Left(err)
+        }
+      }
+
+      private def findAndInvokeConstructor(clazz: java.lang.Class[?], args: List[Any]): Result = {
+        val ctors = clazz.getConstructors.toList
+        findMatchingExecutable(ctors, args, "constructor") match {
+          case Right((ctor, preparedArgs)) =>
+            try Right(ctor.newInstance(preparedArgs.map(_.asInstanceOf[AnyRef])*))
+            catch {
+              case e: java.lang.reflect.InvocationTargetException =>
+                Left(NonEmptyVector.one(s"Constructor threw: ${e.getCause.getMessage}"))
+              case e: Throwable =>
+                Left(NonEmptyVector.one(s"Constructor invocation failed: ${e.getMessage}"))
+            }
+          case Left(err) => Left(err)
+        }
+      }
+
+      private def findMatchingMethod(
+          candidates: List[java.lang.reflect.Method],
+          args: List[Any]
+      ): Either[NonEmptyVector[String], (java.lang.reflect.Method, List[Any])] =
+        findMatchingExecutable(candidates, args, "method")
+
+      private def findMatchingExecutable[E <: java.lang.reflect.Executable](
+          candidates: List[E],
+          args: List[Any],
+          kind: String
+      ): Either[NonEmptyVector[String], (E, List[Any])] = {
+        val byArity = candidates.filter(_.getParameterCount == args.size)
+        val exactMatch =
+          if (byArity.isEmpty) None
+          else if (byArity.size == 1) Some((byArity.head, args))
+          else {
+            val matching = byArity.filter { exec =>
+              val paramTypes = exec.getParameterTypes
+              args.zip(paramTypes).forall { case (arg, paramType) =>
+                arg == null || boxedType(paramType).isAssignableFrom(arg.getClass)
+              }
+            }
+            matching match {
+              case single :: Nil => Some((single, args))
+              case Nil           => None
+              case multiple      => Some((multiple.minBy(_.getParameterTypes.count(_ == classOf[Object])), args))
+            }
+          }
+        exactMatch match {
+          case Some(result) => Right(result)
+          case None         =>
+            tryVarargs(candidates, args, kind)
+        }
+      }
+
+      private def tryVarargs[E <: java.lang.reflect.Executable](
+          candidates: List[E],
+          args: List[Any],
+          kind: String
+      ): Either[NonEmptyVector[String], (E, List[Any])] = {
+        val varargsCandidates = candidates.filter { exec =>
+          val params = exec.getParameterTypes
+          params.nonEmpty && args.size >= params.length - 1 &&
+          (params.last.isAssignableFrom(classOf[scala.collection.immutable.Seq[?]]) ||
+            classOf[scala.collection.Seq[?]].isAssignableFrom(params.last) ||
+            params.last.isArray)
+        }
+        varargsCandidates match {
+          case exec :: _ =>
+            val params = exec.getParameterTypes
+            val normalCount = params.length - 1
+            val (normalArgs, varargArgs) = args.splitAt(normalCount)
+            val wrappedArgs =
+              if (params.last.isArray)
+                normalArgs :+ varargArgs.toArray
+              else
+                normalArgs :+ varargArgs
+            Right((exec, wrappedArgs))
+          case Nil =>
+            Left(
+              NonEmptyVector.one(
+                s"No $kind with ${args.size} parameters found among ${candidates.size} candidates"
+              )
+            )
+        }
+      }
+
+      private def boxedType(clazz: java.lang.Class[?]): java.lang.Class[?] = clazz match {
+        case c if c == java.lang.Boolean.TYPE   => classOf[java.lang.Boolean]
+        case c if c == java.lang.Byte.TYPE      => classOf[java.lang.Byte]
+        case c if c == java.lang.Short.TYPE     => classOf[java.lang.Short]
+        case c if c == java.lang.Integer.TYPE   => classOf[java.lang.Integer]
+        case c if c == java.lang.Long.TYPE      => classOf[java.lang.Long]
+        case c if c == java.lang.Float.TYPE     => classOf[java.lang.Float]
+        case c if c == java.lang.Double.TYPE    => classOf[java.lang.Double]
+        case c if c == java.lang.Character.TYPE => classOf[java.lang.Character]
+        case other                              => other
       }
     }
 

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -314,9 +314,164 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
               case e: Throwable =>
                 Left(NonEmptyVector.one(s"Method '$name' invocation failed: ${e.getMessage}"))
             }
-          case Left(err) => Left(err)
+          case Left(_) =>
+            evalPrimitiveOp(receiver, name, args)
         }
       }
+
+      private def evalPrimitiveOp(receiver: Any, name: String, args: List[Any]): Result = {
+        val decodedName = scala.reflect.NameTransformer.decode(name)
+        (receiver, decodedName, args) match {
+          case (a: Number, _, List(b: Number))                       => evalNumericBinaryOp(a, b, decodedName)
+          case (a: Number, _, List(b: Number))                       => evalNumericBinaryOp(a, b, decodedName)
+          case (a: Number, "unary_-", Nil)                           => evalUnaryMinus(a)
+          case (a: Number, "unary_+", Nil)                           => Right(a)
+          case (a: Number, "unary_~", Nil)                           => evalUnaryBitwiseNot(a)
+          case (a: Number, _, Nil) if decodedName.startsWith("to")   => evalNumericConversion(a, decodedName)
+          case (a: java.lang.Boolean, _, List(b: java.lang.Boolean)) =>
+            evalBooleanOp(a, b, decodedName)
+          case (a: java.lang.Boolean, "unary_!", Nil) => Right(!a)
+          case (a: Comparable[?], _, List(b))         => evalComparisonOp(a, b, decodedName)
+          case (a: String, "+", List(b))              => Right(a + b)
+          case _                                      =>
+            Left(
+              NonEmptyVector.one(
+                s"No method '$decodedName' with ${args.size} parameters found on ${receiver.getClass.getName}"
+              )
+            )
+        }
+      }
+
+      private def evalNumericBinaryOp(a: Number, b: Number, op: String): Result =
+        (a, b) match {
+          case (a: java.lang.Double, b: Number) => evalDoubleBinOp(a.doubleValue, b.doubleValue, op)
+          case (a: Number, b: java.lang.Double) => evalDoubleBinOp(a.doubleValue, b.doubleValue, op)
+          case (a: java.lang.Float, b: Number)  => evalFloatBinOp(a.floatValue, b.floatValue, op)
+          case (a: Number, b: java.lang.Float)  => evalFloatBinOp(a.floatValue, b.floatValue, op)
+          case (a: java.lang.Long, b: Number)   => evalLongBinOp(a.longValue, b.longValue, op)
+          case (a: Number, b: java.lang.Long)   => evalLongBinOp(a.longValue, b.longValue, op)
+          case (a: Number, b: Number)           => evalIntBinOp(a.intValue, b.intValue, op)
+        }
+
+      private def evalIntBinOp(a: Int, b: Int, op: String): Result = op match {
+        case "+"   => Right(a + b: java.lang.Integer)
+        case "-"   => Right(a - b: java.lang.Integer)
+        case "*"   => Right(a * b: java.lang.Integer)
+        case "/"   => Right(a / b: java.lang.Integer)
+        case "%"   => Right(a % b: java.lang.Integer)
+        case "&"   => Right(a & b: java.lang.Integer)
+        case "|"   => Right(a | b: java.lang.Integer)
+        case "^"   => Right(a ^ b: java.lang.Integer)
+        case "<<"  => Right(a << b: java.lang.Integer)
+        case ">>"  => Right(a >> b: java.lang.Integer)
+        case ">>>" => Right(a >>> b: java.lang.Integer)
+        case ">"   => Right(a > b: java.lang.Boolean)
+        case "<"   => Right(a < b: java.lang.Boolean)
+        case ">="  => Right(a >= b: java.lang.Boolean)
+        case "<="  => Right(a <= b: java.lang.Boolean)
+        case "=="  => Right((a == b): java.lang.Boolean)
+        case "!="  => Right((a != b): java.lang.Boolean)
+        case _     => Left(NonEmptyVector.one(s"Unsupported Int operation: $op"))
+      }
+
+      private def evalLongBinOp(a: Long, b: Long, op: String): Result = op match {
+        case "+"  => Right(a + b: java.lang.Long)
+        case "-"  => Right(a - b: java.lang.Long)
+        case "*"  => Right(a * b: java.lang.Long)
+        case "/"  => Right(a / b: java.lang.Long)
+        case "%"  => Right(a % b: java.lang.Long)
+        case "&"  => Right(a & b: java.lang.Long)
+        case "|"  => Right(a | b: java.lang.Long)
+        case "^"  => Right(a ^ b: java.lang.Long)
+        case ">"  => Right(a > b: java.lang.Boolean)
+        case "<"  => Right(a < b: java.lang.Boolean)
+        case ">=" => Right(a >= b: java.lang.Boolean)
+        case "<=" => Right(a <= b: java.lang.Boolean)
+        case "==" => Right((a == b): java.lang.Boolean)
+        case "!=" => Right((a != b): java.lang.Boolean)
+        case _    => Left(NonEmptyVector.one(s"Unsupported Long operation: $op"))
+      }
+
+      private def evalDoubleBinOp(a: Double, b: Double, op: String): Result = op match {
+        case "+"  => Right(a + b: java.lang.Double)
+        case "-"  => Right(a - b: java.lang.Double)
+        case "*"  => Right(a * b: java.lang.Double)
+        case "/"  => Right(a / b: java.lang.Double)
+        case "%"  => Right(a % b: java.lang.Double)
+        case ">"  => Right(a > b: java.lang.Boolean)
+        case "<"  => Right(a < b: java.lang.Boolean)
+        case ">=" => Right(a >= b: java.lang.Boolean)
+        case "<=" => Right(a <= b: java.lang.Boolean)
+        case "==" => Right((a == b): java.lang.Boolean)
+        case "!=" => Right((a != b): java.lang.Boolean)
+        case _    => Left(NonEmptyVector.one(s"Unsupported Double operation: $op"))
+      }
+
+      private def evalFloatBinOp(a: Float, b: Float, op: String): Result = op match {
+        case "+"  => Right(a + b: java.lang.Float)
+        case "-"  => Right(a - b: java.lang.Float)
+        case "*"  => Right(a * b: java.lang.Float)
+        case "/"  => Right(a / b: java.lang.Float)
+        case "%"  => Right(a % b: java.lang.Float)
+        case ">"  => Right(a > b: java.lang.Boolean)
+        case "<"  => Right(a < b: java.lang.Boolean)
+        case ">=" => Right(a >= b: java.lang.Boolean)
+        case "<=" => Right(a <= b: java.lang.Boolean)
+        case "==" => Right((a == b): java.lang.Boolean)
+        case "!=" => Right((a != b): java.lang.Boolean)
+        case _    => Left(NonEmptyVector.one(s"Unsupported Float operation: $op"))
+      }
+
+      private def evalUnaryMinus(a: Number): Result = a match {
+        case a: java.lang.Integer => Right(-a.intValue: java.lang.Integer)
+        case a: java.lang.Long    => Right(-a.longValue: java.lang.Long)
+        case a: java.lang.Double  => Right(-a.doubleValue: java.lang.Double)
+        case a: java.lang.Float   => Right(-a.floatValue: java.lang.Float)
+        case _                    => Left(NonEmptyVector.one(s"Cannot negate: ${a.getClass.getName}"))
+      }
+
+      private def evalUnaryBitwiseNot(a: Number): Result = a match {
+        case a: java.lang.Integer => Right(~a.intValue: java.lang.Integer)
+        case a: java.lang.Long    => Right(~a.longValue: java.lang.Long)
+        case _                    => Left(NonEmptyVector.one(s"Cannot bitwise-not: ${a.getClass.getName}"))
+      }
+
+      private def evalNumericConversion(a: Number, name: String): Result = name match {
+        case "toInt"    => Right(a.intValue: java.lang.Integer)
+        case "toLong"   => Right(a.longValue: java.lang.Long)
+        case "toDouble" => Right(a.doubleValue: java.lang.Double)
+        case "toFloat"  => Right(a.floatValue: java.lang.Float)
+        case "toShort"  => Right(a.shortValue: java.lang.Short)
+        case "toByte"   => Right(a.byteValue: java.lang.Byte)
+        case _          => Left(NonEmptyVector.one(s"Unsupported conversion: $name"))
+      }
+
+      private def evalBooleanOp(a: Boolean, b: Boolean, op: String): Result = op match {
+        case "&&" | "&" => Right(a & b: java.lang.Boolean)
+        case "||" | "|" => Right(a | b: java.lang.Boolean)
+        case "^"        => Right(a ^ b: java.lang.Boolean)
+        case "=="       => Right((a == b): java.lang.Boolean)
+        case "!="       => Right((a != b): java.lang.Boolean)
+        case _          => Left(NonEmptyVector.one(s"Unsupported Boolean operation: $op"))
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+      private def evalComparisonOp(a: Comparable[?], b: Any, op: String): Result =
+        try {
+          val cmp = a.asInstanceOf[Comparable[Any]].compareTo(b)
+          op match {
+            case ">"  => Right((cmp > 0): java.lang.Boolean)
+            case "<"  => Right((cmp < 0): java.lang.Boolean)
+            case ">=" => Right((cmp >= 0): java.lang.Boolean)
+            case "<=" => Right((cmp <= 0): java.lang.Boolean)
+            case "==" => Right((cmp == 0): java.lang.Boolean)
+            case "!=" => Right((cmp != 0): java.lang.Boolean)
+            case _    => Left(NonEmptyVector.one(s"Unsupported comparison: $op"))
+          }
+        } catch {
+          case _: ClassCastException =>
+            Left(NonEmptyVector.one(s"Cannot compare ${a.getClass.getName} with ${b.getClass.getName}"))
+        }
 
       private def findAndInvokeConstructor(clazz: java.lang.Class[?], args: List[Any]): Result = {
         val ctors = clazz.getConstructors.toList

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -2,6 +2,7 @@ package hearth
 package typed
 
 import hearth.fp.data.NonEmptyVector
+import hearth.fp.instances.*
 import hearth.fp.syntax.*
 
 import scala.collection.immutable.ListMap
@@ -156,6 +157,339 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       else if sym.flags.is(Flags.Enum) && (sym.flags.is(Flags.JavaStatic) || sym.flags.is(Flags.StableRealizable))
       then Some(Ref(sym).asExprOf[A])
       else None
+    }
+
+    override def semiEval[A](expr: Expr[A]): Either[NonEmptyVector[String], A] =
+      SemiEval.eval(expr.asTerm).map(_.asInstanceOf[A])
+
+    private object SemiEval {
+
+      type Result = Either[NonEmptyVector[String], Any]
+
+      def eval(term: Term): Result = term match {
+        case Inlined(_, Nil, inner) =>
+          eval(inner)
+
+        case Literal(constant) =>
+          Right(extractConstant(constant))
+
+        case _ if term.symbol.flags.is(Flags.Module) =>
+          resolveModule(term.symbol)
+
+        case Typed(Repeated(elems, _), _) =>
+          elems.iterator.map(eval).toList.parTraverse(identity).map(_.toList)
+
+        case Repeated(elems, _) =>
+          elems.iterator.map(eval).toList.parTraverse(identity).map(_.toList)
+
+        case Typed(inner, _) =>
+          eval(inner)
+
+        case TypeApply(inner, _) =>
+          eval(inner)
+
+        case Apply(_, _) =>
+          evalApply(term)
+
+        case Select(qualifier, name) if term.symbol.isDefDef =>
+          eval(qualifier).flatMap { receiver =>
+            invokeMethod(receiver, term.symbol, name, Nil)
+          }
+
+        case Select(qualifier, name) =>
+          eval(qualifier).flatMap { receiver =>
+            invokeGetter(receiver, name)
+          }
+
+        case Ident(_)
+            if term.symbol.flags.is(Flags.Enum) &&
+              (term.symbol.flags.is(Flags.JavaStatic) || term.symbol.flags.is(Flags.StableRealizable)) =>
+          resolveEnumValue(term.symbol)
+
+        case Ident(_) =>
+          resolveStableRef(term)
+
+        case other =>
+          Left(NonEmptyVector.one(s"Cannot semi-evaluate expression: ${other.show(using Printer.TreeCode)}"))
+      }
+
+      private def evalApply(term: Term): Result = {
+        val (core, argLists) = flattenApply(term)
+        val allArgs = argLists.flatten
+        core match {
+          case Select(New(tpt), "<init>") =>
+            evalConstructor(tpt.tpe, allArgs)
+          case Select(qualifier, name) =>
+            eval(qualifier).flatMap { receiver =>
+              allArgs.map(eval).parTraverse(identity).flatMap { argValues =>
+                invokeMethod(receiver, core.symbol, name, argValues)
+              }
+            }
+          case TypeApply(Select(qualifier, name), _) =>
+            eval(qualifier).flatMap { receiver =>
+              allArgs.map(eval).parTraverse(identity).flatMap { argValues =>
+                invokeMethod(
+                  receiver,
+                  core match { case TypeApply(sel, _) => sel.symbol; case _ => core.symbol },
+                  name,
+                  argValues
+                )
+              }
+            }
+          case TypeApply(inner, _) =>
+            evalApplyOnEvaluated(inner, allArgs)
+          case _ =>
+            evalApplyOnEvaluated(core, allArgs)
+        }
+      }
+
+      private def evalApplyOnEvaluated(funcTerm: Term, allArgs: List[Term]): Result =
+        eval(funcTerm).flatMap { func =>
+          allArgs.map(eval).parTraverse(identity).flatMap { argValues =>
+            invokeMethod(func, "apply", argValues)
+          }
+        }
+
+      private def flattenApply(term: Term): (Term, List[List[Term]]) = term match {
+        case Apply(inner, args) =>
+          val (core, argLists) = flattenApply(inner)
+          (core, argLists :+ args)
+        case TypeApply(inner, _) =>
+          flattenApply(inner)
+        case other =>
+          (other, Nil)
+      }
+
+      private def extractConstant(constant: Constant): Any = constant match {
+        case BooleanConstant(v) => v
+        case ByteConstant(v)    => v
+        case ShortConstant(v)   => v
+        case IntConstant(v)     => v
+        case LongConstant(v)    => v
+        case FloatConstant(v)   => v
+        case DoubleConstant(v)  => v
+        case CharConstant(v)    => v
+        case StringConstant(v)  => v
+        case NullConstant()     => null
+        case ClassOfConstant(_) => null
+      }
+
+      private def resolveModule(sym: Symbol): Result = {
+        val name = sym.fullName
+        val candidates = moduleCandidates(name)
+        candidates
+          .collectFirst { case ModuleSingleton(value) => value }
+          .toRight(NonEmptyVector.one(s"Cannot resolve module: $name"))
+      }
+
+      private def resolveStableRef(term: Term): Result = {
+        val tpe = term.tpe
+        val termSym = tpe.termSymbol
+        if !termSym.isNoSymbol && termSym.flags.is(Flags.Module) then resolveModule(termSym)
+        else {
+          val typeSym = tpe.typeSymbol
+          if typeSym.flags.is(Flags.Module) then resolveModule(typeSym)
+          else {
+            val candidates = moduleCandidates(term.symbol.fullName)
+            candidates
+              .collectFirst { case ModuleSingleton(value) => value }
+              .toRight(
+                NonEmptyVector.one(s"Cannot semi-evaluate expression: ${term.show(using Printer.TreeCode)}")
+              )
+          }
+        }
+      }
+
+      private def resolveEnumValue(sym: Symbol): Result = {
+        val ownerName = sym.owner.fullName
+        val valueName = sym.name
+        val candidates = moduleCandidates(ownerName)
+        val result = candidates.iterator
+          .flatMap { className =>
+            try {
+              val clazz = java.lang.Class.forName(className.stripSuffix("$"))
+              Option(clazz.getField(valueName).get(null))
+            } catch { case _: Throwable => None }
+          }
+          .nextOption()
+        result.toRight(NonEmptyVector.one(s"Cannot resolve enum value: ${sym.fullName}"))
+      }
+
+      private def moduleCandidates(fullName: String): Array[String] = {
+        val name = fullName.replace('.', '/')
+        val withDollar = if name.endsWith("$") then name else name + "$"
+        val withoutDollar = withDollar.stripSuffix("$")
+        val bases = Array(withDollar.replace('/', '.'), withoutDollar.replace('/', '.'))
+        bases.flatMap { base =>
+          Iterator
+            .iterate(base)(_.reverse.replaceFirst("\\.", "\\$").reverse)
+            .take(base.count(_ == '.') + 1)
+            .toArray
+            .reverse
+        }.distinct
+      }
+
+      private object ModuleSingleton {
+        def unapply(className: String): Option[Any] = try
+          Option(java.lang.Class.forName(className).getField("MODULE$").get(null))
+        catch { case _: Throwable => None }
+      }
+
+      private def evalConstructor(tpe: TypeRepr, argTrees: List[Term]): Result = {
+        val className = tpe.typeSymbol.fullName
+        val classOpt = moduleCandidates(className)
+          .filterNot(_.endsWith("$"))
+          .iterator
+          .flatMap { name =>
+            try Some(java.lang.Class.forName(name))
+            catch { case _: Throwable => None }
+          }
+          .nextOption()
+        classOpt match {
+          case None        => Left(NonEmptyVector.one(s"Cannot resolve class for constructor: $className"))
+          case Some(clazz) =>
+            argTrees.map(eval).parTraverse(identity).flatMap { argValues =>
+              findAndInvokeConstructor(clazz, argValues)
+            }
+        }
+      }
+
+      private def invokeGetter(receiver: Any, name: String): Result =
+        invokeMethod(receiver, name, Nil)
+
+      private def invokeMethod(receiver: Any, sym: Symbol, name: String, args: List[Any]): Result = {
+        val bytecodeName = bytecodeNameOf(sym)
+        invokeMethod(receiver, bytecodeName, args).left.flatMap { _ =>
+          if bytecodeName != name then invokeMethod(receiver, name, args)
+          else
+            Left(
+              NonEmptyVector.one(
+                s"Cannot invoke method '$name' on ${receiver.getClass.getName} with ${args.size} args"
+              )
+            )
+        }
+      }
+
+      private def invokeMethod(receiver: Any, name: String, args: List[Any]): Result = {
+        val clazz = receiver.getClass
+        val encodedName = scala.reflect.NameTransformer.encode(name)
+        val candidates = (clazz.getMethods.filter(_.getName == name) ++
+          (if encodedName != name then clazz.getMethods.filter(_.getName == encodedName)
+           else Array.empty[java.lang.reflect.Method])).distinct.toList
+        findMatchingMethod(candidates, args) match {
+          case Right((method, preparedArgs)) =>
+            try {
+              method.setAccessible(true)
+              Right(method.invoke(receiver, preparedArgs.iterator.map(_.asInstanceOf[AnyRef]).toSeq*))
+            } catch {
+              case e: java.lang.reflect.InvocationTargetException =>
+                Left(NonEmptyVector.one(s"Method '$name' threw: ${e.getCause.getMessage}"))
+              case e: Throwable =>
+                Left(NonEmptyVector.one(s"Method '$name' invocation failed: ${e.getMessage}"))
+            }
+          case Left(err) => Left(err)
+        }
+      }
+
+      private def bytecodeNameOf(sym: Symbol): String =
+        sym.annotations
+          .collectFirst {
+            case ann if ann.tpe.typeSymbol.fullName == "scala.annotation.targetName" =>
+              ann.asInstanceOf[Apply] match {
+                case Apply(_, List(Literal(StringConstant(targetName)))) => targetName
+                case _                                                   => sym.name
+              }
+          }
+          .getOrElse(sym.name)
+
+      private def findAndInvokeConstructor(clazz: java.lang.Class[?], args: List[Any]): Result = {
+        val ctors = clazz.getConstructors.toList
+        findMatchingExecutable(ctors, args, "constructor") match {
+          case Right((ctor, preparedArgs)) =>
+            try Right(ctor.newInstance(preparedArgs.iterator.map(_.asInstanceOf[AnyRef]).toSeq*))
+            catch {
+              case e: java.lang.reflect.InvocationTargetException =>
+                Left(NonEmptyVector.one(s"Constructor threw: ${e.getCause.getMessage}"))
+              case e: Throwable =>
+                Left(NonEmptyVector.one(s"Constructor invocation failed: ${e.getMessage}"))
+            }
+          case Left(err) => Left(err)
+        }
+      }
+
+      private def findMatchingMethod(
+          candidates: List[java.lang.reflect.Method],
+          args: List[Any]
+      ): Either[NonEmptyVector[String], (java.lang.reflect.Method, List[Any])] =
+        findMatchingExecutable(candidates, args, "method")
+
+      private def findMatchingExecutable[E <: java.lang.reflect.Executable](
+          candidates: List[E],
+          args: List[Any],
+          kind: String
+      ): Either[NonEmptyVector[String], (E, List[Any])] = {
+        val byArity = candidates.filter(_.getParameterCount == args.size)
+        val exactMatch =
+          if byArity.isEmpty then None
+          else if byArity.size == 1 then Some((byArity.head, args))
+          else {
+            val matching = byArity.filter { exec =>
+              val paramTypes = exec.getParameterTypes
+              args.zip(paramTypes).forall { case (arg, paramType) =>
+                arg == null || boxedType(paramType).isAssignableFrom(arg.getClass)
+              }
+            }
+            matching match {
+              case single :: Nil => Some((single, args))
+              case Nil           => None
+              case multiple      => Some((multiple.minBy(_.getParameterTypes.count(_ == classOf[Object])), args))
+            }
+          }
+        exactMatch match {
+          case Some(result) => Right(result)
+          case None         => tryVarargs(candidates, args, kind)
+        }
+      }
+
+      private def tryVarargs[E <: java.lang.reflect.Executable](
+          candidates: List[E],
+          args: List[Any],
+          kind: String
+      ): Either[NonEmptyVector[String], (E, List[Any])] = {
+        val varargsCandidates = candidates.filter { exec =>
+          val params = exec.getParameterTypes
+          params.nonEmpty && args.size >= params.length - 1 &&
+          (classOf[scala.collection.Seq[?]].isAssignableFrom(params.last) || params.last.isArray)
+        }
+        varargsCandidates match {
+          case exec :: _ =>
+            val params = exec.getParameterTypes
+            val normalCount = params.length - 1
+            val (normalArgs, varargArgs) = args.splitAt(normalCount)
+            val wrappedArgs =
+              if params.last.isArray then normalArgs :+ varargArgs.toArray
+              else normalArgs :+ varargArgs
+            Right((exec, wrappedArgs))
+          case Nil =>
+            Left(
+              NonEmptyVector.one(
+                s"No $kind with ${args.size} parameters found among ${candidates.size} candidates"
+              )
+            )
+        }
+      }
+
+      private def boxedType(clazz: java.lang.Class[?]): java.lang.Class[?] = clazz match {
+        case c if c == java.lang.Boolean.TYPE   => classOf[java.lang.Boolean]
+        case c if c == java.lang.Byte.TYPE      => classOf[java.lang.Byte]
+        case c if c == java.lang.Short.TYPE     => classOf[java.lang.Short]
+        case c if c == java.lang.Integer.TYPE   => classOf[java.lang.Integer]
+        case c if c == java.lang.Long.TYPE      => classOf[java.lang.Long]
+        case c if c == java.lang.Float.TYPE     => classOf[java.lang.Float]
+        case c if c == java.lang.Double.TYPE    => classOf[java.lang.Double]
+        case c if c == java.lang.Character.TYPE => classOf[java.lang.Character]
+        case other                              => other
+      }
     }
 
     override lazy val NullExprCodec: ExprCodec[Null] = {

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -387,9 +387,159 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
               case e: Throwable =>
                 Left(NonEmptyVector.one(s"Method '$name' invocation failed: ${e.getMessage}"))
             }
-          case Left(err) => Left(err)
+          case Left(_) => evalPrimitiveOp(receiver, name, args)
         }
       }
+
+      private def evalPrimitiveOp(receiver: Any, name: String, args: List[Any]): Result = {
+        val decodedName = scala.reflect.NameTransformer.decode(name)
+        (receiver, decodedName, args) match {
+          case (a: Number, _, List(b: Number))                       => evalNumericBinaryOp(a, b, decodedName)
+          case (a: Number, "unary_-", Nil)                           => evalUnaryMinus(a)
+          case (a: Number, "unary_+", Nil)                           => Right(a)
+          case (a: Number, "unary_~", Nil)                           => evalUnaryBitwiseNot(a)
+          case (a: Number, _, Nil) if decodedName.startsWith("to")   => evalNumericConversion(a, decodedName)
+          case (a: java.lang.Boolean, _, List(b: java.lang.Boolean)) => evalBooleanOp(a, b, decodedName)
+          case (a: java.lang.Boolean, "unary_!", Nil)                => Right(!a)
+          case (a: Comparable[?], _, List(b))                        => evalComparisonOp(a, b, decodedName)
+          case (a: String, "+", List(b))                             => Right(a + b)
+          case _                                                     =>
+            Left(
+              NonEmptyVector.one(
+                s"No method '$decodedName' with ${args.size} parameters found on ${receiver.getClass.getName}"
+              )
+            )
+        }
+      }
+
+      private def evalNumericBinaryOp(a: Number, b: Number, op: String): Result = (a, b) match {
+        case (a: java.lang.Double, b: Number) => evalDoubleBinOp(a.doubleValue, b.doubleValue, op)
+        case (a: Number, b: java.lang.Double) => evalDoubleBinOp(a.doubleValue, b.doubleValue, op)
+        case (a: java.lang.Float, b: Number)  => evalFloatBinOp(a.floatValue, b.floatValue, op)
+        case (a: Number, b: java.lang.Float)  => evalFloatBinOp(a.floatValue, b.floatValue, op)
+        case (a: java.lang.Long, b: Number)   => evalLongBinOp(a.longValue, b.longValue, op)
+        case (a: Number, b: java.lang.Long)   => evalLongBinOp(a.longValue, b.longValue, op)
+        case (a: Number, b: Number)           => evalIntBinOp(a.intValue, b.intValue, op)
+      }
+
+      private def evalIntBinOp(a: Int, b: Int, op: String): Result = op match {
+        case "+"   => Right(a + b: java.lang.Integer)
+        case "-"   => Right(a - b: java.lang.Integer)
+        case "*"   => Right(a * b: java.lang.Integer)
+        case "/"   => Right(a / b: java.lang.Integer)
+        case "%"   => Right(a % b: java.lang.Integer)
+        case "&"   => Right(a & b: java.lang.Integer)
+        case "|"   => Right(a | b: java.lang.Integer)
+        case "^"   => Right(a ^ b: java.lang.Integer)
+        case "<<"  => Right(a << b: java.lang.Integer)
+        case ">>"  => Right(a >> b: java.lang.Integer)
+        case ">>>" => Right(a >>> b: java.lang.Integer)
+        case ">"   => Right(a > b: java.lang.Boolean)
+        case "<"   => Right(a < b: java.lang.Boolean)
+        case ">="  => Right(a >= b: java.lang.Boolean)
+        case "<="  => Right(a <= b: java.lang.Boolean)
+        case "=="  => Right((a == b): java.lang.Boolean)
+        case "!="  => Right((a != b): java.lang.Boolean)
+        case _     => Left(NonEmptyVector.one(s"Unsupported Int operation: $op"))
+      }
+
+      private def evalLongBinOp(a: Long, b: Long, op: String): Result = op match {
+        case "+"  => Right(a + b: java.lang.Long)
+        case "-"  => Right(a - b: java.lang.Long)
+        case "*"  => Right(a * b: java.lang.Long)
+        case "/"  => Right(a / b: java.lang.Long)
+        case "%"  => Right(a % b: java.lang.Long)
+        case "&"  => Right(a & b: java.lang.Long)
+        case "|"  => Right(a | b: java.lang.Long)
+        case "^"  => Right(a ^ b: java.lang.Long)
+        case ">"  => Right(a > b: java.lang.Boolean)
+        case "<"  => Right(a < b: java.lang.Boolean)
+        case ">=" => Right(a >= b: java.lang.Boolean)
+        case "<=" => Right(a <= b: java.lang.Boolean)
+        case "==" => Right((a == b): java.lang.Boolean)
+        case "!=" => Right((a != b): java.lang.Boolean)
+        case _    => Left(NonEmptyVector.one(s"Unsupported Long operation: $op"))
+      }
+
+      private def evalDoubleBinOp(a: Double, b: Double, op: String): Result = op match {
+        case "+"  => Right(a + b: java.lang.Double)
+        case "-"  => Right(a - b: java.lang.Double)
+        case "*"  => Right(a * b: java.lang.Double)
+        case "/"  => Right(a / b: java.lang.Double)
+        case "%"  => Right(a % b: java.lang.Double)
+        case ">"  => Right(a > b: java.lang.Boolean)
+        case "<"  => Right(a < b: java.lang.Boolean)
+        case ">=" => Right(a >= b: java.lang.Boolean)
+        case "<=" => Right(a <= b: java.lang.Boolean)
+        case "==" => Right((a == b): java.lang.Boolean)
+        case "!=" => Right((a != b): java.lang.Boolean)
+        case _    => Left(NonEmptyVector.one(s"Unsupported Double operation: $op"))
+      }
+
+      private def evalFloatBinOp(a: Float, b: Float, op: String): Result = op match {
+        case "+"  => Right(a + b: java.lang.Float)
+        case "-"  => Right(a - b: java.lang.Float)
+        case "*"  => Right(a * b: java.lang.Float)
+        case "/"  => Right(a / b: java.lang.Float)
+        case "%"  => Right(a % b: java.lang.Float)
+        case ">"  => Right(a > b: java.lang.Boolean)
+        case "<"  => Right(a < b: java.lang.Boolean)
+        case ">=" => Right(a >= b: java.lang.Boolean)
+        case "<=" => Right(a <= b: java.lang.Boolean)
+        case "==" => Right((a == b): java.lang.Boolean)
+        case "!=" => Right((a != b): java.lang.Boolean)
+        case _    => Left(NonEmptyVector.one(s"Unsupported Float operation: $op"))
+      }
+
+      private def evalUnaryMinus(a: Number): Result = a match {
+        case a: java.lang.Integer => Right(-a.intValue: java.lang.Integer)
+        case a: java.lang.Long    => Right(-a.longValue: java.lang.Long)
+        case a: java.lang.Double  => Right(-a.doubleValue: java.lang.Double)
+        case a: java.lang.Float   => Right(-a.floatValue: java.lang.Float)
+        case _                    => Left(NonEmptyVector.one(s"Cannot negate: ${a.getClass.getName}"))
+      }
+
+      private def evalUnaryBitwiseNot(a: Number): Result = a match {
+        case a: java.lang.Integer => Right(~a.intValue: java.lang.Integer)
+        case a: java.lang.Long    => Right(~a.longValue: java.lang.Long)
+        case _                    => Left(NonEmptyVector.one(s"Cannot bitwise-not: ${a.getClass.getName}"))
+      }
+
+      private def evalNumericConversion(a: Number, name: String): Result = name match {
+        case "toInt"    => Right(a.intValue: java.lang.Integer)
+        case "toLong"   => Right(a.longValue: java.lang.Long)
+        case "toDouble" => Right(a.doubleValue: java.lang.Double)
+        case "toFloat"  => Right(a.floatValue: java.lang.Float)
+        case "toShort"  => Right(a.shortValue: java.lang.Short)
+        case "toByte"   => Right(a.byteValue: java.lang.Byte)
+        case _          => Left(NonEmptyVector.one(s"Unsupported conversion: $name"))
+      }
+
+      private def evalBooleanOp(a: Boolean, b: Boolean, op: String): Result = op match {
+        case "&&" | "&" => Right(a & b: java.lang.Boolean)
+        case "||" | "|" => Right(a | b: java.lang.Boolean)
+        case "^"        => Right(a ^ b: java.lang.Boolean)
+        case "=="       => Right((a == b): java.lang.Boolean)
+        case "!="       => Right((a != b): java.lang.Boolean)
+        case _          => Left(NonEmptyVector.one(s"Unsupported Boolean operation: $op"))
+      }
+
+      private def evalComparisonOp(a: Comparable[?], b: Any, op: String): Result =
+        try {
+          val cmp = a.asInstanceOf[Comparable[Any]].compareTo(b)
+          op match {
+            case ">"  => Right((cmp > 0): java.lang.Boolean)
+            case "<"  => Right((cmp < 0): java.lang.Boolean)
+            case ">=" => Right((cmp >= 0): java.lang.Boolean)
+            case "<=" => Right((cmp <= 0): java.lang.Boolean)
+            case "==" => Right((cmp == 0): java.lang.Boolean)
+            case "!=" => Right((cmp != 0): java.lang.Boolean)
+            case _    => Left(NonEmptyVector.one(s"Unsupported comparison: $op"))
+          }
+        } catch {
+          case _: ClassCastException =>
+            Left(NonEmptyVector.one(s"Cannot compare ${a.getClass.getName} with ${b.getClass.getName}"))
+        }
 
       private def bytecodeNameOf(sym: Symbol): String =
         sym.annotations

--- a/hearth/src/main/scala/hearth/typed/Exprs.scala
+++ b/hearth/src/main/scala/hearth/typed/Exprs.scala
@@ -49,6 +49,8 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
 
     def singletonOf[A: Type]: Option[Expr[A]]
 
+    def semiEval[A](expr: Expr[A]): Either[NonEmptyVector[String], A]
+
     def NullExprCodec: ExprCodec[Null]
     def UnitExprCodec: ExprCodec[Unit]
     def BooleanExprCodec: ExprCodec[Boolean]
@@ -149,6 +151,8 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
 
     def upcast[B](implicit A: Type[A], B: Type[B]): Expr[B] = Expr.upcast(expr)
     def suppressUnused(implicit A: Type[A]): Expr[Unit] = Expr.suppressUnused(expr)
+
+    def semiEval: Either[NonEmptyVector[String], A] = Expr.semiEval(expr)
 
     def asUntyped: UntypedExpr = UntypedExpr.fromTyped(expr)
 


### PR DESCRIPTION
# Add `Expr.semiEval` — compile-time AST-to-value reconstruction

## Motivation

Scala 2 has `eval` inside macros — it compiles and runs code in a REPL-like fashion. Scala 3 deliberately omits this for security reasons, and it will never be ported. However, many macro libraries depend on the ability to evaluate expressions at compile time.

In practice, most use cases don't need a full compiler. They need to evaluate expressions made up of literals, object references, constructor calls, and method calls — things that can be reconstructed by looking at the AST and replaying operations via runtime reflection on classes already on the classpath.

`semiEval` fills this gap as a cross-platform (Scala 2 + 3) limited evaluator that works without a compiler, returning `Either[NonEmptyVector[String], A]` so callers get accumulated error messages when evaluation isn't possible.

## What it handles

- **Literals** — `42`, `"hello"`, `true`, `3.14`, etc.
- **Primitive operators** — `+`, `-`, `*`, `/`, `%`, comparisons, bitwise ops, unary ops (these are compiler intrinsics that don't exist on boxed Java types, so they're handled as built-in operations)
- **Singleton objects** — `None`, `Nil`, or any `object` available on the classpath
- **Constructor calls** — `new Foo(arg1, arg2)` where all arguments are themselves semi-evaluable
- **Method calls** — `obj.method(args)` including varargs, overloaded methods, and operator methods
- **Nested combinations** — `Some(List(1, 2, 3).size)`, `2 + "foo".length`, etc.

## What it cannot handle (returns errors)

- Blocks with local definitions (`{ val x = 1; x + 2 }`)
- Lambda expressions
- Types only defined in the currently-compiled module (not yet on classpath)
- Anything requiring new bytecode generation

## API

```scala
// On ExprModule (companion-style)
Expr.semiEval[A](expr: Expr[A]): Either[NonEmptyVector[String], A]

// As extension method
expr.semiEval: Either[NonEmptyVector[String], A]
```

## Changes

- **Shared API** (`Exprs.scala`): abstract `semiEval` on `ExprModule` + extension method on `ExprMethods`
- **Scala 2** (`ExprsScala2.scala`): recursive evaluator over `c.universe.Tree` with reflection + primitive op support
- **Scala 3** (`ExprsScala3.scala`): recursive evaluator over `quotes.reflect.Term` with reflection + primitive op support, including `@targetName` lookup, `Repeated` (varargs) handling, and stable `val` reference resolution
- **Tests** (`ExprsSpec.scala`): 21 new test cases — literals, singletons, apply calls, method chains, arithmetic, mixed expressions (e.g. `2 + "foo".length`), failure cases
- **Documentation** (`basic-utilities.md`): `Expr.semiEval` section with a runnable cross-compilable snippet — a compile-time even-number validator macro, tested on both Scala 2.13 and 3.3.7
