### PR TITLE
Fix splice isolation for nested Expr.quote and private setter/field visibility

### DIFF
--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -1361,6 +1361,12 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       EqValue(name, matched.as_??, expr.as_??, matched)
     }
 
+    @scala.annotation.tailrec
+    private def stripInlined(term: Term): Term = term match {
+      case Inlined(_, Nil, inner) => stripInlined(inner)
+      case _                      => term
+    }
+
     override def matchOn[A: Type, B: Type](toMatch: Expr[A])(cases: NonEmptyVector[MatchCase[Expr[B]]]): Expr[B] = {
       val uncheckedAnnot = Apply(
         Select(New(TypeTree.of[unchecked]), TypeRepr.of[unchecked].typeSymbol.primaryConstructor),
@@ -1377,11 +1383,9 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             import expr.{Underlying as Matched, value as toSuppress}
 
             // val body = '{ val _ = $toSuppress; $result }
-            // We're constructing:
-            // '{ val fromName = bindName; val _ = fromName; ${ usage } }
             val body = Block(
               List(Expr.suppressUnused(toSuppress).asTerm),
-              result.asTerm
+              stripInlined(result.asTerm)
             )
 
             val sym = TypeRepr.of[Matched].typeSymbol
@@ -1396,11 +1400,9 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             import matchedExpr.value as toSuppress
             import valueExpr.{Underlying as ValueType, value as valueRef}
             // val body = '{ val _ = $valueRef; $result }
-            // We're constructing:
-            // '{ val _ = ref; ${ usage } }
             val body = Block(
               List(Expr.suppressUnused(toSuppress).asTerm),
-              result.asTerm
+              stripInlined(result.asTerm)
             )
             val valueTerm = valueRef.asTerm
             valueTerm match {

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -492,15 +492,14 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
           }
           .filterNot(excludedMethods)
           .flatMap { s =>
-            val fieldName = s.name.pipe { name =>
-              if name.endsWith("_=") then name.dropRight(2) else name
-            }
+            val isSetter = s.name.endsWith("_=")
+            val fieldName = if isSetter then s.name.dropRight(2) else s.name
             val module = moduleBySymbol.get(s)
             UntypedMethod.parseOption(
               isDeclared = declared(s) && !methodsConsideredSynthetic(s),
-              isConstructorArgument = constructorArguments.contains(fieldName),
-              constructorArgumentIndex = constructorArguments.get(fieldName),
-              isCaseField = caseFields(fieldName),
+              isConstructorArgument = constructorArguments.contains(fieldName) && !isSetter,
+              constructorArgumentIndex = if isSetter then None else constructorArguments.get(fieldName),
+              isCaseField = caseFields(fieldName) && !isSetter,
               module = module
             )(s)
           }

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -41,22 +41,31 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
         }
 
       def symbolAvailable(symbol: Symbol, scope: Accessible): Boolean = {
-        val owner = symbol.owner
+        // For setters (name_=), visibility may only be recorded on the corresponding getter/val.
+        // Look it up so that e.g. private[scala] var next propagates to next_=.
+        val effectiveSymbol =
+          if symbol.name.endsWith("_=") then symbol.owner.fieldMember(symbol.name.stripSuffix("_=")) match {
+            case s if !s.isNoSymbol => s
+            case _                  => symbol
+          }
+          else symbol
+
+        val owner = effectiveSymbol.owner
         val enclosing = Symbol.spliceOwner
         def enclosings = Iterator.iterate(enclosing)(_.owner).takeWhile(!_.isNoSymbol)
 
         // Helper methods
-        def isPrivate: Boolean = symbol.flags.is(Flags.Private)
-        def isProtected: Boolean = symbol.flags.is(Flags.Protected)
+        def isPrivate: Boolean = effectiveSymbol.flags.is(Flags.Private)
+        def isProtected: Boolean = effectiveSymbol.flags.is(Flags.Protected)
 
         // High-level checks
         def isPublic: Boolean =
-          !isPrivate && !isProtected && symbol.privateWithin.isEmpty && symbol.protectedWithin.isEmpty
+          !isPrivate && !isProtected && effectiveSymbol.privateWithin.isEmpty && effectiveSymbol.protectedWithin.isEmpty
         def isPrivateButInTheSameClass: Boolean = isPrivate && enclosing == owner
         def isProtectedButInTheSameClass: Boolean =
           isProtected && enclosing.isClassDef && (enclosing.typeRef <:< owner.typeRef)
         def isPrivateWithinButInTheRightPlace: Boolean =
-          symbol.privateWithin.orElse(symbol.protectedWithin).exists { pw =>
+          effectiveSymbol.privateWithin.orElse(effectiveSymbol.protectedWithin).exists { pw =>
             val pwType = pw.typeSymbol
             enclosings.exists(e => pwType == e || pwType == e.companionClass || pwType == e.companionModule)
           }

--- a/hearth/src/main/scala/hearth/typed/Classes.scala
+++ b/hearth/src/main/scala/hearth/typed/Classes.scala
@@ -254,7 +254,10 @@ trait Classes { this: MacroCommons =>
         }
       }
 
-    def caseFieldValuesAt(instance: Expr[A]): ListMap[String, Expr_??] = ListMap.from(caseFields.map { field =>
+    def caseFieldValuesAt(
+        instance: Expr[A],
+        visibility: Accessible = Everywhere
+    ): ListMap[String, Expr_??] = ListMap.from(caseFields.filter(_.value.isAvailable(visibility)).map { field =>
       (field.value match {
         case method: Method.OfInstance[A, ?] if method.isNullary =>
           import method.Returned


### PR DESCRIPTION
## Summary

- Strip `Inlined` wrappers from match case body results in `matchOn` — prevents splice ownership from inner `Expr.quote` calls (used in `parMatchOn` handlers) from crossing splice boundaries. Fixes `CombOuter` with `Option[SealedTrait]` on Scala 3.
- Exclude setters (`name_=`) from being marked as constructor arguments or case fields
- Propagate visibility from getter/val to setter in `symbolAvailable` — look up the field symbol so `private[scala] var next` correctly restricts `next_=`
- Add `visibility` parameter to `CaseClass.caseFieldValuesAt` (default `Everywhere`) so consumers can pass `AtCallSite` to skip inaccessible fields

## Test plan

- [x] All Hearth tests pass (2,835 tests, both Scala versions)
- [x] Kindlings circe-derivation passes (419 Scala 3) — CombOuter with Option[SealedTrait] compiles
- [x] Kindlings diff-derivation passes (253 Scala 3) — CombOuter with List[CaseClass] compiles
- [x] Kindlings sconfig/pureconfig pass on Scala 3
- [x] All modules pass on Scala 2.13