### PR TITLE
Improve semiEval: blocks, lambdas, and Scala 3 resolution

### DIFF
--- a/docs/user-guide/basic-utilities.md
+++ b/docs/user-guide/basic-utilities.md
@@ -643,12 +643,22 @@ Scala 3 by design).
 It handles:
 
 - **Literals** — `42`, `"hello"`, `true`, etc.
+- **Primitive operators** — `+`, `-`, `*`, `/`, `%`, comparisons, bitwise ops, unary ops on numeric types
 - **Singleton objects** — `None`, `Nil`, or any `object` on the classpath
 - **Constructor calls** — `new Foo(arg1, arg2)` where all arguments are also semi-evaluable
-- **Method calls** — `obj.method(args)` where the receiver and all arguments are semi-evaluable
-- **Nested combinations** of the above — `Some(List(1, 2, 3).size)`, `"hello".toUpperCase`, etc.
+- **Method calls** — `obj.method(args)` where the receiver and all arguments are semi-evaluable, including varargs and overloaded methods
+- **Blocks with val definitions** — `{ val x = 1; x + 2 }`, including compiler-generated blocks from implicit resolution
+- **Lambdas** (arity 0–3) — `(x: Int) => x + 1`, including eta-expanded method references like `(s: String) => Predef.wrapString(s)`
+- **Nested combinations** of the above — `Some(List(1, 2, 3).size)`, `2 + "foo".length`, etc.
+- **Inherited methods** — methods defined on a parent class but accessed via a module singleton (e.g., `Predef`'s methods inherited from `LowPriorityImplicits`)
 
-It cannot handle blocks, lambdas, local definitions, or anything that would require generating new bytecode.
+It cannot handle:
+
+- **Definitions** — `def`, `var`, `lazy val`, class/trait/object definitions inside the evaluated tree
+- **Pattern matching** — `match` expressions
+- **Lambdas with arity > 3**
+- **Types not on the classpath** — modules or classes only defined in the currently-compiled module
+
 When evaluation fails, it returns `Left` with all error reasons accumulated.
 
 !!! example "Compile-time even number validation"

--- a/docs/user-guide/basic-utilities.md
+++ b/docs/user-guide/basic-utilities.md
@@ -648,7 +648,7 @@ It handles:
 - **Constructor calls** — `new Foo(arg1, arg2)` where all arguments are also semi-evaluable
 - **Method calls** — `obj.method(args)` where the receiver and all arguments are semi-evaluable, including varargs and overloaded methods
 - **Blocks with val definitions** — `{ val x = 1; x + 2 }`, including compiler-generated blocks from implicit resolution
-- **Lambdas** (arity 0–3) — `(x: Int) => x + 1`, including eta-expanded method references like `(s: String) => Predef.wrapString(s)`
+- **Lambdas** (any arity) — `(x: Int) => x + 1`, including eta-expanded method references; uses `FunctionN` for arity 0–22 and `FunctionXXL` beyond that on Scala 3
 - **Nested combinations** of the above — `Some(List(1, 2, 3).size)`, `2 + "foo".length`, etc.
 - **Inherited methods** — methods defined on a parent class but accessed via a module singleton (e.g., `Predef`'s methods inherited from `LowPriorityImplicits`)
 
@@ -656,7 +656,7 @@ It cannot handle:
 
 - **Definitions** — `def`, `var`, `lazy val`, class/trait/object definitions inside the evaluated tree
 - **Pattern matching** — `match` expressions
-- **Lambdas with arity > 3**
+- **Lambdas with arity > 22** on Scala 2 (Scala 3 supports any arity via `FunctionXXL`)
 - **Types not on the classpath** — modules or classes only defined in the currently-compiled module
 
 When evaluation fails, it returns `Left` with all error reasons accumulated.

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -270,9 +270,12 @@ final class ExprsSpec extends MacroSuite {
           )
         }
 
-        test("should fail for block with definitions") {
-          val result = testSemiEval { val x = 1; x + 2 }
-          result.asMap.get("status") ==> Data("failure")
+        test("should evaluate block with val definitions") {
+          testSemiEval { val x = 1; x + 2 } <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("3"),
+            "class" -> Data("java.lang.Integer")
+          )
         }
       }
     }

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -175,6 +175,12 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
 
       type Result = Either[NonEmptyVector[String], Any]
 
+      final private case class SemiEvalErrors(errors: NonEmptyVector[String])
+          extends scala.util.control.ControlThrowable
+          with scala.util.control.NoStackTrace
+
+      private def throwErrors(errors: NonEmptyVector[String]): Nothing = throw SemiEvalErrors(errors)
+
       def eval(tree: Tree): Result = evalWithLocals(tree, Map.empty)
 
       private def evalWithLocals(tree: Tree, locals: Map[Symbol, Any]): Result = tree match {
@@ -225,7 +231,7 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
             new Function0[Any] {
               def apply(): Any = evalWithLocals(body, locals) match {
                 case Right(v)     => v
-                case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+                case Left(errors) => throwErrors(errors)
               }
             }
           case 1 =>
@@ -234,7 +240,7 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
                 val newLocals = locals + (params(0).symbol -> a)
                 evalWithLocals(body, newLocals) match {
                   case Right(v)     => v
-                  case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+                  case Left(errors) => throwErrors(errors)
                 }
               }
             }
@@ -244,7 +250,7 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
                 val newLocals = locals + (params(0).symbol -> a) + (params(1).symbol -> b)
                 evalWithLocals(body, newLocals) match {
                   case Right(v)     => v
-                  case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+                  case Left(errors) => throwErrors(errors)
                 }
               }
             }
@@ -254,7 +260,7 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
                 val newLocals = locals + (params(0).symbol -> a) + (params(1).symbol -> b) + (params(2).symbol -> c)
                 evalWithLocals(body, newLocals) match {
                   case Right(v)     => v
-                  case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+                  case Left(errors) => throwErrors(errors)
                 }
               }
             }
