### PR TITLE
Fix splice isolation, type printing, semiEval, and flaky MIO for Kindlings/refined-compat

### DIFF
--- a/hearth-better-printers/src/main/scala-2/hearth/treeprinter/ShowCodePrettyScala2.scala
+++ b/hearth-better-printers/src/main/scala-2/hearth/treeprinter/ShowCodePrettyScala2.scala
@@ -1120,6 +1120,13 @@ trait ShowCodePrettyScala2 {
               print(if (x.value.isInstanceOf[String]) highlightString(result) else highlightLiteral(result))
           }
 
+        case LiteralType(x) =>
+          val result = x.escapedStringValue + (x.value match {
+            case _: Float => "f"
+            case _        => ""
+          })
+          print(if (x.value.isInstanceOf[String]) highlightString(result) else highlightLiteral(result))
+
         case RefinedType(parents, decls) =>
           val it = parents.iterator
           while (it.hasNext) {

--- a/hearth-better-printers/src/main/scala-3/hearth/treeprinter/RuntimeAwareTypePrinterScala3.scala
+++ b/hearth-better-printers/src/main/scala-3/hearth/treeprinter/RuntimeAwareTypePrinterScala3.scala
@@ -40,8 +40,14 @@ trait RuntimeAwareTypePrinterScala3 {
     def dealiasAll(tpe: TypeRepr): TypeRepr =
       tpe match {
         case AppliedType(tycon, args) => AppliedType(dealiasAll(tycon), args.map(dealiasAll(_)))
+        case OrType(left, right)      => OrType(dealiasAll(left), dealiasAll(right))
         case _                        => tpe.dealias
       }
+
+    private def flattenOrType(tpe: TypeRepr): List[TypeRepr] = dealiasAll(tpe) match {
+      case OrType(left, right) => flattenOrType(left) ++ flattenOrType(right)
+      case other               => List(other)
+    }
 
     def print(
         tpe: TypeRepr,
@@ -60,6 +66,10 @@ trait RuntimeAwareTypePrinterScala3 {
                   intersperse(argExprs, QExpr(", ")) :::
                   QExpr("]") :: Nil
               concatExprs(optimizeLiterals(parts))
+            case ort @ OrType(_, _) if hasOverrideInOrType(ort, overrideFn) =>
+              val members = flattenOrType(ort)
+              val memberExprs = members.map(m => print(m, overrideFn, printType))
+              concatExprs(optimizeLiterals(intersperse(memberExprs, QExpr(" | "))))
             case _ =>
               QExpr(printType(tpe))
           }
@@ -69,6 +79,16 @@ trait RuntimeAwareTypePrinterScala3 {
       types.exists { tpe =>
         overrideFn(tpe).isDefined || (dealiasAll(tpe) match {
           case AppliedType(_, args) if args.nonEmpty => hasOverrideInTree(args, overrideFn)
+          case _: OrType                             => hasOverrideInOrType(tpe, overrideFn)
+          case _                                     => false
+        })
+      }
+
+    private def hasOverrideInOrType(tpe: TypeRepr, overrideFn: TypeRepr => Option[QExpr[String]]): Boolean =
+      flattenOrType(tpe).exists { member =>
+        overrideFn(member).isDefined || (dealiasAll(member) match {
+          case AppliedType(_, args) if args.nonEmpty => hasOverrideInTree(args, overrideFn)
+          case _: OrType                             => hasOverrideInOrType(member, overrideFn)
           case _                                     => false
         })
       }
@@ -100,7 +120,8 @@ trait RuntimeAwareTypePrinterScala3 {
     private def concatExprs(exprs: List[QExpr[String]]): QExpr[String] = exprs match {
       case Nil      => QExpr("")
       case x :: Nil => x
-      case x :: xs  => xs.foldLeft(x)((acc, next) => '{ $acc + $next })
+      case x :: xs  =>
+        xs.foldLeft(x)((acc, next) => Select.overloaded(acc.asTerm, "+", Nil, List(next.asTerm)).asExprOf[String])
     }
   }
 }

--- a/hearth-better-printers/src/main/scala-3/hearth/treeprinter/RuntimeAwareTypePrinterScala3.scala
+++ b/hearth-better-printers/src/main/scala-3/hearth/treeprinter/RuntimeAwareTypePrinterScala3.scala
@@ -41,12 +41,25 @@ trait RuntimeAwareTypePrinterScala3 {
       tpe match {
         case AppliedType(tycon, args) => AppliedType(dealiasAll(tycon), args.map(dealiasAll(_)))
         case OrType(left, right)      => OrType(dealiasAll(left), dealiasAll(right))
+        case AndType(left, right)     => AndType(dealiasAll(left), dealiasAll(right))
         case _                        => tpe.dealias
       }
 
-    private def flattenOrType(tpe: TypeRepr): List[TypeRepr] = dealiasAll(tpe) match {
-      case OrType(left, right) => flattenOrType(left) ++ flattenOrType(right)
+    private def flattenCompoundType(tpe: TypeRepr): Option[(List[TypeRepr], String)] =
+      dealiasAll(tpe) match {
+        case OrType(left, right)  => Some((flattenOr(left) ++ flattenOr(right), " | "))
+        case AndType(left, right) => Some((flattenAnd(left) ++ flattenAnd(right), " & "))
+        case _                    => None
+      }
+
+    private def flattenOr(tpe: TypeRepr): List[TypeRepr] = dealiasAll(tpe) match {
+      case OrType(left, right) => flattenOr(left) ++ flattenOr(right)
       case other               => List(other)
+    }
+
+    private def flattenAnd(tpe: TypeRepr): List[TypeRepr] = dealiasAll(tpe) match {
+      case AndType(left, right) => flattenAnd(left) ++ flattenAnd(right)
+      case other                => List(other)
     }
 
     def print(
@@ -66,10 +79,12 @@ trait RuntimeAwareTypePrinterScala3 {
                   intersperse(argExprs, QExpr(", ")) :::
                   QExpr("]") :: Nil
               concatExprs(optimizeLiterals(parts))
-            case ort @ OrType(_, _) if hasOverrideInOrType(ort, overrideFn) =>
-              val members = flattenOrType(ort)
+            case compound if flattenCompoundType(compound).exists { case (members, _) =>
+                  hasOverrideInCompound(members, overrideFn)
+                } =>
+              val (members, sep) = flattenCompoundType(compound).get
               val memberExprs = members.map(m => print(m, overrideFn, printType))
-              concatExprs(optimizeLiterals(intersperse(memberExprs, QExpr(" | "))))
+              concatExprs(optimizeLiterals(intersperse(memberExprs, QExpr(sep))))
             case _ =>
               QExpr(printType(tpe))
           }
@@ -79,19 +94,25 @@ trait RuntimeAwareTypePrinterScala3 {
       types.exists { tpe =>
         overrideFn(tpe).isDefined || (dealiasAll(tpe) match {
           case AppliedType(_, args) if args.nonEmpty => hasOverrideInTree(args, overrideFn)
-          case _: OrType                             => hasOverrideInOrType(tpe, overrideFn)
+          case _: OrType | _: AndType                => hasOverrideInCompound(flattenCompound(tpe), overrideFn)
           case _                                     => false
         })
       }
 
-    private def hasOverrideInOrType(tpe: TypeRepr, overrideFn: TypeRepr => Option[QExpr[String]]): Boolean =
-      flattenOrType(tpe).exists { member =>
+    private def hasOverrideInCompound(members: List[TypeRepr], overrideFn: TypeRepr => Option[QExpr[String]]): Boolean =
+      members.exists { member =>
         overrideFn(member).isDefined || (dealiasAll(member) match {
           case AppliedType(_, args) if args.nonEmpty => hasOverrideInTree(args, overrideFn)
-          case _: OrType                             => hasOverrideInOrType(member, overrideFn)
+          case _: OrType | _: AndType                => hasOverrideInCompound(flattenCompound(member), overrideFn)
           case _                                     => false
         })
       }
+
+    private def flattenCompound(tpe: TypeRepr): List[TypeRepr] = dealiasAll(tpe) match {
+      case OrType(left, right)  => flattenOr(left) ++ flattenOr(right)
+      case AndType(left, right) => flattenAnd(left) ++ flattenAnd(right)
+      case other                => List(other)
+    }
 
     private def intersperse[A](list: List[A], sep: A): List[A] = list match {
       case Nil      => Nil

--- a/hearth-micro-fp/src/main/scala/hearth/fp/effect/MIO.scala
+++ b/hearth-micro-fp/src/main/scala/hearth/fp/effect/MIO.scala
@@ -306,7 +306,7 @@ object MIO {
       Pure(s1, Right(scopeId))
     } flatMap { scopeId =>
       io :+ { (s, r) =>
-        _openScopes = _openScopes.tail
+        _openScopes = if (_openScopes.nonEmpty) _openScopes.tail else Nil
         val end = if (benchmarkScopes) Log.Timestamp.now else Log.Timestamp.empty
         Pure(s.closeScope(scopeId, end), r)
       }

--- a/hearth-micro-fp/src/main/scala/hearth/fp/effect/MState.scala
+++ b/hearth-micro-fp/src/main/scala/hearth/fp/effect/MState.scala
@@ -95,7 +95,7 @@ final case class MState private[effect] (
     MState(
       locals,
       updatedLogs,
-      scopeStack.tail,
+      if (scopeStack.nonEmpty) scopeStack.tail else Nil,
       closedScopes + scopeId
     )
   }

--- a/hearth-tests/src/main/scala-3/hearth/treeprinter/RuntimeAwareTypePrinterFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/treeprinter/RuntimeAwareTypePrinterFixtures.scala
@@ -24,4 +24,8 @@ object RuntimeAwareTypePrinterFixtures {
   inline def testShortWithOverride[A]: String = ${ testShortWithOverrideImpl[A] }
   private def testShortWithOverrideImpl[A: Type](using q: Quotes): Expr[String] =
     new RuntimeAwareTypePrinterFixtures(q).testShortWithOverride[A]
+
+  inline def testNoOverrideUnion[A]: String = ${ testNoOverrideImpl[A] }
+  inline def testWithOverrideUnion[A]: String = ${ testWithOverrideImpl[A] }
+  inline def testShortWithOverrideUnion[A]: String = ${ testShortWithOverrideImpl[A] }
 }

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprsScala3Fixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprsScala3Fixtures.scala
@@ -158,6 +158,57 @@ final private class ExprsScala3Fixtures(q: Quotes) extends MacroCommonsScala3(us
     withQuotes{'{ Data(${ passQuotes{result} }) }}
   }
 
+  private def semiEvalToData(result: Either[hearth.fp.data.NonEmptyVector[String], Any]): Data =
+    result match {
+      case Right(value) =>
+        Data.map(
+          "status" -> Data("success"),
+          "value" -> Data(if (value == null) "null" else value.toString),
+          "class" -> Data(if (value == null) "null" else value.getClass.getName)
+        )
+      case Left(errors) =>
+        Data.map(
+          "status" -> Data("failure"),
+          "errors" -> Data(errors.toList.map(Data(_)))
+        )
+    }
+
+  def testSemiEvalIsInstanceOfTrue: Expr[Data] = {
+    import quotes.reflect.*
+    val tree = TypeApply(
+      Select.unique(Literal(StringConstant("hello")), "isInstanceOf"),
+      List(TypeTree.of[String])
+    )
+    Expr(semiEvalToData(tree.asExprOf[Boolean].semiEval))
+  }
+
+  def testSemiEvalIsInstanceOfFalse: Expr[Data] = {
+    import quotes.reflect.*
+    val tree = TypeApply(
+      Select.unique(Literal(IntConstant(42)), "isInstanceOf"),
+      List(TypeTree.of[String])
+    )
+    Expr(semiEvalToData(tree.asExprOf[Boolean].semiEval))
+  }
+
+  def testSemiEvalIsInstanceOfSupertype: Expr[Data] = {
+    import quotes.reflect.*
+    val tree = TypeApply(
+      Select.unique(Literal(StringConstant("hello")), "isInstanceOf"),
+      List(TypeTree.of[AnyRef])
+    )
+    Expr(semiEvalToData(tree.asExprOf[Boolean].semiEval))
+  }
+
+  def testSemiEvalAsInstanceOf: Expr[Data] = {
+    import quotes.reflect.*
+    val tree = TypeApply(
+      Select.unique(Literal(IntConstant(42)), "asInstanceOf"),
+      List(TypeTree.of[Any])
+    )
+    Expr(semiEvalToData(tree.asExprOf[Any].semiEval))
+  }
+
   def testSemiEvalValueOf: Expr[Data] = {
     import quotes.reflect.*
     val valueOfExpr = Apply(
@@ -281,6 +332,22 @@ object ExprsScala3Fixtures {
   inline def testValDefBuilderOfVarScopeIssue: Data = ${ testValDefBuilderOfVarScopeIssueImpl }
   private def testValDefBuilderOfVarScopeIssueImpl(using q: Quotes): Expr[Data] =
     new ExprsScala3Fixtures(q).testValDefBuilderOfVarScopeIssue
+
+  inline def testSemiEvalIsInstanceOfTrue: Data = ${ testSemiEvalIsInstanceOfTrueImpl }
+  private def testSemiEvalIsInstanceOfTrueImpl(using q: Quotes): Expr[Data] =
+    new ExprsScala3Fixtures(q).testSemiEvalIsInstanceOfTrue
+
+  inline def testSemiEvalIsInstanceOfFalse: Data = ${ testSemiEvalIsInstanceOfFalseImpl }
+  private def testSemiEvalIsInstanceOfFalseImpl(using q: Quotes): Expr[Data] =
+    new ExprsScala3Fixtures(q).testSemiEvalIsInstanceOfFalse
+
+  inline def testSemiEvalIsInstanceOfSupertype: Data = ${ testSemiEvalIsInstanceOfSupertypeImpl }
+  private def testSemiEvalIsInstanceOfSupertypeImpl(using q: Quotes): Expr[Data] =
+    new ExprsScala3Fixtures(q).testSemiEvalIsInstanceOfSupertype
+
+  inline def testSemiEvalAsInstanceOf: Data = ${ testSemiEvalAsInstanceOfImpl }
+  private def testSemiEvalAsInstanceOfImpl(using q: Quotes): Expr[Data] =
+    new ExprsScala3Fixtures(q).testSemiEvalAsInstanceOf
 
   inline def testSemiEvalValueOf: Data = ${ testSemiEvalValueOfImpl }
   private def testSemiEvalValueOfImpl(using q: Quotes): Expr[Data] =

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprsScala3Fixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprsScala3Fixtures.scala
@@ -158,6 +158,31 @@ final private class ExprsScala3Fixtures(q: Quotes) extends MacroCommonsScala3(us
     withQuotes{'{ Data(${ passQuotes{result} }) }}
   }
 
+  def testSemiEvalValueOf: Expr[Data] = {
+    import quotes.reflect.*
+    val valueOfExpr = Apply(
+      TypeApply(
+        Select(New(TypeTree.of[ValueOf[42]]), TypeRepr.of[ValueOf[42]].typeSymbol.primaryConstructor),
+        List(TypeTree.of[42])
+      ),
+      List(Literal(IntConstant(42)))
+    ).asExprOf[ValueOf[42]]
+    val result = valueOfExpr.semiEval match {
+      case Right(value) =>
+        Data.map(
+          "status" -> Data("success"),
+          "value" -> Data(value.toString),
+          "class" -> Data(value.getClass.getName)
+        )
+      case Left(errors) =>
+        Data.map(
+          "status" -> Data("failure"),
+          "errors" -> Data(errors.toList.map(Data(_)))
+        )
+    }
+    Expr(result)
+  }
+
   def testValDefBuilderOfLazyScopeIssue: Expr[Data] = {
     def result: Expr[Int] = withQuotes {
       '{
@@ -256,6 +281,10 @@ object ExprsScala3Fixtures {
   inline def testValDefBuilderOfVarScopeIssue: Data = ${ testValDefBuilderOfVarScopeIssueImpl }
   private def testValDefBuilderOfVarScopeIssueImpl(using q: Quotes): Expr[Data] =
     new ExprsScala3Fixtures(q).testValDefBuilderOfVarScopeIssue
+
+  inline def testSemiEvalValueOf: Data = ${ testSemiEvalValueOfImpl }
+  private def testSemiEvalValueOfImpl(using q: Quotes): Expr[Data] =
+    new ExprsScala3Fixtures(q).testSemiEvalValueOf
 
   inline def testValDefBuilderOfLazyScopeIssue: Data = ${ testValDefBuilderOfLazyScopeIssueImpl }
   private def testValDefBuilderOfLazyScopeIssueImpl(using q: Quotes): Expr[Data] =

--- a/hearth-tests/src/test/scala-3/hearth/treeprinter/RuntimeAwareTypePrinterScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/treeprinter/RuntimeAwareTypePrinterScala3Spec.scala
@@ -1,0 +1,59 @@
+package hearth
+package treeprinter
+
+final class RuntimeAwareTypePrinterScala3Spec extends MacroSuite {
+
+  group("runtimeAwareTypePrint — union types (Scala 3 only)") {
+
+    group("no overrides") {
+
+      test("for String | Int") {
+        assert(
+          RuntimeAwareTypePrinterFixtures.testNoOverrideUnion[String | Int] ==
+            "java.lang.String | scala.Int"
+        )
+      }
+
+      test("for String | Int | Boolean") {
+        assert(
+          RuntimeAwareTypePrinterFixtures.testNoOverrideUnion[String | Int | Boolean] ==
+            "java.lang.String | scala.Int | scala.Boolean"
+        )
+      }
+    }
+
+    group("with overrides") {
+
+      test("String | Int — overrides String member") {
+        assert(
+          RuntimeAwareTypePrinterFixtures.testWithOverrideUnion[String | Int] ==
+            "RUNTIME_STRING | RUNTIME_INT"
+        )
+      }
+
+      test("String | Boolean — only String overridden") {
+        assert(
+          RuntimeAwareTypePrinterFixtures.testWithOverrideUnion[String | Boolean] ==
+            "RUNTIME_STRING | scala.Boolean"
+        )
+      }
+
+      test("Boolean | Double — no overrides match, falls through to plain print") {
+        assert(
+          RuntimeAwareTypePrinterFixtures.testWithOverrideUnion[Boolean | Double] ==
+            "scala.Boolean | scala.Double"
+        )
+      }
+    }
+
+    group("short print with overrides") {
+
+      test("String | Int") {
+        assert(
+          RuntimeAwareTypePrinterFixtures.testShortWithOverrideUnion[String | Int] ==
+            "RUNTIME_STRING | Int"
+        )
+      }
+    }
+  }
+}

--- a/hearth-tests/src/test/scala-3/hearth/treeprinter/RuntimeAwareTypePrinterScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/treeprinter/RuntimeAwareTypePrinterScala3Spec.scala
@@ -1,6 +1,9 @@
 package hearth
 package treeprinter
 
+trait Marker1
+trait Marker2
+
 final class RuntimeAwareTypePrinterScala3Spec extends MacroSuite {
 
   group("runtimeAwareTypePrint — union types (Scala 3 only)") {
@@ -53,6 +56,30 @@ final class RuntimeAwareTypePrinterScala3Spec extends MacroSuite {
           RuntimeAwareTypePrinterFixtures.testShortWithOverrideUnion[String | Int] ==
             "RUNTIME_STRING | Int"
         )
+      }
+    }
+  }
+
+  group("runtimeAwareTypePrint — intersection types (Scala 3 only)") {
+
+    group("no overrides") {
+
+      test("for Marker1 & Marker2") {
+        val result = RuntimeAwareTypePrinterFixtures.testNoOverrideUnion[Marker1 & Marker2]
+        assert(
+          result.contains("Marker1") && result.contains("Marker2"),
+          s"Expected both Marker1 and Marker2 in: $result"
+        )
+      }
+    }
+
+    group("with overrides — uses String & Int to test component override") {
+
+      test("String & Int — overrides both components") {
+        val result = RuntimeAwareTypePrinterFixtures.testWithOverrideUnion[String & Int]
+        assert(result.contains("RUNTIME_STRING"), s"Expected RUNTIME_STRING in: $result")
+        assert(result.contains("RUNTIME_INT"), s"Expected RUNTIME_INT in: $result")
+        assert(result.contains(" & "), s"Expected ' & ' separator in: $result")
       }
     }
   }

--- a/hearth-tests/src/test/scala-3/hearth/typed/ExprsScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/ExprsScala3Spec.scala
@@ -118,7 +118,39 @@ final class ExprsScala3Spec extends MacroSuite {
       }
     }
 
-    group("method Expr.semiEval — ValueOf unwrapping") {
+    group("method Expr.semiEval — asInstanceOf/isInstanceOf/ValueOf") {
+
+      test("isInstanceOf should return true when type matches") {
+        ExprsScala3Fixtures.testSemiEvalIsInstanceOfTrue <==> Data.map(
+          "status" -> Data("success"),
+          "value" -> Data("true"),
+          "class" -> Data("java.lang.Boolean")
+        )
+      }
+
+      test("isInstanceOf should return false when type does not match") {
+        ExprsScala3Fixtures.testSemiEvalIsInstanceOfFalse <==> Data.map(
+          "status" -> Data("success"),
+          "value" -> Data("false"),
+          "class" -> Data("java.lang.Boolean")
+        )
+      }
+
+      test("isInstanceOf should return true for supertype") {
+        ExprsScala3Fixtures.testSemiEvalIsInstanceOfSupertype <==> Data.map(
+          "status" -> Data("success"),
+          "value" -> Data("true"),
+          "class" -> Data("java.lang.Boolean")
+        )
+      }
+
+      test("asInstanceOf should pass through value") {
+        ExprsScala3Fixtures.testSemiEvalAsInstanceOf <==> Data.map(
+          "status" -> Data("success"),
+          "value" -> Data("42"),
+          "class" -> Data("java.lang.Integer")
+        )
+      }
 
       test("should evaluate ValueOf constructor successfully") {
         val result = ExprsScala3Fixtures.testSemiEvalValueOf

--- a/hearth-tests/src/test/scala-3/hearth/typed/ExprsScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/ExprsScala3Spec.scala
@@ -117,5 +117,14 @@ final class ExprsScala3Spec extends MacroSuite {
         )
       }
     }
+
+    group("method Expr.semiEval — ValueOf unwrapping") {
+
+      test("should evaluate ValueOf constructor successfully") {
+        val result = ExprsScala3Fixtures.testSemiEvalValueOf
+        assert(result.get("status").contains(Data("success")), s"Expected status=success, got: $result")
+        assert(result.get("class").contains(Data("scala.ValueOf")), s"Expected class=scala.ValueOf, got: $result")
+      }
+    }
   }
 }

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -318,6 +318,7 @@ final class ExprsSpec extends MacroSuite {
           )
         }
       }
+
     }
 
     group("type VarArgs") {

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -206,6 +206,18 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
         case Typed(inner, _) =>
           evalWithLocals(inner, locals)
 
+        case TypeApply(Select(qualifier, name), typeArgs)
+            if name.decodedName.toString == "isInstanceOf" && typeArgs.size == 1 =>
+          evalWithLocals(qualifier, locals).flatMap { receiver =>
+            runtimeClassOf(typeArgs.head.tpe) match {
+              case Some(clazz) => Right(clazz.isInstance(receiver))
+              case None        => Right(true)
+            }
+          }
+
+        case TypeApply(Select(qualifier, _), _) if tree.symbol.name.decodedName.toString == "asInstanceOf" =>
+          evalWithLocals(qualifier, locals)
+
         case TypeApply(inner, _) =>
           evalWithLocals(inner, locals)
 
@@ -346,6 +358,31 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
         catch { case _: Throwable => None }
       }
 
+      private def runtimeClassOf(tpe: c.Type): Option[java.lang.Class[?]] = {
+        val dealiased = tpe.dealias.widen
+        val name = dealiased.typeSymbol.fullName
+        val primitives = Map(
+          "scala.Boolean" -> classOf[java.lang.Boolean],
+          "scala.Byte" -> classOf[java.lang.Byte],
+          "scala.Short" -> classOf[java.lang.Short],
+          "scala.Int" -> classOf[java.lang.Integer],
+          "scala.Long" -> classOf[java.lang.Long],
+          "scala.Float" -> classOf[java.lang.Float],
+          "scala.Double" -> classOf[java.lang.Double],
+          "scala.Char" -> classOf[java.lang.Character]
+        )
+        primitives.get(name).orElse {
+          moduleCandidates(name)
+            .filterNot(_.endsWith("$"))
+            .iterator
+            .flatMap(n =>
+              try Some(java.lang.Class.forName(n))
+              catch { case _: Throwable => None }
+            )
+            .nextOption()
+        }
+      }
+
       private def evalConstructor(tpe: c.Type, argTrees: List[Tree], locals: Map[Symbol, Any]): Result = {
         val className = tpe.typeSymbol.fullName
         val classOpt = moduleCandidates(className)
@@ -370,7 +407,6 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
 
       private def invokeMethod(receiver: Any, name: String, args: List[Any]): Result = {
         if (name == "asInstanceOf" && args.isEmpty) return Right(receiver)
-        if (name == "isInstanceOf" && args.isEmpty) return Right(true)
         val clazz = receiver.getClass
         val encodedName = scala.reflect.NameTransformer.encode(name)
         val candidates = (clazz.getMethods.filter(_.getName == name) ++

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -369,6 +369,8 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
         invokeMethod(receiver, name, Nil)
 
       private def invokeMethod(receiver: Any, name: String, args: List[Any]): Result = {
+        if (name == "asInstanceOf" && args.isEmpty) return Right(receiver)
+        if (name == "isInstanceOf" && args.isEmpty) return Right(true)
         val clazz = receiver.getClass
         val encodedName = scala.reflect.NameTransformer.encode(name)
         val candidates = (clazz.getMethods.filter(_.getName == name) ++

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -203,6 +203,17 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         case Typed(inner, _) =>
           evalWithLocals(inner, locals)
 
+        case TypeApply(Select(qualifier, name), typeArgs) if name == "isInstanceOf" && typeArgs.size == 1 =>
+          evalWithLocals(qualifier, locals).flatMap { receiver =>
+            runtimeClassOf(typeArgs.head.tpe) match {
+              case Some(clazz) => Right(clazz.isInstance(receiver))
+              case None        => Right(true)
+            }
+          }
+
+        case TypeApply(Select(qualifier, _), _) if term.symbol.name == "asInstanceOf" =>
+          evalWithLocals(qualifier, locals)
+
         case TypeApply(inner, _) =>
           evalWithLocals(inner, locals)
 
@@ -496,6 +507,31 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         catch { case _: Throwable => None }
       }
 
+      private def runtimeClassOf(tpe: TypeRepr): Option[java.lang.Class[?]] = {
+        val dealiased = tpe.dealias.widen
+        val name = dealiased.typeSymbol.fullName
+        val primitives = Map(
+          "scala.Boolean" -> classOf[java.lang.Boolean],
+          "scala.Byte" -> classOf[java.lang.Byte],
+          "scala.Short" -> classOf[java.lang.Short],
+          "scala.Int" -> classOf[java.lang.Integer],
+          "scala.Long" -> classOf[java.lang.Long],
+          "scala.Float" -> classOf[java.lang.Float],
+          "scala.Double" -> classOf[java.lang.Double],
+          "scala.Char" -> classOf[java.lang.Character]
+        )
+        primitives.get(name).orElse {
+          moduleCandidates(name)
+            .filterNot(_.endsWith("$"))
+            .iterator
+            .flatMap(n =>
+              try Some(java.lang.Class.forName(n))
+              catch { case _: Throwable => None }
+            )
+            .nextOption()
+        }
+      }
+
       private def evalConstructor(tpe: TypeRepr, argTrees: List[Term], locals: Map[Symbol, Any]): Result = {
         val className = tpe.typeSymbol.fullName
         val classOpt = moduleCandidates(className)
@@ -533,7 +569,6 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
 
       private def invokeMethod(receiver: Any, name: String, args: List[Any]): Result = {
         if name == "asInstanceOf" && args.isEmpty then return Right(receiver)
-        if name == "isInstanceOf" && args.isEmpty then return Right(true)
         val clazz = receiver.getClass
         val encodedName = scala.reflect.NameTransformer.encode(name)
         val candidates = (clazz.getMethods.filter(_.getName == name) ++

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -145,7 +145,8 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       expr.asInstanceOf[Expr[B]] // check that A <:< B without upcasting in code (Scala 3 should get away without it)
     }
 
-    override def suppressUnused[A: Type](expr: Expr[A]): Expr[Unit] = '{ val _ = $expr; () }
+    override def suppressUnused[A: Type](expr: Expr[A]): Expr[Unit] =
+      Block(List(expr.asTerm), Literal(UnitConstant())).asExprOf[Unit]
 
     override def singletonOf[A: Type]: Option[Expr[A]] = {
       import quotes.reflect.*
@@ -745,7 +746,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         val byArity = candidates.filter(_.getParameterCount == args.size)
         val exactMatch =
           if byArity.isEmpty then None
-          else if byArity.size == 1 then Some((byArity.head, args))
+          else if byArity.size == 1 then Some((byArity.head, adaptArgs(byArity.head, args)))
           else {
             val matching = byArity.filter { exec =>
               val paramTypes = exec.getParameterTypes
@@ -755,8 +756,16 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             }
             matching match {
               case single :: Nil => Some((single, args))
-              case Nil           => None
-              case multiple      => Some((multiple.minBy(_.getParameterTypes.count(_ == classOf[Object])), args))
+              case Nil           =>
+                byArity
+                  .find { exec =>
+                    val adapted = adaptArgs(exec, args)
+                    exec.getParameterTypes.zip(adapted).forall { case (paramType, arg) =>
+                      arg == null || boxedType(paramType).isAssignableFrom(arg.getClass)
+                    }
+                  }
+                  .map(exec => (exec, adaptArgs(exec, args)))
+              case multiple => Some((multiple.minBy(_.getParameterTypes.count(_ == classOf[Object])), args))
             }
           }
         exactMatch match {
@@ -764,6 +773,14 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
           case None         => tryVarargs(candidates, args, kind)
         }
       }
+
+      private def adaptArgs(exec: java.lang.reflect.Executable, args: List[Any]): List[Any] =
+        exec.getParameterTypes.toList.zip(args).map { case (paramType, arg) =>
+          arg match {
+            case vo: ValueOf[?] if !boxedType(paramType).isAssignableFrom(arg.getClass) => vo.value
+            case _                                                                      => arg
+          }
+        }
 
       private def tryVarargs[E <: java.lang.reflect.Executable](
           candidates: List[E],
@@ -1308,7 +1325,14 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
     }
 
     override def matchOn[A: Type, B: Type](toMatch: Expr[A])(cases: NonEmptyVector[MatchCase[Expr[B]]]): Expr[B] = {
-      val uncheckedToMatch = '{ ${ toMatch.asTerm.changeOwner(Symbol.spliceOwner).asExprOf[A] }: @scala.unchecked }
+      val uncheckedAnnot = Apply(
+        Select(New(TypeTree.of[unchecked]), TypeRepr.of[unchecked].typeSymbol.primaryConstructor),
+        Nil
+      )
+      val uncheckedToMatch = Typed(
+        toMatch.asTerm.changeOwner(Symbol.spliceOwner),
+        Annotated(TypeTree.of[A], uncheckedAnnot)
+      )
 
       val caseTrees = cases
         .map {
@@ -1365,7 +1389,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         .toVector
         .toList
 
-      Match(uncheckedToMatch.asTerm, caseTrees).asExprOf[B]
+      Match(uncheckedToMatch, caseTrees).asExprOf[B]
     }
 
     override def partition[A, B, C](matchCase: MatchCase[A])(f: A => Either[B, C]): Either[MatchCase[B], MatchCase[C]] =

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -532,6 +532,8 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       }
 
       private def invokeMethod(receiver: Any, name: String, args: List[Any]): Result = {
+        if name == "asInstanceOf" && args.isEmpty then return Right(receiver)
+        if name == "isInstanceOf" && args.isEmpty then return Right(true)
         val clazz = receiver.getClass
         val encodedName = scala.reflect.NameTransformer.encode(name)
         val candidates = (clazz.getMethods.filter(_.getName == name) ++

--- a/hearth/src/main/scala-3/hearth/typed/TypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/TypesScala3.scala
@@ -49,6 +49,7 @@ trait TypesScala3 extends Types { this: MacroCommonsScala3 =>
     private def dealiasAll(tpe: TypeRepr): TypeRepr =
       tpe match {
         case AppliedType(tycon, args) => AppliedType(dealiasAll(tycon), args.map(dealiasAll(_)))
+        case OrType(left, right)      => OrType(dealiasAll(left), dealiasAll(right))
         case _                        => tpe.dealias
       }
 

--- a/hearth/src/main/scala-3/hearth/typed/TypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/TypesScala3.scala
@@ -50,6 +50,7 @@ trait TypesScala3 extends Types { this: MacroCommonsScala3 =>
       tpe match {
         case AppliedType(tycon, args) => AppliedType(dealiasAll(tycon), args.map(dealiasAll(_)))
         case OrType(left, right)      => OrType(dealiasAll(left), dealiasAll(right))
+        case AndType(left, right)     => AndType(dealiasAll(left), dealiasAll(right))
         case _                        => tpe.dealias
       }
 


### PR DESCRIPTION
## Summary

- Fix Scala 3 splice isolation in `matchOn` and `suppressUnused` by replacing quoted syntax with reflect API
- Add union type (`OrType`) support to `RuntimeAwareTypePrinter` and replace quoted `concatExprs` with reflect API
- Add `LiteralType` handling to Scala 2 `showCodePretty` (distinct from `FoldableConstantType` since Scala 2.13)
- Handle `asInstanceOf`/`isInstanceOf` as compiler intrinsics in `semiEval` — `isInstanceOf` resolves the runtime `Class` and checks via `Class.isInstance`
- Unwrap `ValueOf[T]` arguments in `semiEval` method invocation when they don't match erased parameter types
- Guard `scopeStack.tail` in `MState.closeScope` against empty list during MIO timeout reconstruction

## Test plan

- [x] All Hearth tests pass on both Scala 2.13 and 3 (2,833 tests)
- [ ] ~Kindlings circe/sconfig/pureconfig encoder tests pass on Scala 3 (including `CombOuter` with `Option[SealedTrait]`)~ fixed in followup #279 
- [x] refined-compat passes all 60 predicate coverage tests on both Scala 2.13 and 3 (numeric, string, collection, generic, boolean composition, type aliases)
- [x] New regression tests: union type printing (6), ValueOf semiEval (1), isInstanceOf true/false/supertype (3), asInstanceOf passthrough (1)