### PR TITLE
Add MacroExtension priority, IsCollectionOf.foreach, and Expr.typeOf

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,14 +36,13 @@ val dev = new DevProperties(
   platforms = versions.platforms
 )
 
-val logCrossQuotes = {
+val logCrossQuotes =
   dev.props.getProperty("log.cross-quotes") match {
     case "true"                          => true
     case "false"                         => false
     case otherwise if otherwise.nonEmpty => otherwise
     case _                               => !isCI
   }
-}
 
 // Common settings:
 
@@ -78,7 +77,7 @@ val useCrossQuotes = versions.scalas.flatMap { scalaVersion =>
       // Enable logging from cross-quotes.
       MatrixAction
         .ForScala(_.isScala2)
-        .Configure(_.settings(scalacOptions += s"-Xmacro-settings:hearth.cross-quotes.logging=${logCrossQuotes}")),
+        .Configure(_.settings(scalacOptions += s"-Xmacro-settings:hearth.cross-quotes.logging=$logCrossQuotes")),
       // Depends on cross-quotes specific for the platform.
       MatrixAction {
         case (version, List(VirtualAxis.jvm)) => version.isScala2
@@ -106,7 +105,7 @@ val useCrossQuotes = versions.scalas.flatMap { scalaVersion =>
                 // Ensures recompilation.
                 s"-Jdummy=${jar.lastModified}",
                 // Enable logging from cross-quotes.
-                s"-P:hearth.cross-quotes:logging=${logCrossQuotes}"
+                s"-P:hearth.cross-quotes:logging=$logCrossQuotes"
               )
             }
           )

--- a/docs/user-guide/basic-utilities.md
+++ b/docs/user-guide/basic-utilities.md
@@ -633,6 +633,13 @@ It can be used to e.g. prevent the macro from summoning itself, so that recursio
 | `Expr.suppressUnused[A](expr)`            | `expr.suppressUnused`       | `Expr[Unit]`                        | prevents "unused value" warnings                                                                         |
 | `Expr.singletonOf[A]`                     | —                           | `Option[Expr[A]]`                   | returns singleton reference if `A` is a case object, Java enum value, or Scala 3 parameterless enum case |
 | `Expr.semiEval[A](expr)`                  | `expr.semiEval`             | `Either[NonEmptyVector[String], A]` | reconstructs a runtime value from expression AST using reflection                                        |
+| `Expr.typeOf[A](expr)`                    | `expr.tpe`                  | `Type[A]`                           | extracts the compiler-inferred type of an expression                                                     |
+
+!!! warning "Expr.typeOf / expr.tpe returns the compiler-inferred type"
+
+    The returned `Type[A]` may be **narrower** than the declared type parameter `A`. For instance, if `A` is `Any` but
+    the expression tree carries `String`, `expr.tpe` returns `Type[String]` (typed as `Type[A]`). Use this only when
+    you need the exact type the compiler inferred for the expression — not when you need the declared type parameter.
 
 ### `Expr.semiEval`
 
@@ -3590,6 +3597,13 @@ from the classpath.
 
 Extensions are discovered via Java's [ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) mechanism,
 allowing functionality to be added just by having the right JAR on the classpath during compilation.
