### PR TITLE
Fix NonEmptyMap.map/flatMap producing duplicate keys

### DIFF
--- a/hearth-micro-fp/src/main/scala/hearth/fp/data/NonEmptyMap.scala
+++ b/hearth-micro-fp/src/main/scala/hearth/fp/data/NonEmptyMap.scala
@@ -22,11 +22,9 @@ final case class NonEmptyMap[K, +V](head: (K, V), tail: ListMap[K, V]) {
     else NonEmptyMap(head, tail.removed(pair._1) + pair)
 
   def map[K2, V2](f: ((K, V)) => (K2, V2)): NonEmptyMap[K2, V2] =
-    NonEmptyMap(f(head), ListMap.from(tail.iterator.map(f)))
-  def flatMap[K2, V2](f: ((K, V)) => NonEmptyMap[K2, V2]): NonEmptyMap[K2, V2] = {
-    val NonEmptyMap(head2, tail2) = f(head)
-    NonEmptyMap(head2, ListMap.from(tail2.iterator ++ tail.iterator.flatMap(a => f(a).iterator)))
-  }
+    NonEmptyMap.fromListMap(ListMap.from(iterator.map(f))).get
+  def flatMap[K2, V2](f: ((K, V)) => NonEmptyMap[K2, V2]): NonEmptyMap[K2, V2] =
+    NonEmptyMap.fromListMap(ListMap.from(iterator.flatMap(kv => f(kv).iterator))).get
 
   def iterator: Iterator[(K, V)] = Iterator(head) ++ tail.iterator
   def toListMap: ListMap[K, V] = ListMap.from(iterator)

--- a/hearth-tests/src/test/scalajvm/hearth/fp/data/NonEmptyMapSpec.scala
+++ b/hearth-tests/src/test/scalajvm/hearth/fp/data/NonEmptyMapSpec.scala
@@ -264,14 +264,30 @@ final class NonEmptyMapSpec extends ScalaCheckSuite with Laws {
       val appended = nem :+ ("b", 20)
       appended.toList === List(("a", 1), ("b", 20))
     }
+
+    test("map should deduplicate when keys collide") {
+      val nem = NonEmptyMap(("a", 1), ("b", 2))
+      val collapsed = nem.map { case (_, v) => ("x", v) }
+      collapsed.size === 1
+      collapsed.toListMap === ListMap("x" -> 2)
+      collapsed.toList === List(("x", 2))
+    }
+
+    test("flatMap should deduplicate when keys collide") {
+      val nem = NonEmptyMap(("a", 1), ("b", 2))
+      val collapsed = nem.flatMap { case (_, v) => NonEmptyMap(("x", v)) }
+      collapsed.size === 1
+      collapsed.toListMap === ListMap("x" -> 2)
+      collapsed.toList === List(("x", 2))
+    }
   }
 
   group("Property-based Tests") {
 
-    property("map should preserve length") {
+    property("map should deduplicate colliding keys") {
       forAll { (nem: NonEmptyMap[String, Int]) =>
         val mapped = nem.map { case (k, v) => (k.toUpperCase, v * 2) }
-        mapped.toList.length == nem.toList.length
+        mapped.size == mapped.toListMap.size
       }
     }
 


### PR DESCRIPTION
## Summary

- **`NonEmptyMap.map`** and **`flatMap`** concatenated head and tail results without deduplication, violating the key-uniqueness invariant when the transform mapped distinct source keys to the same target key (e.g. `nem.map { case (_, v) => ("x", v) }`)
- Both methods now route through `ListMap.from` + `fromListMap` which deduplicates with last-writer-wins semantics, matching standard `Map.map` behavior on collisions
- After the fix, `size`, `iterator`, and `toListMap` always agree

Fixes #268

## Test plan

- [x] Added regression tests for key collision in `map` and `flatMap`
- [x] Updated property test from "map should preserve length" to "map should deduplicate colliding keys" (asserts `size == toListMap.size`)
- [x] All 39 NonEmptyMapSpec tests pass on Scala 2.13
- [x] `hearthMicroFp3/compile` passes (Scala 3)