### PR TITLE
Improve semiEval and validate ValDefs.createVar for inline decode loops

### DIFF
--- a/docs/user-guide/basic-utilities.md
+++ b/docs/user-guide/basic-utilities.md
@@ -645,10 +645,12 @@ It handles:
 - **Literals** — `42`, `"hello"`, `true`, etc.
 - **Primitive operators** — `+`, `-`, `*`, `/`, `%`, comparisons, bitwise ops, unary ops on numeric types
 - **Singleton objects** — `None`, `Nil`, or any `object` on the classpath
+- **Companion object members** — `MyConfig.default` (val), `MyConfig.create(42)` (def), including chained access like `MyConfig.default.value`
 - **Constructor calls** — `new Foo(arg1, arg2)` where all arguments are also semi-evaluable
 - **Method calls** — `obj.method(args)` where the receiver and all arguments are semi-evaluable, including varargs and overloaded methods
 - **Blocks with val definitions** — `{ val x = 1; x + 2 }`, including compiler-generated blocks from implicit resolution
 - **Lambdas** (any arity) — `(x: Int) => x + 1`, including eta-expanded method references; uses `FunctionN` for arity 0–22 and `FunctionXXL` beyond that on Scala 3
+- **Eta-expanded methods as function arguments** — `config.withMapper(MyUtils.transform)` where a `def` is auto-converted to a function value
 - **Nested combinations** of the above — `Some(List(1, 2, 3).size)`, `2 + "foo".length`, etc.
 - **Inherited methods** — methods defined on a parent class but accessed via a module singleton (e.g., `Predef`'s methods inherited from `LowPriorityImplicits`)
 

--- a/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
@@ -52,6 +52,8 @@ final private class ExprsFixtures(val c: blackbox.Context) extends MacroCommonsS
 
   def testValDefsCreateAndUseImpl: c.Expr[Data] = testValDefsCreateAndUse
 
+  def testValDefsVarInWhileLoopImpl: c.Expr[Data] = testValDefsVarInWhileLoop
+
   def testValDefsPartitionAndCloseImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[B] =
     testValDefsPartitionAndClose[A, B](expr)
 
@@ -186,6 +188,8 @@ object ExprsFixtures {
   def testMatchCaseTraverse[A, B](expr: A): B = macro ExprsFixtures.testMatchCaseTraverseImpl[A, B]
 
   def testValDefsCreateAndUse: Data = macro ExprsFixtures.testValDefsCreateAndUseImpl
+
+  def testValDefsVarInWhileLoop: Data = macro ExprsFixtures.testValDefsVarInWhileLoopImpl
 
   def testValDefsPartitionAndClose[A, B](expr: A): B = macro ExprsFixtures.testValDefsPartitionAndCloseImpl[A, B]
 

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
@@ -98,6 +98,10 @@ object ExprsFixtures {
   inline def testValDefsCreateAndUse: Data = ${ testValDefsCreateAndUseImpl }
   private def testValDefsCreateAndUseImpl(using q: Quotes): Expr[Data] = new ExprsFixtures(q).testValDefsCreateAndUse
 
+  inline def testValDefsVarInWhileLoop: Data = ${ testValDefsVarInWhileLoopImpl }
+  private def testValDefsVarInWhileLoopImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefsVarInWhileLoop
+
   inline def testValDefsPartitionAndClose[A, B](inline expr: A): B = ${
     testValDefsPartitionAndCloseImpl[A, B]('expr)
   }

--- a/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
@@ -252,6 +252,58 @@ trait ExprsFixturesImpl { this: MacroTypedCommons & hearth.untyped.UntypedMethod
     }
   }
 
+  def testValDefsVarInWhileLoop: Expr[Data] = {
+    implicit val intType: Type[Int] = IntType
+    implicit val stringType: Type[String] = StringType
+
+    val simpleLoop: Expr[Int] = ValDefs.createVar[Int](Expr(0), "_n").use { case (n, setN) =>
+      Expr.quote {
+        var i = 0
+        while (i < 5) {
+          Expr.splice(setN(Expr.quote(Expr.splice(n) + 1)))
+          i += 1
+        }
+        Expr.splice(n)
+      }
+    }
+
+    val dispatchResult: Expr[Int] = {
+      val countVar = ValDefs.createVar[Int](Expr(0), "_count")
+      val keyVar = ValDefs.createVar[String](Expr(""), "_key")
+
+      ValDefsTraverse
+        .map2(countVar, keyVar) { case ((countGet, countSet), (keyGet, keySet)) =>
+          (countGet, countSet, keyGet, keySet)
+        }
+        .use { case (countGet, countSet, keyGet, keySet) =>
+          val dispatch: Expr[Unit] = Expr.quote {
+            if (Expr.splice(keyGet) == "increment")
+              Expr.splice(countSet(Expr.quote(Expr.splice(countGet) + 1)))
+            else ()
+          }
+
+          Expr.quote {
+            Expr.splice(keySet(Expr("increment")))
+            Expr.splice(dispatch)
+            Expr.splice(keySet(Expr("skip")))
+            Expr.splice(dispatch)
+            Expr.splice(keySet(Expr("increment")))
+            Expr.splice(dispatch)
+            Expr.splice(keySet(Expr("increment")))
+            Expr.splice(dispatch)
+            Expr.splice(countGet)
+          }
+        }
+    }
+
+    Expr.quote {
+      Data.map(
+        "simpleLoop" -> Data(Expr.splice(simpleLoop)),
+        "dispatchResult" -> Data(Expr.splice(dispatchResult))
+      )
+    }
+  }
+
   def testValDefsPartitionAndClose[A: Type, B: Type](expr: Expr[A]): Expr[B] = {
     val either = ValDefs.createDef(expr, "a").partition { a =>
       if (Type[A] <:< Type.of[AnyRef] && Type[B] <:< Type.of[AnyRef]) Right {
@@ -2320,6 +2372,7 @@ trait ExprsFixturesImpl { this: MacroTypedCommons & hearth.untyped.UntypedMethod
   // types using in fixtures
 
   private val IntType = Type.of[Int]
+  private val StringType = Type.of[String]
   private val UnitType = Type.of[Unit]
   private val DataType = Type.of[Data]
   private val IntFunctionType = Type.of[Int => Int]

--- a/hearth-tests/src/main/scala/hearth/typed/SemiEvalFixtures.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/SemiEvalFixtures.scala
@@ -1,0 +1,15 @@
+package hearth
+package typed
+
+case class SemiEvalConfig(value: Int, name: String) {
+
+  def withMapper(f: String => String): String = f(name)
+}
+object SemiEvalConfig {
+
+  val default: SemiEvalConfig = SemiEvalConfig(0, "default")
+
+  def create(value: Int): SemiEvalConfig = SemiEvalConfig(value, "created")
+
+  def transform(s: String): String = s.toUpperCase
+}

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -277,6 +277,46 @@ final class ExprsSpec extends MacroSuite {
             "class" -> Data("java.lang.Integer")
           )
         }
+
+        test("should evaluate companion object val: SemiEvalConfig.default") {
+          testSemiEval(SemiEvalConfig.default) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("SemiEvalConfig(0,default)"),
+            "class" -> Data("hearth.typed.SemiEvalConfig")
+          )
+        }
+
+        test("should evaluate chained access on companion val: SemiEvalConfig.default.value") {
+          testSemiEval(SemiEvalConfig.default.value) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("0"),
+            "class" -> Data("java.lang.Integer")
+          )
+        }
+
+        test("should evaluate companion object def call: SemiEvalConfig.create(42)") {
+          testSemiEval(SemiEvalConfig.create(42)) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("SemiEvalConfig(42,created)"),
+            "class" -> Data("hearth.typed.SemiEvalConfig")
+          )
+        }
+
+        test("should evaluate companion object method call with args: SemiEvalConfig.transform(\"hello\")") {
+          testSemiEval(SemiEvalConfig.transform("hello")) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("HELLO"),
+            "class" -> Data("java.lang.String")
+          )
+        }
+
+        test("should evaluate eta-expanded method passed as function arg: default.withMapper(transform)") {
+          testSemiEval(SemiEvalConfig.default.withMapper(SemiEvalConfig.transform)) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("DEFAULT"),
+            "class" -> Data("java.lang.String")
+          )
+        }
       }
     }
 

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -467,6 +467,15 @@ final class ExprsSpec extends MacroSuite {
         )
       }
 