+
+Extensions are loaded in **priority order** (descending). Override `def priority: Int` (default `0`) to control ordering:
+
+  - Higher priority values load first — their providers are registered and matched before lower-priority ones.
+  - Lower priority values act as fallbacks — e.g. `IsValueTypeProviderForOpaque` uses priority `-1000` so that
+    library-specific opaque type handlers (like Iron's) at the default priority `0` take precedence.
+  - Extensions with the same priority retain their ServiceLoader discovery order (the sort is stable).
 
 ### `MIO` Termination Handling
 

--- a/docs/user-guide/standard-extensions.md
+++ b/docs/user-guide/standard-extensions.md
@@ -664,7 +664,7 @@ In these examples:
  1. **Loading extensions**: We call `Environment.loadStandardExtensions()` to load all standard macro extensions, which registers providers for `IsCollection` support.
  2. **Pattern matching**: We use `IsCollection.unapply` to check if a type is a collection. If it matches, we get an `IsCollection[A]` instance.
  3. **Accessing item type**: We import `isCollection.Underlying as Item` to get the existential item type, and `isCollection.value.CtorResult` to get the result type that can be built.
- 4. **Iteration**: We use `isCollection.value.asIterable(collection)` to convert the collection to an `Iterable[Item]` that we can iterate over.
+ 4. **Iteration**: We use `isCollection.value.asIterable(collection)` to convert the collection to an `Iterable[Item]` that we can iterate over. Alternatively, `isCollection.value.foreach(collection)(f)` provides an optimized iteration path — the default delegates to `asIterable`, but providers may override it with zero-overhead loops (e.g. indexed array access, Java iterator without Scala conversion).
  5. **Building**: We use `isCollection.value.factory` to get a `Factory[Item, CtorResult]`, create a builder, add items, and use `isCollection.value.build` to construct the final collection.
 
 This API works seamlessly with Scala collections, `Array`s, `IArray`s (Scala 3), and Java collections, all through the same interface!

--- a/hearth-tests/src/main/scala-2/hearth/std/StdExtensionsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/std/StdExtensionsFixtures.scala
@@ -21,6 +21,9 @@ final private class StdExtensionsFixtures(val c: blackbox.Context)
 
   def testIsValueTypeImpl[A: c.WeakTypeTag](value: c.Expr[A]): c.Expr[Data] = testIsValueType[A](value)
 
+  def testIsCollectionForeachImpl[A: c.WeakTypeTag](value: c.Expr[A]): c.Expr[Data] =
+    testIsCollectionForeach[A](value)
+
   def testCtorLikesImpl[A: c.WeakTypeTag]: c.Expr[Data] = testCtorLikes[A]
 
   def testParseImpl[A: c.WeakTypeTag]: c.Expr[Data] = testParse[A]
@@ -37,6 +40,8 @@ object StdExtensionsFixtures {
   def testIsEither[A](value: A): Data = macro StdExtensionsFixtures.testIsEitherImpl[A]
 
   def testIsValueType[A](value: A): Data = macro StdExtensionsFixtures.testIsValueTypeImpl[A]
+
+  def testIsCollectionForeach[A](value: A): Data = macro StdExtensionsFixtures.testIsCollectionForeachImpl[A]
 
   def testCtorLikes[A]: Data = macro StdExtensionsFixtures.testCtorLikesImpl[A]
 

--- a/hearth-tests/src/main/scala-3/hearth/std/StdExtensionsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/std/StdExtensionsFixtures.scala
@@ -30,6 +30,10 @@ object StdExtensionsFixtures {
   private def testIsValueTypeImpl[A: Type](value: Expr[A])(using q: Quotes): Expr[Data] =
     new StdExtensionsFixtures(q).testIsValueType[A](value)
 
+  inline def testIsCollectionForeach[A](inline value: A): Data = ${ testIsCollectionForeachImpl[A]('value) }
+  private def testIsCollectionForeachImpl[A: Type](value: Expr[A])(using q: Quotes): Expr[Data] =
+    new StdExtensionsFixtures(q).testIsCollectionForeach[A](value)
+
   inline def testCtorLikes[A]: Data = ${ testCtorLikesImpl[A] }
   private def testCtorLikesImpl[A: Type](using q: Quotes): Expr[Data] =
     new StdExtensionsFixtures(q).testCtorLikes[A]

--- a/hearth-tests/src/main/scala/hearth/std/ForeachTestHelper.scala
+++ b/hearth-tests/src/main/scala/hearth/std/ForeachTestHelper.scala
@@ -1,0 +1,13 @@
+package hearth
+package std
+
+object ForeachTestHelper {
+  private val buf = new ThreadLocal[scala.collection.mutable.ListBuffer[String]] {
+    override def initialValue(): scala.collection.mutable.ListBuffer[String] =
+      scala.collection.mutable.ListBuffer.empty[String]
+  }
+
+  def reset(): Unit = buf.get().clear()
+  def add(s: String): Unit = buf.get() += s
+  def result(): List[String] = buf.get().toList
+}

--- a/hearth-tests/src/main/scala/hearth/std/StdExtensionsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/std/StdExtensionsFixturesImpl.scala
@@ -343,6 +343,44 @@ trait StdExtensionsFixturesImpl { this: MacroCommons & StdExtensions =>
         }
   }
 
+  def testIsCollectionForeach[A: Type](value: Expr[A]): Expr[Data] = Type[A] match {
+    case IsMap(isMap) =>
+      import isMap.{Underlying as Pair, value as isMapOf}
+      import isMapOf.{Key, Value}
+      implicit val dataType: Type[Data] = DataType
+
+      val foreachExpr = isMapOf.foreach(value) { pair =>
+        val keyExpr = isMapOf.key(pair)
+        val valueExpr = isMapOf.value(pair)
+        Expr.quote {
+          ForeachTestHelper.add(Expr.splice(keyExpr).toString + "=" + Expr.splice(valueExpr).toString)
+        }
+      }
+      Expr.quote {
+        ForeachTestHelper.reset()
+        Expr.splice(foreachExpr)
+        Data(ForeachTestHelper.result().map { entry =>
+          val parts = entry.split("=", 2)
+          Data.map("key" -> Data(parts(0)), "value" -> Data(parts(1)))
+        })
+      }
+    case IsCollection(isCollection) =>
+      import isCollection.{Underlying as Elem, value as isCollectionOf}
+      implicit val dataType: Type[Data] = DataType
+
+      val foreachExpr = isCollectionOf.foreach(value) { item =>
+        Expr.quote {
+          ForeachTestHelper.add(Expr.splice(item).toString)
+        }
+      }
+      Expr.quote {
+        ForeachTestHelper.reset()
+        Expr.splice(foreachExpr)
+        Data(ForeachTestHelper.result().map(Data(_)))
+      }
+    case _ => Expr(Data("<no collection>"))
+  }
+
   def testCtorLikes[A: Type]: Expr[Data] =
     CtorLikes.unapply(Type[A]) match {
       case Some(ctors) =>

--- a/hearth-tests/src/test/scala-3/hearth/std/StdExtensionsScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/std/StdExtensionsScala3Spec.scala
@@ -105,6 +105,34 @@ final class StdExtensionsScala3Spec extends MacroSuite {
       }
     }
 
+    group("class: IsCollectionOf[A, Item].foreach, iterates via foreach") {
+      import StdExtensionsFixtures.testIsCollectionForeach
+
+      test("for IArray[Int]") {
+        testIsCollectionForeach(IArray[Int](1, 2, 3)) <==> Data.list(
+          Data("1"),
+          Data("2"),
+          Data("3")
+        )
+      }
+
+      test("for IArray[String]") {
+        testIsCollectionForeach(IArray("one", "two", "three")) <==> Data.list(
+          Data("one"),
+          Data("two"),
+          Data("three")
+        )
+      }
+
+      test("for IArray[Double]") {
+        testIsCollectionForeach(IArray[Double](1.0, 2.0, 3.0)) <==> Data.list(
+          Data(if Platform.byHearth.isJs then "1" else "1.0"),
+          Data(if Platform.byHearth.isJs then "2" else "2.0"),
+          Data(if Platform.byHearth.isJs then "3" else "3.0")
+        )
+      }
+    }
+
     group("class: IsValueType[A], opaque types") {
       import StdExtensionsFixtures.testIsValueType
       import hearth.examples.opaqueid.OpaqueId

--- a/hearth-tests/src/test/scala/hearth/std/StdExtensionsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/std/StdExtensionsSpec.scala
@@ -500,6 +500,83 @@ final class StdExtensionsSpec extends MacroSuite {
       }
     }
 
+    group("class: IsCollectionOf[A, Item].foreach, iterates via foreach") {
+      import StdExtensionsFixtures.testIsCollectionForeach
+
+      test("for Scala List") {
+        testIsCollectionForeach(List("one", "two", "three")) <==> Data.list(
+          Data("one"),
+          Data("two"),
+          Data("three")
+        )
+      }
+
+      test("for Scala Vector") {
+        testIsCollectionForeach(Vector("one", "two", "three")) <==> Data.list(
+          Data("one"),
+          Data("two"),
+          Data("three")
+        )
+      }
+
+      test("for Scala Set") {
+        testIsCollectionForeach(scala.collection.immutable.ListSet("one", "two", "three")) <==> Data.list(
+          Data("one"),
+          Data("two"),
+          Data("three")
+        )
+      }
+
+      test("for Scala Map") {
+        testIsCollectionForeach(scala.collection.immutable.ListMap(1 -> "one", 2 -> "two")) <==> Data.list(
+          Data.map("key" -> Data("1"), "value" -> Data("one")),
+          Data.map("key" -> Data("2"), "value" -> Data("two"))
+        )
+      }
+
+      test("for Array") {
+        testIsCollectionForeach(Array("one", "two", "three")) <==> Data.list(
+          Data("one"),
+          Data("two"),
+          Data("three")
+        )
+      }
+
+      test("for Array[Int]") {
+        testIsCollectionForeach(Array(1, 2, 3)) <==> Data.list(
+          Data("1"),
+          Data("2"),
+          Data("3")
+        )
+      }
+
+      test("for String") {
+        testIsCollectionForeach("abc") <==> Data.list(
+          Data("a"),
+          Data("b"),
+          Data("c")
+        )
+      }
+
+      test("for Scala Option") {
+        testIsCollectionForeach(Option("value")) <==> Data.list(Data("value"))
+        testIsCollectionForeach(Option.empty[String]) <==> Data.list()
+      }
+
+      test("for Scala Iterator") {
+        testIsCollectionForeach(Iterator("one", "two", "three")) <==> Data.list(
+          Data("one"),
+          Data("two"),
+          Data("three")
+        )
+        testIsCollectionForeach(Iterator.empty[String]) <==> Data.list()
+      }
+
+      test("for empty List") {
+        testIsCollectionForeach(List.empty[String]) <==> Data.list()
+      }
+    }
+
     group("class: IsOption[A], returns preprocessed option") {
       import StdExtensionsFixtures.testIsOption
 

--- a/hearth-tests/src/test/scalajvm/hearth/std/StdExtensionsJvmSpec.scala
+++ b/hearth-tests/src/test/scalajvm/hearth/std/StdExtensionsJvmSpec.scala
@@ -586,6 +586,171 @@ final class StdExtensionsJvmSpec extends MacroSuite {
       }
     }
 
+    group("class: IsCollectionOf[A, Item].foreach, iterates via foreach") {
+      import StdExtensionsFixtures.testIsCollectionForeach
+
+      test("for java.util.ArrayList") {
+        testIsCollectionForeach[java.util.ArrayList[String]](new java.util.ArrayList[String]() {
+          add("one")
+          add("two")
+          add("three")
+        }) <==> Data.list(
+          Data("one"),
+          Data("two"),
+          Data("three")
+        )
+      }
+
+      test("for java.util.LinkedList") {
+        testIsCollectionForeach[java.util.LinkedList[String]](new java.util.LinkedList[String]() {
+          add("one")
+          add("two")
+          add("three")
+        }) <==> Data.list(
+          Data("one"),
+          Data("two"),
+          Data("three")
+        )
+      }
+
+      test("for java.util.LinkedHashSet") {
+        testIsCollectionForeach[java.util.LinkedHashSet[String]](new java.util.LinkedHashSet[String]() {
+          add("one")
+          add("two")
+          add("three")
+        }) <==> Data.list(
+          Data("one"),
+          Data("two"),
+          Data("three")
+        )
+      }
+
+      test("for java.util.LinkedHashMap") {
+        testIsCollectionForeach[java.util.LinkedHashMap[Int, String]](new java.util.LinkedHashMap[Int, String]() {
+          put(1, "one")
+          put(2, "two")
+        }) <==> Data.list(
+          Data.map("key" -> Data("1"), "value" -> Data("one")),
+          Data.map("key" -> Data("2"), "value" -> Data("two"))
+        )
+      }
+
+      test("for java.util.TreeMap") {
+        testIsCollectionForeach[java.util.TreeMap[Int, String]](new java.util.TreeMap[Int, String]() {
+          put(2, "two")
+          put(1, "one")
+        }) <==> Data.list(
+          Data.map("key" -> Data("1"), "value" -> Data("one")),
+          Data.map("key" -> Data("2"), "value" -> Data("two"))
+        )
+      }
+
+      test("for java.lang.Iterable") {
+        val iterable: java.lang.Iterable[String] = new java.lang.Iterable[String] {
+          override def iterator(): java.util.Iterator[String] =
+            java.util.Arrays.asList("one", "two", "three").iterator()
+        }
+        testIsCollectionForeach(iterable) <==> Data.list(
+          Data("one"),
+          Data("two"),
+          Data("three")
+        )
+      }
+
+      test("for java.util.Iterator") {
+        testIsCollectionForeach(java.util.Arrays.asList("one", "two", "three").iterator()) <==> Data.list(
+          Data("one"),
+          Data("two"),
+          Data("three")
+        )
+      }
+
+      test("for java.util.Enumeration") {
+        testIsCollectionForeach(
+          java.util.Collections.enumeration(java.util.Arrays.asList("one", "two", "three"))
+        ) <==> Data.list(
+          Data("one"),
+          Data("two"),
+          Data("three")
+        )
+      }
+
+      test("for java.util.BitSet") {
+        testIsCollectionForeach {
+          val bs = new java.util.BitSet()
+          bs.set(1)
+          bs.set(3)
+          bs.set(5)
+          bs
+        } <==> Data.list(
+          Data("1"),
+          Data("3"),
+          Data("5")
+        )
+      }
+
+      test("for java.util.stream.Stream") {
+        testIsCollectionForeach(java.util.stream.Stream.of("one", "two", "three")) <==> Data.list(
+          Data("one"),
+          Data("two"),
+          Data("three")
+        )
+      }
+
+      test("for java.util.stream.IntStream") {
+        testIsCollectionForeach(java.util.stream.IntStream.of(1, 2, 3)) <==> Data.list(
+          Data("1"),
+          Data("2"),
+          Data("3")
+        )
+      }
+
+      test("for java.util.stream.LongStream") {
+        testIsCollectionForeach(java.util.stream.LongStream.of(1L, 2L, 3L)) <==> Data.list(
+          Data("1"),
+          Data("2"),
+          Data("3")
+        )
+      }
+
+      test("for java.util.stream.DoubleStream") {
+        testIsCollectionForeach(java.util.stream.DoubleStream.of(1.0, 2.0, 3.0)) <==> Data.list(
+          Data("1.0"),
+          Data("2.0"),
+          Data("3.0")
+        )
+      }
+
+      test("for java.util.Optional") {
+        testIsCollectionForeach(java.util.Optional.of("value")) <==> Data.list(Data("value"))
+        testIsCollectionForeach(java.util.Optional.empty[String]) <==> Data.list()
+      }
+
+      test("for java.util.Hashtable") {
+        val ht = new java.util.Hashtable[Int, String]()
+        ht.put(1, "one")
+        val result = testIsCollectionForeach[java.util.Hashtable[Int, String]](ht)
+        assert(result.asList.exists(_.size == 1))
+      }
+
+      test("for java.util.Properties") {
+        val props = new java.util.Properties()
+        props.put("key", "value")
+        val result = testIsCollectionForeach(props)
+        assert(result.asList.exists(_.size == 1))
+      }
+
+      test("for java.util.EnumMap") {
+        val em = new java.util.EnumMap[Thread.State, String](classOf[Thread.State])
+        em.put(Thread.State.NEW, "one")
+        em.put(Thread.State.RUNNABLE, "two")
+        testIsCollectionForeach[java.util.EnumMap[Thread.State, String]](em) <==> Data.list(
+          Data.map("key" -> Data("NEW"), "value" -> Data("one")),
+          Data.map("key" -> Data("RUNNABLE"), "value" -> Data("two"))
+        )
+      }
+    }
+
     group("class: IsOption[A], returns preprocessed option") {
       import StdExtensionsFixtures.testIsOption
 

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -168,6 +168,11 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
       }
     }
 
+    override def typeOf[A](expr: Expr[A]): Type[A] =
+      UntypedType.toTyped(
+        expr.attemptPipe(_.actualType.finalResultType)(_.staticType.finalResultType)
+      )
+
     override def semiEval[A](expr: Expr[A]): Either[NonEmptyVector[String], A] =
       SemiEval.eval(expr.tree).map(_.asInstanceOf[A])
 

--- a/hearth/src/main/scala-3/hearth/std/extensions/IsCollectionProviderForIArray.scala
+++ b/hearth/src/main/scala-3/hearth/std/extensions/IsCollectionProviderForIArray.scala
@@ -41,6 +41,15 @@ final class IsCollectionProviderForIArray extends StandardMacroExtension { loade
         Existential[IsCollectionOf[A, *], Item](new IsCollectionOf[A, Item] {
           // We will use Array as the collection type, we need to adjust how we convert the collection to Iterable.
           override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = toIterableExpr(value)
+          override def foreach(value: Expr[A])(f: Expr[Item] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val arr = Expr.splice(value).asInstanceOf[IArray[Item]]
+            var i = 0
+            while i < arr.length do {
+              val item = arr(i)
+              Expr.splice(f(Expr.quote(item)))
+              i += 1
+            }
+          }
           // Arrays have no smart constructors, so we just return the array itself.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A

--- a/hearth/src/main/scala-3/hearth/std/extensions/IsValueTypeProviderForOpaque.scala
+++ b/hearth/src/main/scala-3/hearth/std/extensions/IsValueTypeProviderForOpaque.scala
@@ -14,6 +14,8 @@ import scala.quoted.Quotes
 @scala.annotation.experimental
 final class IsValueTypeProviderForOpaque extends StandardMacroExtension { loader =>
 
+  override def priority: Int = -1000
+
   override def extend(ctx: MacroCommons & StdExtensions): Unit = ctx match {
     case ctx3: (MacroCommonsScala3 & StdExtensions) =>
       // Extracts platform-specific type representation, so that it would not clash with Cross-Quotes

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -159,6 +159,9 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       else None
     }
 
+    override def typeOf[A](expr: Expr[A]): Type[A] =
+      UntypedType.toTyped(expr.asTerm.tpe)
+
     override def semiEval[A](expr: Expr[A]): Either[NonEmptyVector[String], A] =
       SemiEval.eval(expr.asTerm).map(_.asInstanceOf[A])
 

--- a/hearth/src/main/scala/hearth/Environments.scala
+++ b/hearth/src/main/scala/hearth/Environments.scala
@@ -322,7 +322,8 @@ trait Environments extends EnvironmentCrossQuotesSupport { env =>
 
       extensions match {
         case Right(extensions) =>
-          val (failure, success) = extensions.partitionMap(safeLoadExtension)
+          val sorted = extensions.sortBy(_.priority)(Ordering[Int].reverse)
+          val (failure, success) = sorted.partitionMap(safeLoadExtension)
           val loadedExtensions = ListSet.from(success)
           NonEmptyMap.fromListMap(ListMap.from(failure)) match {
             case Some(failed) => ExtensionLoadingResult.SomeFailed(loadedExtensions, failed)

--- a/hearth/src/main/scala/hearth/MacroExtension.scala
+++ b/hearth/src/main/scala/hearth/MacroExtension.scala
@@ -31,5 +31,7 @@ abstract class MacroExtension[Macro: ClassTag] extends PartialFunction[Any, Unit
 
   final def apply(ctx: Any): Unit = extend(Macro.cast(ctx))
 
+  def priority: Int = 0
+
   def extend(ctx: Macro): Unit
 }

--- a/hearth/src/main/scala/hearth/std/StdExtensions.scala
+++ b/hearth/src/main/scala/hearth/std/StdExtensions.scala
@@ -272,6 +272,24 @@ trait StdExtensions { this: MacroCommons =>
 
     def asIterable(value: Expr[CollA]): Expr[Iterable[Item]]
 
+    def foreach(value: Expr[CollA])(f: Expr[Item] => Expr[Unit]): Expr[Unit] = {
+      val iterableExpr = asIterable(value)
+      Type.Ctor1.of[Iterable].unapply(Expr.typeOf(iterableExpr)) match {
+        case Some(item) =>
+          import item.Underlying as I
+          val castIterableExpr = iterableExpr.asInstanceOf[Expr[Iterable[I]]]
+          val lambda =
+            LambdaBuilder.of1[I]("item").buildWith(f.asInstanceOf[Expr[I] => Expr[Unit]])(using Type.of[Unit])
+          Expr.quote {
+            Expr.splice(castIterableExpr).foreach(Expr.splice(lambda))
+          }
+        case None =>
+          hearthRequirementFailed(
+            s"foreach default: asIterable did not return Iterable[_], got ${Expr.typeOf(iterableExpr).prettyPrint}"
+          )
+      }
+    }
+
     type CtorResult
     @ImportedCrossTypeImplicit
     implicit val CtorResult: Type[CtorResult]

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForArray.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForArray.scala
@@ -40,6 +40,15 @@ final class IsCollectionProviderForArray extends StandardMacroExtension { loader
         Existential[IsCollectionOf[A, *], Item](new IsCollectionOf[A, Item] {
           // We will use Array as the collection type, we need to adjust how we convert the collection to Iterable.
           override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = toIterableExpr(value)
+          override def foreach(value: Expr[A])(f: Expr[Item] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val arr = Expr.splice(value).asInstanceOf[Array[Item]]
+            var i = 0
+            while (i < arr.length) {
+              val item = arr(i)
+              Expr.splice(f(Expr.quote(item)))
+              i += 1
+            }
+          }
           // Arrays have no smart constructors, so we just return the array itself.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A

--- a/hearth/src/main/scala/hearth/typed/Exprs.scala
+++ b/hearth/src/main/scala/hearth/typed/Exprs.scala
@@ -49,6 +49,16 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
 
     def singletonOf[A: Type]: Option[Expr[A]]
 
+    /** Returns the type of an expression as seen by the compiler.
+      *
+      * '''Warning:''' the returned type may be narrower than the declared `A`. For instance, if `A` is `Any` but the
+      * expression tree carries `String`, this method returns `Type[String]` (typed as `Type[A]`). Use this only when
+      * you need the compiler-inferred type and are aware that it may be more specific than the type parameter suggests.
+      *
+      * @since 0.3.1
+      */
+    def typeOf[A](expr: Expr[A]): Type[A]
+
     def semiEval[A](expr: Expr[A]): Either[NonEmptyVector[String], A]
 
     def NullExprCodec: ExprCodec[Null]
@@ -151,6 +161,14 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
 
     def upcast[B](implicit A: Type[A], B: Type[B]): Expr[B] = Expr.upcast(expr)
     def suppressUnused(implicit A: Type[A]): Expr[Unit] = Expr.suppressUnused(expr)
+
+    /** Returns the type of this expression as seen by the compiler.
+      *
+      * '''Warning:''' the returned type may be narrower than `A` — see [[ExprModule.typeOf]].
+      *
+      * @since 0.3.1
+      */
+    def tpe: Type[A] = Expr.typeOf(expr)
 
     def semiEval: Either[NonEmptyVector[String], A] = Expr.semiEval(expr)
 

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
@@ -34,6 +34,15 @@ final class IsCollectionProviderForJavaBitSet extends StandardMacroExtension { l
               else Some(currentValue, bitSet.nextSetBit(currentValue + 1))
             }
           }
+          override def foreach(value: Expr[A])(f: Expr[Int] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val bitSet = Expr.splice(value).asInstanceOf[java.util.BitSet]
+            var i = bitSet.nextSetBit(0)
+            while (i >= 0) {
+              val item = i
+              Expr.splice(f(Expr.quote(item)))
+              i = bitSet.nextSetBit(i + 1)
+            }
+          }
           // Java BitSet has no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
@@ -60,6 +60,13 @@ final class IsCollectionProviderForJavaCollection extends StandardMacroExtension
           override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = Expr.quote {
             scala.jdk.javaapi.CollectionConverters.asScala(Expr.splice(value).iterator()).to(Iterable)
           }
+          override def foreach(value: Expr[A])(f: Expr[Item] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val it = Expr.splice(value).iterator()
+            while (it.hasNext()) {
+              val item = it.next()
+              Expr.splice(f(Expr.quote(item)))
+            }
+          }
           // Java collections have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
@@ -48,6 +48,16 @@ final class IsCollectionProviderForJavaDictionary extends StandardMacroExtension
               .map(key => (key, dict.get(key)))
               .to(Iterable)
           }
+          override def foreach(value: Expr[A])(f: Expr[Pair] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val dict: java.util.Dictionary[Key, Value] =
+              Expr.splice(value).asInstanceOf[java.util.Dictionary[Key, Value]]
+            val keys = dict.keys()
+            while (keys.hasMoreElements()) {
+              val key = keys.nextElement()
+              val item = (key, dict.get(key))
+              Expr.splice(f(Expr.quote(item)))
+            }
+          }
           // Java dictionaries have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
@@ -130,6 +140,17 @@ final class IsCollectionProviderForJavaDictionary extends StandardMacroExtension
             // We will use scala.jdk.javaapi.CollectionConverters.asScala to convert the dictionary to Iterable.
             override def asIterable(value: Expr[java.util.Properties]): Expr[Iterable[(String, String)]] =
               asScalaExpr(value)
+            override def foreach(value: Expr[java.util.Properties])(
+                f: Expr[(String, String)] => Expr[Unit]
+            ): Expr[Unit] = Expr.quote {
+              val properties: java.util.Properties = Expr.splice(value)
+              val keys = properties.keys()
+              while (keys.hasMoreElements()) {
+                val key = keys.nextElement().asInstanceOf[String]
+                val item = (key, properties.get(key).asInstanceOf[String])
+                Expr.splice(f(Expr.quote(item)))
+              }
+            }
             // Java dictionaries have no smart constructors, we'll provide a Factory that builds them as plain values.
             override type CtorResult = java.util.Properties
             implicit override val CtorResult: Type[CtorResult] = juProperties

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaEnumeration.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaEnumeration.scala
@@ -32,6 +32,13 @@ final class IsCollectionProviderForJavaEnumeration extends StandardMacroExtensio
           override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = Expr.quote {
             scala.jdk.javaapi.CollectionConverters.asScala(Expr.splice(toEnumeration(value))).to(Iterable)
           }
+          override def foreach(value: Expr[A])(f: Expr[Item] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val e = Expr.splice(toEnumeration(value))
+            while (e.hasMoreElements()) {
+              val item = e.nextElement()
+              Expr.splice(f(Expr.quote(item)))
+            }
+          }
           // Java enumerations have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterable.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterable.scala
@@ -35,6 +35,13 @@ final class IsCollectionProviderForJavaIterable extends StandardMacroExtension {
               .asScala(Expr.splice(toIterable(value)).iterator())
               .to(scala.collection.Iterable)
           }
+          override def foreach(value: Expr[A])(f: Expr[Item] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val it = Expr.splice(toIterable(value)).iterator()
+            while (it.hasNext()) {
+              val item = it.next()
+              Expr.splice(f(Expr.quote(item)))
+            }
+          }
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
           override def factory: Expr[scala.collection.Factory[Item, CtorResult]] = Expr.quote {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterator.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterator.scala
@@ -32,6 +32,13 @@ final class IsCollectionProviderForJavaIterator extends StandardMacroExtension {
           override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = Expr.quote {
             scala.jdk.javaapi.CollectionConverters.asScala(Expr.splice(toIterator(value))).to(Iterable)
           }
+          override def foreach(value: Expr[A])(f: Expr[Item] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val it = Expr.splice(toIterator(value))
+            while (it.hasNext()) {
+              val item = it.next()
+              Expr.splice(f(Expr.quote(item)))
+            }
+          }
           // Java iterators have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
@@ -59,6 +59,13 @@ final class IsCollectionProviderForJavaMap extends StandardMacroExtension { load
               )
               .to(Iterable)
           }
+          override def foreach(value: Expr[A])(f: Expr[Pair] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val it = Expr.splice(value).asInstanceOf[java.util.Map[Key0, Value0]].entrySet().iterator()
+            while (it.hasNext()) {
+              val item = it.next()
+              Expr.splice(f(Expr.quote(item)))
+            }
+          }
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
           override def factory: Expr[scala.collection.Factory[Pair, CtorResult]] = Expr.quote {
@@ -117,6 +124,13 @@ final class IsCollectionProviderForJavaMap extends StandardMacroExtension { load
           // We will use scala.jdk.javaapi.CollectionConverters.asScala to convert the map to Iterable.
           override def asIterable(value: Expr[A]): Expr[Iterable[Pair]] = Expr.quote {
             scala.jdk.javaapi.CollectionConverters.asScala(Expr.splice(value).entrySet().iterator()).to(Iterable)
+          }
+          override def foreach(value: Expr[A])(f: Expr[Pair] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val it = Expr.splice(value).entrySet().iterator()
+            while (it.hasNext()) {
+              val item = it.next()
+              Expr.splice(f(Expr.quote(item)))
+            }
           }
           // Java maps have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaOptional.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaOptional.scala
@@ -40,6 +40,13 @@ final class IsCollectionProviderForJavaOptional extends StandardMacroExtension {
             val opt = Expr.splice(toOptional(value))
             if (opt.isPresent) List(opt.get()) else Nil
           }
+          override def foreach(value: Expr[A])(f: Expr[Item] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val opt = Expr.splice(toOptional(value))
+            if (opt.isPresent) {
+              val item = opt.get()
+              Expr.splice(f(Expr.quote(item)))
+            }
+          }
           // CtorResult is List[Item] so the smart constructor can validate element count.
           override type CtorResult = List[Item]
           implicit override val CtorResult: Type[CtorResult] = listItemType

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaStream.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaStream.scala
@@ -47,6 +47,13 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
             new scala.jdk.StreamConverters.StreamHasToScala(Expr.splice(toStreamExpr(value)))
               .toScala(Iterable)(using Expr.splice(accumulatorFactoryInfoExpr))
           }
+          override def foreach(value: Expr[A])(f: Expr[Item] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val it = Expr.splice(toStreamExpr(value)).iterator()
+            while (it.hasNext()) {
+              val item = it.next()
+              Expr.splice(f(Expr.quote(item)))
+            }
+          }
           // Java streams have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
@@ -90,6 +97,13 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
           override def asIterable(value: Expr[A]): Expr[Iterable[Int]] = Expr.quote {
             new scala.jdk.StreamConverters.IntStreamHasToScala(Expr.splice(toIntStreamExpr(value)))
               .toScala(Iterable)(using Expr.splice(accumulatorFactoryInfoExpr))
+          }
+          override def foreach(value: Expr[A])(f: Expr[Int] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val it = Expr.splice(toIntStreamExpr(value)).iterator()
+            while (it.hasNext()) {
+              val item = it.next().intValue()
+              Expr.splice(f(Expr.quote(item)))
+            }
           }
           // Java int streams have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
@@ -135,6 +149,13 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
             new scala.jdk.StreamConverters.LongStreamHasToScala(Expr.splice(toLongStreamExpr(value)))
               .toScala(Iterable)(using Expr.splice(accumulatorFactoryInfoExpr))
           }
+          override def foreach(value: Expr[A])(f: Expr[Long] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val it = Expr.splice(toLongStreamExpr(value)).iterator()
+            while (it.hasNext()) {
+              val item = it.next().longValue()
+              Expr.splice(f(Expr.quote(item)))
+            }
+          }
           // Java long streams have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
@@ -179,6 +200,13 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
           override def asIterable(value: Expr[A]): Expr[Iterable[Double]] = Expr.quote {
             new scala.jdk.StreamConverters.DoubleStreamHasToScala(Expr.splice(toDoubleStreamExpr(value)))
               .toScala(Iterable)(using Expr.splice(accumulatorFactoryInfoExpr))
+          }
+          override def foreach(value: Expr[A])(f: Expr[Double] => Expr[Unit]): Expr[Unit] = Expr.quote {
+            val it = Expr.splice(toDoubleStreamExpr(value)).iterator()
+            while (it.hasNext()) {
+              val item = it.next().doubleValue()
+              Expr.splice(f(Expr.quote(item)))
+            }
           }
           // Java double streams have no smart constructors, we'll provide a Factory that builds them as plain values.
           override type CtorResult = A


### PR DESCRIPTION
## Summary

- **MacroExtension priority sorting**: Extensions are now sorted by `priority` (descending, stable) during loading. Higher values load first; default is `0`. This enables fallback/first-choice semantics for providers using first-match strategy.
- **IsValueTypeProviderForOpaque priority -1000**: Makes the default opaque type handler a fallback so library-specific handlers (e.g. Iron) at priority `0` take precedence.
- **IsCollectionOf.foreach**: New method with a backward-compatible default implementation (delegates to `asIterable` via `LambdaBuilder`). Optimized overrides for Array/IArray (indexed while loop), Java Collection/Iterable/Iterator/Enumeration/Optional (native Java iterator), Java Map/Dictionary (entrySet/keys iterator), Java BitSet (`nextSetBit` loop), and Java Stream (`.iterator()`).
- **Expr.typeOf / expr.tpe**: New API to extract the compiler-inferred `Type[A]` from an `Expr[A]`. Used internally by the default `foreach` to obtain `Type[Item]` without adding abstract members to `IsCollectionOf`. Includes a warning about type narrowing in the docs.

## Test plan

- [x] `sbt --client "quick-clean ; quick-test"` passes: Scala 2 (855 tests) and Scala 3 (936 tests), 0 failures
- [x] foreach tested for: List, Vector, Set, Map, Array, Array[Int], String, Option, Iterator, IArray (Int/String/Double), ArrayList, LinkedList, LinkedHashSet, LinkedHashMap, TreeMap, java.lang.Iterable, java.util.Iterator, Enumeration, BitSet, Stream (all 4 variants), Optional, Hashtable, Properties, EnumSet, EnumMap
- [x] Priority sorting verified by existing EnvironmentSpec (stable sort preserves order for equal priorities)
- [x] Documentation updated for `Expr.typeOf`/`tpe`, `foreach`, and `priority`