### PR TITLE
Fix cross-quotes rassoc name collision for deeply nested :: in foldLeft

### DIFF
--- a/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
+++ b/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
@@ -895,6 +895,7 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
         }
       }
       .pipe(implicitTypeReferenceReplacer.transform)
+      .pipe(SyntheticBlockValInliner.transform)
       // Convert to String - we are assuming that showCodePretty produces correct Scala code (that cannot be said of toString or showCode)
       .tap { source =>
         if (loggingEnabled) {
@@ -936,6 +937,45 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
                      |""".stripMargin)
         }
       }
+  }
+
+  /** Inlines synthetic block vals whose RHS is a simple Ident.
+    *
+    * After SpliceReplacer runs, compiler-generated synthetic vals (e.g. `rassoc$1` from right-associative operator
+    * desugaring) have their RHS replaced with a stub Ident. When `Expr.quote` is used inside a loop (e.g. `foldLeft`),
+    * the quasiquote is compiled once but evaluated N times, producing N trees all with the same synthetic val name. At
+    * 12+ nesting levels, the Scala 2 compiler fails to resolve these duplicate names.
+    *
+    * By inlining `{ val synth = stubIdent; body(synth) }` into `body(stubIdent)`, we eliminate the val entirely.
+    */
+  private object SyntheticBlockValInliner extends Transformer {
+
+    private def isSimpleIdent(tree: Tree): Boolean = tree match {
+      case Ident(_) => true
+      case _        => false
+    }
+
+    override def transform(tree: Tree): Tree = tree match {
+      case Block(List(vd: ValDef), body) if vd.mods.hasFlag(Flag.SYNTHETIC) && isSimpleIdent(vd.rhs) =>
+        var refCount = 0
+        object counter extends Traverser {
+          override def traverse(t: Tree): Unit = t match {
+            case Ident(name) if name == vd.name => refCount += 1
+            case _                              => super.traverse(t)
+          }
+        }
+        counter.traverse(body)
+        if (refCount == 1) {
+          object replacer extends Transformer {
+            override def transform(t: Tree): Tree = t match {
+              case Ident(name) if name == vd.name => vd.rhs
+              case _                              => super.transform(t)
+            }
+          }
+          transform(replacer.transform(body))
+        } else super.transform(tree)
+      case _ => super.transform(tree)
+    }
   }
 
   /** When we replace stubs, we should be careful to e.g. not replace Something$1 before Something$10, or we will end up

--- a/hearth-tests/src/main/scala/hearth/crossquotes/CrossExprsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/CrossExprsFixturesImpl.scala
@@ -221,6 +221,21 @@ trait CrossExprsFixturesImpl { this: MacroTypedCommons =>
       }
     }
 
+    def rightAssocInFoldLeft: Expr[Data] = {
+      val elements: _root_.scala.List[Expr[_root_.java.lang.String]] =
+        (1 to 13).toList.map(i => Expr(i.toString))
+      val reversed = elements.reverse
+      val listExpr: Expr[_root_.scala.List[_root_.java.lang.String]] =
+        reversed.tail.foldLeft(
+          Expr.quote(_root_.scala.List(Expr.splice(reversed.head)))
+        ) { (accExpr, elemExpr) =>
+          Expr.quote(Expr.splice(elemExpr) :: Expr.splice(accExpr))
+        }
+      Expr.quote {
+        Data(Expr.splice(listExpr).mkString(","))
+      }
+    }
+
     Expr.quote {
       Data.map(
         "features" -> Data.map(
@@ -231,7 +246,8 @@ trait CrossExprsFixturesImpl { this: MacroTypedCommons =>
         ),
         "edgeCases" -> Data.map(
           "chainingOnSplice" -> Expr.splice(chainingOnSplice(Expr.quote(new StringBuilder), Expr("name"))),
-          "implicitTypeSubstitution" -> Expr.splice(implicitTypeSubstitution)
+          "implicitTypeSubstitution" -> Expr.splice(implicitTypeSubstitution),
+          "rightAssocInFoldLeft" -> Expr.splice(rightAssocInFoldLeft)
         )
       )
     }

--- a/hearth-tests/src/test/scala/hearth/crossquotes/CrossExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/crossquotes/CrossExprsSpec.scala
@@ -35,7 +35,8 @@ final class CrossExprsSpec extends MacroSuite {
               "fromNestedImport" -> Data("key: 1, value: onekey: 2, value: two"),
               "fromSplittedNestedImport" -> Data("key: 1, value: onekey: 2, value: two"),
               "fromSameClassImplicit" -> Data("key: 1, value: onekey: 2, value: two")
-            )
+            ),
+            "rightAssocInFoldLeft" -> Data("1,2,3,4,5,6,7,8,9,10,11,12,13")
           )
         )
       }


### PR DESCRIPTION
## Summary

- Fixes `not found: value rassoc$1` when deriving type classes for Java enums (e.g. `java.time.Month`) on Scala 2
- Root cause: cross-quotes bakes the parser's right-associative desugaring (`{ val rassoc$1 = x; y.::(rassoc$1) }`) into a quasiquote with a hardcoded `TermName("rassoc$1")`. When `Expr.quote(elem :: acc)` runs inside `foldLeft`, every iteration reuses the same name, producing 12+ levels of nested `val rassoc$1` that the compiler can't resolve
- Adds `SyntheticBlockValInliner` to the cross-quotes `convert()` pipeline: inlines synthetic block vals whose RHS is a simple Ident (always the case after `SpliceReplacer` replaces `Expr.splice` with stubs), eliminating the name from the quasiquote entirely
- Note: the previous `removeMacroSuffix` fix was irrelevant — it's not used in the cross-quotes pipeline

## Test plan

- [x] Added `rightAssocInFoldLeft` edge case to `CrossExprsFixturesImpl` — builds a 13-element list using `foldLeft` + `Expr.quote(elem :: acc)`, the exact pattern that triggered the bug
- [x] All 1741 hearth tests pass (822 Scala 2.13 + 900 Scala 3 + 19 sandwich)
- [x] Kindlings `JavaEnumSpec` passes on both Scala 2 (45 tests) and Scala 3 (48 tests) with local snapshot