+      test("ValDefs.createVar vars accessible in while loop with spliced dispatch") {
+        import ExprsFixtures.testValDefsVarInWhileLoop
+
+        testValDefsVarInWhileLoop ==> Data.map(
+          "simpleLoop" -> Data(5),
+          "dispatchResult" -> Data(3)
+        )
+      }
+
       test("methods ValDefs.{partition, close} should allow branching and closing a scoped block") {
         import ExprsFixtures.testValDefsPartitionAndClose
 

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -220,6 +220,14 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
         case Ident(_) if locals.contains(tree.symbol) =>
           Right(locals(tree.symbol))
 
+        case Ident(_)
+            if tree.symbol != null && tree.symbol != NoSymbol &&
+              tree.symbol.owner != null && tree.symbol.owner != NoSymbol &&
+              (tree.symbol.owner.isModule || tree.symbol.owner.isModuleClass) =>
+          resolveModule(tree.symbol.owner).flatMap { receiver =>
+            invokeGetter(receiver, tree.symbol.name.decodedName.toString)
+          }
+
         case other =>
           Left(NonEmptyVector.one(s"Cannot semi-evaluate expression: ${showCode(other)}"))
       }

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -226,6 +226,11 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         case Ident(_) if term.symbol.isDefDef =>
           resolveMethodOnOwner(term.symbol)
 
+        case Ident(_) if term.symbol.owner.flags.is(Flags.Module) =>
+          resolveModule(term.symbol.owner).flatMap { receiver =>
+            invokeGetter(receiver, term.symbol.name)
+          }
+
         case Ident(_) =>
           resolveStableRef(term)
 


### PR DESCRIPTION
## Summary

- **semiEval**: Support `val` fields on companion objects (e.g., `JsoniterConfig.default`) and eta-expanded method references passed as function values (e.g., `Config.default.withMapper(NameMappers.snakeCase)`)
- **ValDefs.createVar**: Add test validating the inline decode loop pattern needed by Kindlings — multiple vars via `map2`, dispatch chains, `while` loops, all in one `use` scope

## Details

### semiEval fix

In Scala 3, `Ident` nodes for `val` symbols on module owners fell through to `resolveStableRef`, which tried to find a nonexistent module singleton. Added an `Ident` case in both Scala 2 and Scala 3 that resolves the owner module and invokes the getter.

### ValDefs.createVar validation

The `while` loop + `map2` + spliced dispatch pattern already works — no implementation changes needed, just the test to prove it. This unblocks Kindlings' inline decode loop optimization (eliminating `Array[Any]` boxing for primitive fields).

## Test plan

- [x] All 909+ existing tests pass on both Scala 2.13 and Scala 3
- [x] New semiEval tests: companion object val, chained access, def call, method call with args, eta-expanded method as function arg
- [x] New ValDefs test: vars in while loop with spliced dispatch chain composed via map2
- [x] Published locally as `0.3.0-32-g2777955-SNAPSHOT` for Kindlings verification