### PR TITLE
Update scala3Newest to 3.8.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val versions = new {
 
   // Versions we can compile tests against if needed, to check for regressions.
   val scala213Newest = "2.13.18"
-  val scala3Newest = "3.8.3"
+  val scala3Newest = "3.8.4"
 
   // Which versions should be cross-compiled for publishing.
   val scalas = List(scala213, scala3)

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -33,6 +33,10 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
       else Left(s"Expected param Symbol, got $symbol")
   }
 
+  private def safeMemberType(tpe: TypeRepr, symbol: Symbol): TypeRepr =
+    try tpe.memberType(symbol)
+    catch { case _: AssertionError => symbol.owner.typeRef.memberType(symbol) }
+
   object UntypedParameters extends UntypedParametersModule {
 
     override def toTyped[Instance: Type](untyped: UntypedParameters): Parameters = {
@@ -52,8 +56,11 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
       // Constructor methods still have to have their type parameters manually applied, even if we know the exact type of their class.
       lazy val appliedIfNecessary = {
         val raw =
-          if instanceTpe.typeArgs.isEmpty && method.symbol.isClassConstructor then instanceTpe.memberType(method.symbol)
-          else instanceTpe.memberType(method.symbol).appliedTo(instanceTpe.typeArgs)
+          if instanceTpe.typeArgs.isEmpty && method.symbol.isClassConstructor then safeMemberType(
+            instanceTpe,
+            method.symbol
+          )
+          else safeMemberType(instanceTpe, method.symbol).appliedTo(instanceTpe.typeArgs)
         // Extension methods have a receiver parameter as the first value parameter list in their type,
         // which was already dropped from `parameters` — skip it here too to keep names aligned.
         if method.symbol.flags.is(Flags.ExtensionMethod) then raw match {
@@ -368,7 +375,7 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
           )
         case Invocation.OnModule(_) =>
           if !untyped.hasTypeParameters then {
-            val returnType = Instance.memberType(untyped.symbol).widenByName match {
+            val returnType = safeMemberType(Instance, untyped.symbol).widenByName match {
               case lambda: LambdaType => lambda.resType.as_??
               case out                => out.as_??
             }
@@ -384,7 +391,7 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
           }
         case Invocation.OnInstance =>
           if !untyped.hasTypeParameters then {
-            val returnType = Instance.memberType(untyped.symbol).widenByName match {
+            val returnType = safeMemberType(Instance, untyped.symbol).widenByName match {
               case lambda: LambdaType => lambda.resType.as_??
               case out                => out.as_??
             }


### PR DESCRIPTION
## Summary
- Bumps the regression-testing Scala 3 version from 3.8.3 to 3.8.4
- Fixes `AssertionError: method X is not a member of Y` failures caused by Scala 3.8.4 stricter `TypeRepr.memberType` validation

## Root cause
Scala 3.8.4 changed `TypeRepr.memberType(symbol)` to throw `AssertionError` when the symbol isn't a genuine member of the type. Previously this was silently handled. This broke Hearth's `UntypedMethodsScala3` in three places where `memberType` was called with a type that didn't own the method:

1. **`NoInstance.parameters`** — used the return type (`Returned`) instead of the declaring type for `memberType` resolution. For static methods like `Boolean.compare(boolean, boolean): int`, this meant calling `Int.memberType(compare)` which fails.
2. **`toTyped` (OnModule)** — same pattern for companion/static methods
3. **`toTyped` (OnInstance)** — same pattern for instance methods on types with inherited/synthetic members like `writeReplace`, `canEqual`, `wrapShortIArray`

## Fix
Added `safeMemberType` helper that catches `AssertionError` and falls back to resolving via the symbol's owner type (`symbol.owner.typeRef.memberType(symbol)`), which always succeeds since the method IS a member of its owner.

## Test plan
- [x] `quick-clean ; quick-test` passes on primary versions (3.3.7 + 2.13.16)
- [x] `NEWEST_SCALA_TESTS=true hearthTests3/test` passes (1012 tests, 0 failures)
- [x] CI passes on all platforms (JVM, JS, Native) with `NEWEST_SCALA_TESTS=true`