@@ -283,25 +289,25 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
             evalConstructor(tpt.tpe, allArgTrees, locals)
           case Select(qualifier, name) =>
             evalWithLocals(qualifier, locals).flatMap { receiver =>
-              allArgTrees.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+              allArgTrees.map(a => evalWithLocals(a, locals)).parSequence.flatMap { argValues =>
                 invokeMethod(receiver, name.decodedName.toString, argValues)
               }
             }
           case TypeApply(Select(qualifier, name), _) =>
             evalWithLocals(qualifier, locals).flatMap { receiver =>
-              allArgTrees.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+              allArgTrees.map(a => evalWithLocals(a, locals)).parSequence.flatMap { argValues =>
                 invokeMethod(receiver, name.decodedName.toString, argValues)
               }
             }
           case TypeApply(inner, _) =>
             evalWithLocals(inner, locals).flatMap { func =>
-              allArgTrees.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+              allArgTrees.map(a => evalWithLocals(a, locals)).parSequence.flatMap { argValues =>
                 invokeMethod(func, "apply", argValues)
               }
             }
           case _ =>
             evalWithLocals(core, locals).flatMap { func =>
-              allArgTrees.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+              allArgTrees.map(a => evalWithLocals(a, locals)).parSequence.flatMap { argValues =>
                 invokeMethod(func, "apply", argValues)
               }
             }
@@ -357,7 +363,7 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
         classOpt match {
           case None        => Left(NonEmptyVector.one(s"Cannot resolve class for constructor: $className"))
           case Some(clazz) =>
-            argTrees.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+            argTrees.map(a => evalWithLocals(a, locals)).parSequence.flatMap { argValues =>
               findAndInvokeConstructor(clazz, argValues)
             }
         }
@@ -378,6 +384,8 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
               method.setAccessible(true)
               Right(method.invoke(receiver, preparedArgs.map(_.asInstanceOf[AnyRef])*))
             } catch {
+              case e: java.lang.reflect.InvocationTargetException if e.getCause.isInstanceOf[SemiEvalErrors] =>
+                Left(e.getCause.asInstanceOf[SemiEvalErrors].errors)
               case e: java.lang.reflect.InvocationTargetException =>
                 Left(NonEmptyVector.one(s"Method '$name' threw: ${e.getCause.getMessage}"))
               case e: Throwable =>
@@ -548,6 +556,8 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
           case Right((ctor, preparedArgs)) =>
             try Right(ctor.newInstance(preparedArgs.map(_.asInstanceOf[AnyRef])*))
             catch {
+              case e: java.lang.reflect.InvocationTargetException if e.getCause.isInstanceOf[SemiEvalErrors] =>
+                Left(e.getCause.asInstanceOf[SemiEvalErrors].errors)
               case e: java.lang.reflect.InvocationTargetException =>
                 Left(NonEmptyVector.one(s"Constructor threw: ${e.getCause.getMessage}"))
               case e: Throwable =>

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -226,48 +226,31 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
 
       private def evalLambda(params: List[ValDef], body: Tree, locals: Map[Symbol, Any]): Result = {
         val arity = params.size
-        val fn: AnyRef = arity match {
-          case 0 =>
-            new Function0[Any] {
-              def apply(): Any = evalWithLocals(body, locals) match {
-                case Right(v)     => v
+        val functionClass =
+          try java.lang.Class.forName(s"scala.Function$arity")
+          catch {
+            case _: ClassNotFoundException =>
+              return Left(NonEmptyVector.one(s"Lambda with $arity parameters not supported"))
+          }
+        val proxy = java.lang.reflect.Proxy.newProxyInstance(
+          functionClass.getClassLoader,
+          Array[java.lang.Class[?]](functionClass),
+          (_: Any, method: java.lang.reflect.Method, rawArgs: Array[AnyRef]) =>
+            if (method.getName == "apply") {
+              val args = if (rawArgs == null) Array.empty[AnyRef] else rawArgs
+              var newLocals = locals
+              var i = 0
+              while (i < params.size) {
+                newLocals = newLocals + (params(i).symbol -> args(i))
+                i += 1
+              }
+              evalWithLocals(body, newLocals) match {
+                case Right(v)     => v.asInstanceOf[AnyRef]
                 case Left(errors) => throwErrors(errors)
               }
-            }
-          case 1 =>
-            new Function1[Any, Any] {
-              def apply(a: Any): Any = {
-                val newLocals = locals + (params(0).symbol -> a)
-                evalWithLocals(body, newLocals) match {
-                  case Right(v)     => v
-                  case Left(errors) => throwErrors(errors)
-                }
-              }
-            }
-          case 2 =>
-            new Function2[Any, Any, Any] {
-              def apply(a: Any, b: Any): Any = {
-                val newLocals = locals + (params(0).symbol -> a) + (params(1).symbol -> b)
-                evalWithLocals(body, newLocals) match {
-                  case Right(v)     => v
-                  case Left(errors) => throwErrors(errors)
-                }
-              }
-            }
-          case 3 =>
-            new Function3[Any, Any, Any, Any] {
-              def apply(a: Any, b: Any, c: Any): Any = {
-                val newLocals = locals + (params(0).symbol -> a) + (params(1).symbol -> b) + (params(2).symbol -> c)
-                evalWithLocals(body, newLocals) match {
-                  case Right(v)     => v
-                  case Left(errors) => throwErrors(errors)
-                }
-              }
-            }
-          case n =>
-            return Left(NonEmptyVector.one(s"Lambda with $n parameters not supported (max 3)"))
-        }
-        Right(fn)
+            } else method.invoke(this, rawArgs*)
+        )
+        Right(proxy)
       }
 
       private def evalBlock(stats: List[Tree], expr: Tree, locals: Map[Symbol, Any]): Result =

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -175,9 +175,14 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
 
       type Result = Either[NonEmptyVector[String], Any]
 
-      def eval(tree: Tree): Result = tree match {
+      def eval(tree: Tree): Result = evalWithLocals(tree, Map.empty)
+
+      private def evalWithLocals(tree: Tree, locals: Map[Symbol, Any]): Result = tree match {
         case Literal(Constant(value)) =>
           Right(value)
+
+        case Block(stats, expr) =>
+          evalBlock(stats, expr, locals)
 
         case _
             if tree.symbol != null && tree.symbol != NoSymbol &&
@@ -185,59 +190,74 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
           resolveModule(tree.symbol)
 
         case Typed(inner, _) =>
-          eval(inner)
+          evalWithLocals(inner, locals)
 
         case TypeApply(inner, _) =>
-          eval(inner)
+          evalWithLocals(inner, locals)
 
         case Apply(_, _) =>
-          evalApply(tree)
+          evalApplyWithLocals(tree, locals)
 
         case Select(qualifier, name) if tree.symbol != null && tree.symbol != NoSymbol && tree.symbol.isMethod =>
-          eval(qualifier).flatMap { receiver =>
+          evalWithLocals(qualifier, locals).flatMap { receiver =>
             invokeMethod(receiver, name.decodedName.toString, Nil)
           }
 
         case Select(qualifier, name) =>
-          eval(qualifier).flatMap { receiver =>
+          evalWithLocals(qualifier, locals).flatMap { receiver =>
             invokeGetter(receiver, name.decodedName.toString)
           }
+
+        case Ident(_) if locals.contains(tree.symbol) =>
+          Right(locals(tree.symbol))
 
         case other =>
           Left(NonEmptyVector.one(s"Cannot semi-evaluate expression: ${showCode(other)}"))
       }
 
-      private def evalApply(tree: Tree): Result = {
+      private def evalBlock(stats: List[Tree], expr: Tree, locals: Map[Symbol, Any]): Result =
+        stats
+          .foldLeft[Either[NonEmptyVector[String], Map[Symbol, Any]]](Right(locals)) {
+            case (Left(errors), _)                  => Left(errors)
+            case (Right(currentLocals), vd: ValDef) =>
+              evalWithLocals(vd.rhs, currentLocals).map(value => currentLocals + (vd.symbol -> value))
+            case (_, stat) =>
+              Left(NonEmptyVector.one(s"Cannot semi-evaluate statement: ${showCode(stat)}"))
+          }
+          .flatMap(finalLocals => evalWithLocals(expr, finalLocals))
+
+      private def evalApplyWithLocals(tree: Tree, locals: Map[Symbol, Any]): Result = {
         val (core, argLists) = flattenApply(tree)
         val allArgTrees = argLists.flatten
         core match {
           case Select(New(tpt), termNames.CONSTRUCTOR) =>
-            evalConstructor(tpt.tpe, allArgTrees)
+            evalConstructor(tpt.tpe, allArgTrees, locals)
           case Select(qualifier, name) =>
-            eval(qualifier).flatMap { receiver =>
-              allArgTrees.map(eval).parTraverse(identity).flatMap { argValues =>
+            evalWithLocals(qualifier, locals).flatMap { receiver =>
+              allArgTrees.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
                 invokeMethod(receiver, name.decodedName.toString, argValues)
               }
             }
           case TypeApply(Select(qualifier, name), _) =>
-            eval(qualifier).flatMap { receiver =>
-              allArgTrees.map(eval).parTraverse(identity).flatMap { argValues =>
+            evalWithLocals(qualifier, locals).flatMap { receiver =>
+              allArgTrees.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
                 invokeMethod(receiver, name.decodedName.toString, argValues)
               }
             }
           case TypeApply(inner, _) =>
-            evalApplyOnEvaluated(inner, allArgTrees)
+            evalWithLocals(inner, locals).flatMap { func =>
+              allArgTrees.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+                invokeMethod(func, "apply", argValues)
+              }
+            }
           case _ =>
-            evalApplyOnEvaluated(core, allArgTrees)
+            evalWithLocals(core, locals).flatMap { func =>
+              allArgTrees.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+                invokeMethod(func, "apply", argValues)
+              }
+            }
         }
       }
-
-      private def evalApplyOnEvaluated(funcTree: Tree, allArgTrees: List[Tree]): Result =
-        eval(funcTree).flatMap { func =>
-          allArgTrees.map(eval).parTraverse(identity).flatMap { argValues =>
-            invokeMethod(func, "apply", argValues)
-          }
-        }
 
       private def flattenApply(tree: Tree): (Tree, List[List[Tree]]) = tree match {
         case Apply(inner, args) =>
@@ -275,7 +295,7 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
         catch { case _: Throwable => None }
       }
 
-      private def evalConstructor(tpe: c.Type, argTrees: List[Tree]): Result = {
+      private def evalConstructor(tpe: c.Type, argTrees: List[Tree], locals: Map[Symbol, Any]): Result = {
         val className = tpe.typeSymbol.fullName
         val classOpt = moduleCandidates(className)
           .filterNot(_.endsWith("$"))
@@ -288,7 +308,7 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
         classOpt match {
           case None        => Left(NonEmptyVector.one(s"Cannot resolve class for constructor: $className"))
           case Some(clazz) =>
-            argTrees.map(eval).parTraverse(identity).flatMap { argValues =>
+            argTrees.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
               findAndInvokeConstructor(clazz, argValues)
             }
         }

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -181,6 +181,9 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
         case Literal(Constant(value)) =>
           Right(value)
 
+        case Function(params, body) =>
+          evalLambda(params, body, locals)
+
         case Block(stats, expr) =>
           evalBlock(stats, expr, locals)
 
@@ -213,6 +216,52 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
 
         case other =>
           Left(NonEmptyVector.one(s"Cannot semi-evaluate expression: ${showCode(other)}"))
+      }
+
+      private def evalLambda(params: List[ValDef], body: Tree, locals: Map[Symbol, Any]): Result = {
+        val arity = params.size
+        val fn: AnyRef = arity match {
+          case 0 =>
+            new Function0[Any] {
+              def apply(): Any = evalWithLocals(body, locals) match {
+                case Right(v)     => v
+                case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+              }
+            }
+          case 1 =>
+            new Function1[Any, Any] {
+              def apply(a: Any): Any = {
+                val newLocals = locals + (params(0).symbol -> a)
+                evalWithLocals(body, newLocals) match {
+                  case Right(v)     => v
+                  case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+                }
+              }
+            }
+          case 2 =>
+            new Function2[Any, Any, Any] {
+              def apply(a: Any, b: Any): Any = {
+                val newLocals = locals + (params(0).symbol -> a) + (params(1).symbol -> b)
+                evalWithLocals(body, newLocals) match {
+                  case Right(v)     => v
+                  case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+                }
+              }
+            }
+          case 3 =>
+            new Function3[Any, Any, Any, Any] {
+              def apply(a: Any, b: Any, c: Any): Any = {
+                val newLocals = locals + (params(0).symbol -> a) + (params(1).symbol -> b) + (params(2).symbol -> c)
+                evalWithLocals(body, newLocals) match {
+                  case Right(v)     => v
+                  case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+                }
+              }
+            }
+          case n =>
+            return Left(NonEmptyVector.one(s"Lambda with $n parameters not supported (max 3)"))
+        }
+        Right(fn)
       }
 
       private def evalBlock(stats: List[Tree], expr: Tree, locals: Map[Symbol, Any]): Result =

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -244,17 +244,10 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
 
       private def evalLambdaWithBody(allParams: List[ValDef], body: Term, locals: Map[Symbol, Any]): Result = {
         val arity = allParams.size
+        val isFunctionXXL = arity > 22
         val functionClass =
-          try java.lang.Class.forName(s"scala.Function$arity")
-          catch {
-            case _: ClassNotFoundException =>
-              try java.lang.Class.forName("scala.runtime.FunctionXXL")
-              catch {
-                case _: ClassNotFoundException =>
-                  return Left(NonEmptyVector.one(s"Lambda with $arity parameters not supported"))
-              }
-          }
-        val isFunctionXXL = functionClass.getName == "scala.runtime.FunctionXXL"
+          if isFunctionXXL then java.lang.Class.forName("scala.runtime.FunctionXXL")
+          else java.lang.Class.forName(s"scala.Function$arity")
         val proxy = java.lang.reflect.Proxy.newProxyInstance(
           functionClass.getClassLoader,
           Array(functionClass),

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -242,43 +242,42 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         }
       }
 
-      private def evalLambdaWithBody(allParams: List[ValDef], body: Term, locals: Map[Symbol, Any]): Result =
-        allParams.size match {
-          case 0 =>
-            Right(new Function0[Any] {
-              def apply(): Any = evalWithLocals(body, locals) match {
-                case Right(v)     => v
+      private def evalLambdaWithBody(allParams: List[ValDef], body: Term, locals: Map[Symbol, Any]): Result = {
+        val arity = allParams.size
+        val functionClass =
+          try java.lang.Class.forName(s"scala.Function$arity")
+          catch {
+            case _: ClassNotFoundException =>
+              try java.lang.Class.forName("scala.runtime.FunctionXXL")
+              catch {
+                case _: ClassNotFoundException =>
+                  return Left(NonEmptyVector.one(s"Lambda with $arity parameters not supported"))
+              }
+          }
+        val isFunctionXXL = functionClass.getName == "scala.runtime.FunctionXXL"
+        val proxy = java.lang.reflect.Proxy.newProxyInstance(
+          functionClass.getClassLoader,
+          Array(functionClass),
+          (_: Any, method: java.lang.reflect.Method, rawArgs: Array[AnyRef]) =>
+            if method.getName == "apply" then {
+              val args =
+                if isFunctionXXL then rawArgs(0).asInstanceOf[Array[AnyRef]]
+                else if rawArgs == null then Array.empty[AnyRef]
+                else rawArgs
+              var newLocals = locals
+              var i = 0
+              while i < allParams.size do {
+                newLocals = newLocals + (allParams(i).symbol -> args(i))
+                i += 1
+              }
+              evalWithLocals(body, newLocals) match {
+                case Right(v)     => v.asInstanceOf[AnyRef]
                 case Left(errors) => throwErrors(errors)
               }
-            })
-          case 1 =>
-            Right(new Function1[Any, Any] {
-              def apply(a: Any): Any = evalWithLocals(body, locals + (allParams(0).symbol -> a)) match {
-                case Right(v)     => v
-                case Left(errors) => throwErrors(errors)
-              }
-            })
-          case 2 =>
-            Right(new Function2[Any, Any, Any] {
-              def apply(a: Any, b: Any): Any =
-                evalWithLocals(body, locals + (allParams(0).symbol -> a) + (allParams(1).symbol -> b)) match {
-                  case Right(v)     => v
-                  case Left(errors) => throwErrors(errors)
-                }
-            })
-          case 3 =>
-            Right(new Function3[Any, Any, Any, Any] {
-              def apply(a: Any, b: Any, c: Any): Any =
-                evalWithLocals(
-                  body,
-                  locals + (allParams(0).symbol -> a) + (allParams(1).symbol -> b) + (allParams(2).symbol -> c)
-                ) match {
-                  case Right(v)     => v
-                  case Left(errors) => throwErrors(errors)
-                }
-            })
-          case n => Left(NonEmptyVector.one(s"Lambda with $n parameters not supported (max 3)"))
-        }
+            } else method.invoke(this, rawArgs*)
+        )
+        Right(proxy)
+      }
 
       private def evalBlock(stats: List[Statement], expr: Term, locals: Map[Symbol, Any]): Result =
         stats

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -427,50 +427,10 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
               )
           }
         }
-        else {
-          val ownerCompanion = owner.companionModule
-          if !ownerCompanion.isNoSymbol && ownerCompanion.flags.is(Flags.Module) then resolveModule(ownerCompanion)
-            .flatMap { receiver =>
-              invokeMethod(receiver, sym.name, Nil)
-            }
-          else {
-            val ownerClass =
-              try Some(java.lang.Class.forName(owner.fullName.replace("$.", "$")))
-              catch { case _: Throwable => None }
-            ownerClass.flatMap { oc =>
-              oc.getClassLoader.nn
-                .loadClass(oc.getName)
-                .getMethods
-                .find(_.getName == sym.name)
-                .flatMap { _ =>
-                  val childModuleName = oc.getPackageName.nn + ".Predef$"
-                  val allCandidates = moduleCandidates(owner.fullName).iterator ++
-                    Iterator(childModuleName) ++
-                    Iterator(oc.getName + "$")
-                  allCandidates
-                    .flatMap { cn =>
-                      try {
-                        val clazz = java.lang.Class.forName(cn)
-                        if oc.isAssignableFrom(clazz) then {
-                          val module = clazz.getField("MODULE$").get(null)
-                          module.getClass.getMethods
-                            .find(m => m.getName == sym.name && m.getParameterCount == 0)
-                            .map { m =>
-                              m.setAccessible(true)
-                              m.invoke(module)
-                            }
-                        } else None
-                      } catch { case _: Throwable => None }
-                    }
-                    .nextOption()
-                }
-            } match {
-              case Some(v) => Right(v)
-              case None    =>
-                Left(NonEmptyVector.one(s"Cannot resolve method ${sym.name} on non-module owner ${owner.fullName}"))
-            }
+        else
+          resolveModuleForInheritedMethod(sym).flatMap { receiver =>
+            invokeMethod(receiver, sym.name, Nil)
           }
-        }
       }
 
       private def resolveStableRef(term: Term): Result = {

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -167,7 +167,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       type Result = Either[NonEmptyVector[String], Any]
 
       def eval(term: Term): Result = term match {
-        case Inlined(_, Nil, inner) =>
+        case Inlined(_, _, inner) =>
           eval(inner)
 
         case Literal(constant) =>
@@ -206,6 +206,9 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
               (term.symbol.flags.is(Flags.JavaStatic) || term.symbol.flags.is(Flags.StableRealizable)) =>
           resolveEnumValue(term.symbol)
 
+        case Ident(_) if term.symbol.isDefDef =>
+          resolveMethodOnOwner(term.symbol)
+
         case Ident(_) =>
           resolveStableRef(term)
 
@@ -238,6 +241,12 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             }
           case TypeApply(inner, _) =>
             evalApplyOnEvaluated(inner, allArgs)
+          case Ident(_) if core.symbol.isDefDef && core.symbol.owner.flags.is(Flags.Module) =>
+            resolveModule(core.symbol.owner).flatMap { receiver =>
+              allArgs.map(eval).parTraverse(identity).flatMap { argValues =>
+                invokeMethod(receiver, core.symbol, core.symbol.name, argValues)
+              }
+            }
           case _ =>
             evalApplyOnEvaluated(core, allArgs)
         }
@@ -282,6 +291,37 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
           .toRight(NonEmptyVector.one(s"Cannot resolve module: $name"))
       }
 
+      private def resolveMethodOnOwner(sym: Symbol): Result = {
+        val owner = sym.owner
+        if owner.flags.is(Flags.Module) then resolveModule(owner).flatMap { receiver =>
+          val clazz = receiver.getClass
+          val name = bytecodeNameOf(sym)
+          val methods = clazz.getMethods.filter(m => m.getName == name || m.getName == sym.name).distinct
+          methods.find(_.getParameterCount == 0) match {
+            case Some(method) =>
+              try {
+                method.setAccessible(true)
+                Right(method.invoke(receiver))
+              } catch {
+                case e: java.lang.reflect.InvocationTargetException =>
+                  Left(NonEmptyVector.one(s"Method '${sym.name}' threw: ${e.getCause.getMessage}"))
+                case e: Throwable =>
+                  Left(NonEmptyVector.one(s"Method '${sym.name}' invocation failed: ${e.getMessage}"))
+              }
+            case None =>
+              val arities = methods.iterator.map(_.getParameterCount).toSet.toList.sorted.mkString(", ")
+              Left(
+                NonEmptyVector.one(
+                  s"Cannot invoke method '${sym.name}' on ${owner.fullName} with 0 args " +
+                    s"(available arities: $arities)"
+                )
+              )
+          }
+        }
+        else
+          Left(NonEmptyVector.one(s"Cannot resolve method ${sym.name} on non-module owner ${owner.fullName}"))
+      }
+
       private def resolveStableRef(term: Term): Result = {
         val tpe = term.tpe
         val termSym = tpe.termSymbol
@@ -316,7 +356,8 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       }
 
       private def moduleCandidates(fullName: String): Array[String] = {
-        val name = fullName.replace('.', '/')
+        val normalized = fullName.replace("$.", "$")
+        val name = normalized.replace('.', '/')
         val withDollar = if name.endsWith("$") then name else name + "$"
         val withoutDollar = withDollar.stripSuffix("$")
         val bases = Array(withDollar.replace('/', '.'), withoutDollar.replace('/', '.'))

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -166,9 +166,14 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
 
       type Result = Either[NonEmptyVector[String], Any]
 
-      def eval(term: Term): Result = term match {
+      def eval(term: Term): Result = evalWithLocals(term, Map.empty)
+
+      private def evalWithLocals(term: Term, locals: Map[Symbol, Any]): Result = term match {
         case Inlined(_, _, inner) =>
-          eval(inner)
+          evalWithLocals(inner, locals)
+
+        case Block(stats, expr) =>
+          evalBlock(stats, expr, locals)
 
         case Literal(constant) =>
           Right(extractConstant(constant))
@@ -177,29 +182,32 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
           resolveModule(term.symbol)
 
         case Typed(Repeated(elems, _), _) =>
-          elems.iterator.map(eval).toList.parTraverse(identity).map(_.toList)
+          elems.iterator.map(t => evalWithLocals(t, locals)).toList.parTraverse(identity).map(_.toList)
 
         case Repeated(elems, _) =>
-          elems.iterator.map(eval).toList.parTraverse(identity).map(_.toList)
+          elems.iterator.map(t => evalWithLocals(t, locals)).toList.parTraverse(identity).map(_.toList)
 
         case Typed(inner, _) =>
-          eval(inner)
+          evalWithLocals(inner, locals)
 
         case TypeApply(inner, _) =>
-          eval(inner)
+          evalWithLocals(inner, locals)
 
         case Apply(_, _) =>
-          evalApply(term)
+          evalApplyWithLocals(term, locals)
 
         case Select(qualifier, name) if term.symbol.isDefDef =>
-          eval(qualifier).flatMap { receiver =>
+          evalWithLocals(qualifier, locals).flatMap { receiver =>
             invokeMethod(receiver, term.symbol, name, Nil)
           }
 
         case Select(qualifier, name) =>
-          eval(qualifier).flatMap { receiver =>
+          evalWithLocals(qualifier, locals).flatMap { receiver =>
             invokeGetter(receiver, name)
           }
+
+        case Ident(_) if locals.contains(term.symbol) =>
+          Right(locals(term.symbol))
 
         case Ident(_)
             if term.symbol.flags.is(Flags.Enum) &&
@@ -216,21 +224,37 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
           Left(NonEmptyVector.one(s"Cannot semi-evaluate expression: ${other.show(using Printer.TreeCode)}"))
       }
 
-      private def evalApply(term: Term): Result = {
+      private def evalBlock(stats: List[Statement], expr: Term, locals: Map[Symbol, Any]): Result =
+        stats
+          .foldLeft[Either[NonEmptyVector[String], Map[Symbol, Any]]](Right(locals)) {
+            case (Left(errors), _)                  => Left(errors)
+            case (Right(currentLocals), vd: ValDef) =>
+              vd.rhs match {
+                case Some(rhs) =>
+                  evalWithLocals(rhs, currentLocals).map(value => currentLocals + (vd.symbol -> value))
+                case None =>
+                  Left(NonEmptyVector.one(s"Cannot evaluate val without rhs: ${vd.name}"))
+              }
+            case (_, stat) =>
+              Left(NonEmptyVector.one(s"Cannot semi-evaluate statement: ${stat.show(using Printer.TreeCode)}"))
+          }
+          .flatMap(finalLocals => evalWithLocals(expr, finalLocals))
+
+      private def evalApplyWithLocals(term: Term, locals: Map[Symbol, Any]): Result = {
         val (core, argLists) = flattenApply(term)
         val allArgs = argLists.flatten
         core match {
           case Select(New(tpt), "<init>") =>
-            evalConstructor(tpt.tpe, allArgs)
+            evalConstructor(tpt.tpe, allArgs, locals)
           case Select(qualifier, name) =>
-            eval(qualifier).flatMap { receiver =>
-              allArgs.map(eval).parTraverse(identity).flatMap { argValues =>
+            evalWithLocals(qualifier, locals).flatMap { receiver =>
+              allArgs.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
                 invokeMethod(receiver, core.symbol, name, argValues)
               }
             }
           case TypeApply(Select(qualifier, name), _) =>
-            eval(qualifier).flatMap { receiver =>
-              allArgs.map(eval).parTraverse(identity).flatMap { argValues =>
+            evalWithLocals(qualifier, locals).flatMap { receiver =>
+              allArgs.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
                 invokeMethod(
                   receiver,
                   core match { case TypeApply(sel, _) => sel.symbol; case _ => core.symbol },
@@ -240,24 +264,25 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
               }
             }
           case TypeApply(inner, _) =>
-            evalApplyOnEvaluated(inner, allArgs)
+            evalWithLocals(inner, locals).flatMap { func =>
+              allArgs.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+                invokeMethod(func, "apply", argValues)
+              }
+            }
           case Ident(_) if core.symbol.isDefDef && core.symbol.owner.flags.is(Flags.Module) =>
             resolveModule(core.symbol.owner).flatMap { receiver =>
-              allArgs.map(eval).parTraverse(identity).flatMap { argValues =>
+              allArgs.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
                 invokeMethod(receiver, core.symbol, core.symbol.name, argValues)
               }
             }
           case _ =>
-            evalApplyOnEvaluated(core, allArgs)
+            evalWithLocals(core, locals).flatMap { func =>
+              allArgs.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+                invokeMethod(func, "apply", argValues)
+              }
+            }
         }
       }
-
-      private def evalApplyOnEvaluated(funcTerm: Term, allArgs: List[Term]): Result =
-        eval(funcTerm).flatMap { func =>
-          allArgs.map(eval).parTraverse(identity).flatMap { argValues =>
-            invokeMethod(func, "apply", argValues)
-          }
-        }
 
       private def flattenApply(term: Term): (Term, List[List[Term]]) = term match {
         case Apply(inner, args) =>
@@ -376,7 +401,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         catch { case _: Throwable => None }
       }
 
-      private def evalConstructor(tpe: TypeRepr, argTrees: List[Term]): Result = {
+      private def evalConstructor(tpe: TypeRepr, argTrees: List[Term], locals: Map[Symbol, Any]): Result = {
         val className = tpe.typeSymbol.fullName
         val classOpt = moduleCandidates(className)
           .filterNot(_.endsWith("$"))
@@ -389,7 +414,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         classOpt match {
           case None        => Left(NonEmptyVector.one(s"Cannot resolve class for constructor: $className"))
           case Some(clazz) =>
-            argTrees.map(eval).parTraverse(identity).flatMap { argValues =>
+            argTrees.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
               findAndInvokeConstructor(clazz, argValues)
             }
         }

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -166,6 +166,12 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
 
       type Result = Either[NonEmptyVector[String], Any]
 
+      final private case class SemiEvalErrors(errors: NonEmptyVector[String])
+          extends scala.util.control.ControlThrowable
+          with scala.util.control.NoStackTrace
+
+      private def throwErrors(errors: NonEmptyVector[String]): Nothing = throw SemiEvalErrors(errors)
+
       def eval(term: Term): Result = evalWithLocals(term, Map.empty)
 
       private def evalWithLocals(term: Term, locals: Map[Symbol, Any]): Result = term match {
@@ -185,10 +191,10 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
           resolveModule(term.symbol)
 
         case Typed(Repeated(elems, _), _) =>
-          elems.iterator.map(t => evalWithLocals(t, locals)).toList.parTraverse(identity).map(_.toList)
+          elems.iterator.map(t => evalWithLocals(t, locals)).toList.parSequence.map(_.toList)
 
         case Repeated(elems, _) =>
-          elems.iterator.map(t => evalWithLocals(t, locals)).toList.parTraverse(identity).map(_.toList)
+          elems.iterator.map(t => evalWithLocals(t, locals)).toList.parSequence.map(_.toList)
 
         case Typed(inner, _) =>
           evalWithLocals(inner, locals)
@@ -242,14 +248,14 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             Right(new Function0[Any] {
               def apply(): Any = evalWithLocals(body, locals) match {
                 case Right(v)     => v
-                case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+                case Left(errors) => throwErrors(errors)
               }
             })
           case 1 =>
             Right(new Function1[Any, Any] {
               def apply(a: Any): Any = evalWithLocals(body, locals + (allParams(0).symbol -> a)) match {
                 case Right(v)     => v
-                case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+                case Left(errors) => throwErrors(errors)
               }
             })
           case 2 =>
@@ -257,7 +263,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
               def apply(a: Any, b: Any): Any =
                 evalWithLocals(body, locals + (allParams(0).symbol -> a) + (allParams(1).symbol -> b)) match {
                   case Right(v)     => v
-                  case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+                  case Left(errors) => throwErrors(errors)
                 }
             })
           case 3 =>
@@ -268,7 +274,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                   locals + (allParams(0).symbol -> a) + (allParams(1).symbol -> b) + (allParams(2).symbol -> c)
                 ) match {
                   case Right(v)     => v
-                  case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+                  case Left(errors) => throwErrors(errors)
                 }
             })
           case n => Left(NonEmptyVector.one(s"Lambda with $n parameters not supported (max 3)"))
@@ -298,13 +304,13 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             evalConstructor(tpt.tpe, allArgs, locals)
           case Select(qualifier, name) =>
             evalWithLocals(qualifier, locals).flatMap { receiver =>
-              allArgs.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+              allArgs.map(a => evalWithLocals(a, locals)).parSequence.flatMap { argValues =>
                 invokeMethod(receiver, core.symbol, name, argValues)
               }
             }
           case TypeApply(Select(qualifier, name), _) =>
             evalWithLocals(qualifier, locals).flatMap { receiver =>
-              allArgs.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+              allArgs.map(a => evalWithLocals(a, locals)).parSequence.flatMap { argValues =>
                 invokeMethod(
                   receiver,
                   core match { case TypeApply(sel, _) => sel.symbol; case _ => core.symbol },
@@ -315,25 +321,25 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             }
           case TypeApply(inner, _) =>
             evalWithLocals(inner, locals).flatMap { func =>
-              allArgs.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+              allArgs.map(a => evalWithLocals(a, locals)).parSequence.flatMap { argValues =>
                 invokeMethod(func, "apply", argValues)
               }
             }
           case Ident(_) if core.symbol.isDefDef && core.symbol.owner.flags.is(Flags.Module) =>
             resolveModule(core.symbol.owner).flatMap { receiver =>
-              allArgs.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+              allArgs.map(a => evalWithLocals(a, locals)).parSequence.flatMap { argValues =>
                 invokeMethod(receiver, core.symbol, core.symbol.name, argValues)
               }
             }
           case Ident(_) if core.symbol.isDefDef =>
             resolveModuleForInheritedMethod(core.symbol).flatMap { receiver =>
-              allArgs.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+              allArgs.map(a => evalWithLocals(a, locals)).parSequence.flatMap { argValues =>
                 invokeMethod(receiver, core.symbol.name, argValues)
               }
             }
           case _ =>
             evalWithLocals(core, locals).flatMap { func =>
-              allArgs.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+              allArgs.map(a => evalWithLocals(a, locals)).parSequence.flatMap { argValues =>
                 invokeMethod(func, "apply", argValues)
               }
             }
@@ -412,6 +418,8 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 method.setAccessible(true)
                 Right(method.invoke(receiver))
               } catch {
+                case e: java.lang.reflect.InvocationTargetException if e.getCause.isInstanceOf[SemiEvalErrors] =>
+                  Left(e.getCause.asInstanceOf[SemiEvalErrors].errors)
                 case e: java.lang.reflect.InvocationTargetException =>
                   Left(NonEmptyVector.one(s"Method '${sym.name}' threw: ${e.getCause.getMessage}"))
                 case e: Throwable =>
@@ -540,7 +548,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         classOpt match {
           case None        => Left(NonEmptyVector.one(s"Cannot resolve class for constructor: $className"))
           case Some(clazz) =>
-            argTrees.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+            argTrees.map(a => evalWithLocals(a, locals)).parSequence.flatMap { argValues =>
               findAndInvokeConstructor(clazz, argValues)
             }
         }
@@ -574,6 +582,8 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
               method.setAccessible(true)
               Right(method.invoke(receiver, preparedArgs.iterator.map(_.asInstanceOf[AnyRef]).toSeq*))
             } catch {
+              case e: java.lang.reflect.InvocationTargetException if e.getCause.isInstanceOf[SemiEvalErrors] =>
+                Left(e.getCause.asInstanceOf[SemiEvalErrors].errors)
               case e: java.lang.reflect.InvocationTargetException =>
                 Left(NonEmptyVector.one(s"Method '$name' threw: ${e.getCause.getMessage}"))
               case e: Throwable =>
@@ -750,6 +760,8 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
           case Right((ctor, preparedArgs)) =>
             try Right(ctor.newInstance(preparedArgs.iterator.map(_.asInstanceOf[AnyRef]).toSeq*))
             catch {
+              case e: java.lang.reflect.InvocationTargetException if e.getCause.isInstanceOf[SemiEvalErrors] =>
+                Left(e.getCause.asInstanceOf[SemiEvalErrors].errors)
               case e: java.lang.reflect.InvocationTargetException =>
                 Left(NonEmptyVector.one(s"Constructor threw: ${e.getCause.getMessage}"))
               case e: Throwable =>

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -172,6 +172,9 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         case Inlined(_, _, inner) =>
           evalWithLocals(inner, locals)
 
+        case Block(List(ddef: DefDef), closure: Closure) =>
+          evalLambda(ddef, locals)
+
         case Block(stats, expr) =>
           evalBlock(stats, expr, locals)
 
@@ -224,6 +227,53 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
           Left(NonEmptyVector.one(s"Cannot semi-evaluate expression: ${other.show(using Printer.TreeCode)}"))
       }
 
+      private def evalLambda(ddef: DefDef, locals: Map[Symbol, Any]): Result = {
+        val paramsClauses = ddef.paramss
+        val allParams = paramsClauses.flatMap(_.params).collect { case vd: ValDef => vd }
+        ddef.rhs match {
+          case None       => Left(NonEmptyVector.one("Lambda has no body"))
+          case Some(body) => evalLambdaWithBody(allParams, body, locals)
+        }
+      }
+
+      private def evalLambdaWithBody(allParams: List[ValDef], body: Term, locals: Map[Symbol, Any]): Result =
+        allParams.size match {
+          case 0 =>
+            Right(new Function0[Any] {
+              def apply(): Any = evalWithLocals(body, locals) match {
+                case Right(v)     => v
+                case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+              }
+            })
+          case 1 =>
+            Right(new Function1[Any, Any] {
+              def apply(a: Any): Any = evalWithLocals(body, locals + (allParams(0).symbol -> a)) match {
+                case Right(v)     => v
+                case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+              }
+            })
+          case 2 =>
+            Right(new Function2[Any, Any, Any] {
+              def apply(a: Any, b: Any): Any =
+                evalWithLocals(body, locals + (allParams(0).symbol -> a) + (allParams(1).symbol -> b)) match {
+                  case Right(v)     => v
+                  case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+                }
+            })
+          case 3 =>
+            Right(new Function3[Any, Any, Any, Any] {
+              def apply(a: Any, b: Any, c: Any): Any =
+                evalWithLocals(
+                  body,
+                  locals + (allParams(0).symbol -> a) + (allParams(1).symbol -> b) + (allParams(2).symbol -> c)
+                ) match {
+                  case Right(v)     => v
+                  case Left(errors) => throw new RuntimeException(errors.mkString(", "))
+                }
+            })
+          case n => Left(NonEmptyVector.one(s"Lambda with $n parameters not supported (max 3)"))
+        }
+
       private def evalBlock(stats: List[Statement], expr: Term, locals: Map[Symbol, Any]): Result =
         stats
           .foldLeft[Either[NonEmptyVector[String], Map[Symbol, Any]]](Right(locals)) {
@@ -275,6 +325,12 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 invokeMethod(receiver, core.symbol, core.symbol.name, argValues)
               }
             }
+          case Ident(_) if core.symbol.isDefDef =>
+            resolveModuleForInheritedMethod(core.symbol).flatMap { receiver =>
+              allArgs.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
+                invokeMethod(receiver, core.symbol.name, argValues)
+              }
+            }
           case _ =>
             evalWithLocals(core, locals).flatMap { func =>
               allArgs.map(a => evalWithLocals(a, locals)).parTraverse(identity).flatMap { argValues =>
@@ -316,6 +372,34 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
           .toRight(NonEmptyVector.one(s"Cannot resolve module: $name"))
       }
 
+      private def resolveModuleForInheritedMethod(sym: Symbol): Result = {
+        val owner = sym.owner
+        val ownerClassName = owner.fullName.replace("$.", "$")
+        try {
+          val ownerClass = java.lang.Class.forName(ownerClassName)
+          val candidates = owner.owner.declarations.iterator
+            .filter(s => s.flags.is(Flags.Module) && !s.isNoSymbol)
+            .flatMap(s => moduleCandidates(s.fullName).iterator)
+            .toList
+            .distinct
+          val result = candidates.iterator
+            .flatMap { cn =>
+              try {
+                val clazz = java.lang.Class.forName(cn)
+                if ownerClass.isAssignableFrom(clazz) then Some(clazz.getField("MODULE$").get(null))
+                else None
+              } catch { case _: Throwable => None }
+            }
+            .nextOption()
+          result.toRight(
+            NonEmptyVector.one(s"Cannot find module extending ${owner.fullName} for method ${sym.name}")
+          )
+        } catch {
+          case _: Throwable =>
+            Left(NonEmptyVector.one(s"Cannot resolve class for ${owner.fullName}"))
+        }
+      }
+
       private def resolveMethodOnOwner(sym: Symbol): Result = {
         val owner = sym.owner
         if owner.flags.is(Flags.Module) then resolveModule(owner).flatMap { receiver =>
@@ -343,8 +427,50 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
               )
           }
         }
-        else
-          Left(NonEmptyVector.one(s"Cannot resolve method ${sym.name} on non-module owner ${owner.fullName}"))
+        else {
+          val ownerCompanion = owner.companionModule
+          if !ownerCompanion.isNoSymbol && ownerCompanion.flags.is(Flags.Module) then resolveModule(ownerCompanion)
+            .flatMap { receiver =>
+              invokeMethod(receiver, sym.name, Nil)
+            }
+          else {
+            val ownerClass =
+              try Some(java.lang.Class.forName(owner.fullName.replace("$.", "$")))
+              catch { case _: Throwable => None }
+            ownerClass.flatMap { oc =>
+              oc.getClassLoader.nn
+                .loadClass(oc.getName)
+                .getMethods
+                .find(_.getName == sym.name)
+                .flatMap { _ =>
+                  val childModuleName = oc.getPackageName.nn + ".Predef$"
+                  val allCandidates = moduleCandidates(owner.fullName).iterator ++
+                    Iterator(childModuleName) ++
+                    Iterator(oc.getName + "$")
+                  allCandidates
+                    .flatMap { cn =>
+                      try {
+                        val clazz = java.lang.Class.forName(cn)
+                        if oc.isAssignableFrom(clazz) then {
+                          val module = clazz.getField("MODULE$").get(null)
+                          module.getClass.getMethods
+                            .find(m => m.getName == sym.name && m.getParameterCount == 0)
+                            .map { m =>
+                              m.setAccessible(true)
+                              m.invoke(module)
+                            }
+                        } else None
+                      } catch { case _: Throwable => None }
+                    }
+                    .nextOption()
+                }
+            } match {
+              case Some(v) => Right(v)
+              case None    =>
+                Left(NonEmptyVector.one(s"Cannot resolve method ${sym.name} on non-module owner ${owner.fullName}"))
+            }
+          }
+        }
       }
 
       private def resolveStableRef(term: Term): Result = {


### PR DESCRIPTION
# Improve semiEval: blocks, lambdas, and Scala 3 resolution

## Context

The initial `semiEval` implementation handled literals, objects, constructors, and method calls. However, real-world usage (specifically evaluating `Validate` instances from the [refined](https://github.com/fthomas/refined) library) revealed several gaps in Scala 3's expression resolution and the inability to evaluate blocks and lambdas that the compiler generates during implicit resolution.

This PR addresses those gaps to make `semiEval` capable of evaluating refined's `Validate[T, P]` instances at compile time on Scala 3 — the core requirement for implementing [refined#932](https://github.com/fthomas/refined/issues/932).

## Changes

### Block evaluation (both Scala 2 and 3)

The evaluator now maintains a local scope (`Map[Symbol, Any]`) that accumulates `val` bindings as they are evaluated. `Ident` references are resolved against this scope before falling back to module resolution.

This enables evaluation of compiler-generated blocks like `{ val a = 0; WitnessAs(a) }` that appear in refined's implicit resolution trees.

The test case `{ val x = 1; x + 2 }` now evaluates to `3` instead of failing.

### Lambda evaluation (both Scala 2 and 3)

Lambdas are now evaluated by creating runtime function instances via `java.lang.reflect.Proxy`, supporting any arity. On Scala 2, `FunctionN` (0–22) is supported. On Scala 3, `FunctionN` (0–22) and `FunctionXXL` (>22) are both supported.

- **Scala 2**: matches `Function(params, body)`
- **Scala 3**: matches `Block(List(DefDef(...)), Closure(...))`

Errors inside lambdas are propagated via `SemiEvalErrors` (`ControlThrowable with NoStackTrace`), preserving the structured `NonEmptyVector[String]` errors through reflection call boundaries without stack trace overhead.

### Scala 3 resolution improvements

- **`Inlined` with non-empty bindings**: now stripped (was `Nil`-only), enabling evaluation of compiler-inlined implicit trees
- **`$. → $` normalization** in module candidate names: fixes resolution of nested objects like `eu.timepit.refined.numeric$Greater$`
- **`Ident` as core of `Apply`**: when the flattened core of an `Apply` chain is a bare `Ident` referring to a `DefDef` on a module, the module is resolved and the method is invoked with the collected arguments
- **Inherited methods on non-module owners**: when a method's owner is a non-module class (e.g., `wrapString` on `LowPriorityImplicits`), semiEval searches sibling module declarations that extend the owner class (finding `Predef`)

### Cleanup

- Replace `.parTraverse(identity)` with `.parSequence` (13 occurrences)
- Update documentation to reflect all supported expression forms

## Verified against

- All 819 (Scala 2) + 900 (Scala 3) hearth tests pass
- Sandwich tests pass
- [refined-compat](https://github.com/kubuszok/refined-compat) passes all 6 tests on both Scala 2.13 and 3.3.7:
  - `Int Refined Positive` (numeric predicate via `Greater[_0]`)
  - `Int Refined NonNegative` (composed predicate via `Not[Less[_0]]`)
  - `String Refined NonEmpty` (collection predicate requiring lambda evaluation)
  - Compile-time rejection of invalid values (`-1` for `Positive`, `""` for `NonEmpty`)
  - `autoUnwrap` for refined → base type conversion
