### PR TITLE
Bump Scala 3 to 3.3.8, enable -Yfuture-lazy-vals, bump newest 3 to 3.8.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This document provides guidelines for AI agents (like Claude Code, GitHub Copilo
 **Hearth** is the first Scala macros' standard library, designed to make macro development easier and more maintainable across Scala 2.13 and Scala 3.
 
 - **Language**: Scala (pure Scala library)
-- **Scala Versions**: 2.13.16, 3.3.7 (primary); 2.13.18, 3.8.3 (regression testing)
+- **Scala Versions**: 2.13.16, 3.3.8 (primary); 2.13.18, 3.8.4 (regression testing)
 - **Platforms**: JVM, Scala.js, Scala Native
 - **Build Tool**: SBT (but see restrictions below)
 - **License**: Apache 2.0

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val isNewestScalaTests = sys.env.get("NEWEST_SCALA_TESTS").contains("true")
 val versions = new {
   // Versions we are publishing for.
   val scala213 = "2.13.16"
-  val scala3 = "3.3.7"
+  val scala3 = "3.3.8-RC2"
 
   // Versions we can compile tests against if needed, to check for regressions.
   val scala213Newest = "2.13.18"
@@ -143,7 +143,7 @@ val settings = Seq(
       "-Werror",
       "-Xcheck-macros"
     ) ++ (if (scalaVersion.value == versions.scala3Newest) Seq("-Xkind-projector:underscores")
-          else Seq("-Ykind-projector:underscores")),
+          else Seq("-Yfuture-lazy-vals", "-Ykind-projector:underscores")),
     for2_13 = Seq(
       // format: off
       "-encoding", "UTF-8",
@@ -325,7 +325,9 @@ lazy val root = (project in file("."))
     description := "Build setup for Hearth modules",
     logo :=
       s"""Hearth ${(version).value} build for (${versions.scala213}, ${versions.scala3}) x (Scala JVM, Scala.js $scalaJSVersion, Scala Native $nativeVersion)
-         |
+         |${if (isNewestScalaTests)
+          s" - Testing against Scala ${versions.scala213Newest} and ${versions.scala3Newest} for forward compatibility and newest features support\n"
+        else ""}
          |This build uses sbt-projectmatrix with sbt-commandmatrix helper:
          | - Scala JVM adds no suffix to a project name seen in build.sbt
          | - Scala.js adds the "JS" suffix to a project name seen in build.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,15 @@ val dev = new DevProperties(
   platforms = versions.platforms
 )
 
+val only1VersionInIDE = dev.only1VersionInIDE :+ MatrixAction
+  .ForPlatform(VirtualAxis.jvm)
+  .Configure(
+    _.settings(
+      // There is a bug in Scala Native 0.5.12 which crashes when seeing this flag, so we disable it for non-JVM.
+      scalacOptions ++= { if (scalaVersion.value == versions.scala3) Seq("-Yfuture-lazy-vals") else Seq.empty }
+    )
+  )
+
 val logCrossQuotes =
   dev.props.getProperty("log.cross-quotes") match {
     case "true"                          => true
@@ -143,7 +152,7 @@ val settings = Seq(
       "-Werror",
       "-Xcheck-macros"
     ) ++ (if (scalaVersion.value == versions.scala3Newest) Seq("-Xkind-projector:underscores")
-          else Seq("-Yfuture-lazy-vals", "-Ykind-projector:underscores")),
+          else Seq("-Ykind-projector:underscores")),
     for2_13 = Seq(
       // format: off
       "-encoding", "UTF-8",
@@ -190,6 +199,10 @@ val settings = Seq(
          )
        else Seq.empty)
   )
+)
+
+val jvmOnlySettings = Seq(
+  scalacOptions ++= { if (scalaVersion.value == versions.scala3) Seq("-Yfuture-lazy-vals") else Seq.empty }
 )
 
 val scalaNewestSettings = Seq(
@@ -365,7 +378,7 @@ lazy val root = (project in file("."))
 
 lazy val hearthBetterPrinters = projectMatrix
   .in(file("hearth-better-printers"))
-  .someVariations(versions.scalas, versions.platforms)(dev.only1VersionInIDE *)
+  .someVariations(versions.scalas, versions.platforms)(only1VersionInIDE *)
   .disablePlugins(WelcomePlugin)
   .settings(
     moduleName := "hearth-better-printers",
@@ -382,7 +395,7 @@ lazy val hearthBetterPrinters = projectMatrix
 
 lazy val hearthCrossQuotes = projectMatrix
   .in(file("hearth-cross-quotes"))
-  .someVariations(versions.scalas, versions.platforms)((defineCrossQuotes ++ dev.only1VersionInIDE) *)
+  .someVariations(versions.scalas, versions.platforms)((defineCrossQuotes ++ only1VersionInIDE) *)
   .enablePlugins(SourceGenPlugin)
   .disablePlugins(WelcomePlugin, MimaPlugin)
   .settings(
@@ -407,11 +420,12 @@ lazy val hearthCrossQuotes = projectMatrix
   )
   .settings(settings *)
   .settings(publishSettings *)
+  .jvmPlatform(Seq(versions.scala3), jvmOnlySettings)
   .dependsOn(hearthBetterPrinters)
 
 lazy val hearthMicroFp = projectMatrix
   .in(file("hearth-micro-fp"))
-  .someVariations(versions.scalas, versions.platforms)(dev.only1VersionInIDE *)
+  .someVariations(versions.scalas, versions.platforms)(only1VersionInIDE *)
   .disablePlugins(WelcomePlugin)
   .settings(
     moduleName := "hearth-micro-fp",
@@ -426,10 +440,11 @@ lazy val hearthMicroFp = projectMatrix
   .settings(publishSettings *)
   .settings(dependencies *)
   .settings(mimaSettings *)
+  .jvmPlatform(Seq(versions.scala3), jvmOnlySettings)
 
 lazy val hearth = projectMatrix
   .in(file("hearth"))
-  .someVariations(versions.scalas, versions.platforms)(((dev.only1VersionInIDE ++ useCrossQuotes)) *)
+  .someVariations(versions.scalas, versions.platforms)(((only1VersionInIDE ++ useCrossQuotes)) *)
   .enablePlugins(SourceGenPlugin)
   .disablePlugins(WelcomePlugin)
   .settings(
@@ -450,12 +465,13 @@ lazy val hearth = projectMatrix
   .settings(dependencies *)
   .settings(mimaSettings *)
   .settings(macroExtensionTraits := Seq("hearth.std.StandardMacroExtension"))
+  .jvmPlatform(Seq(versions.scala3), jvmOnlySettings)
   .dependsOn(hearthMicroFp)
   .dependsOn(hearthBetterPrinters)
 
 lazy val hearthMunit = projectMatrix
   .in(file("hearth-munit"))
-  .someVariations(versions.scalas, versions.platforms)(dev.only1VersionInIDE *)
+  .someVariations(versions.scalas, versions.platforms)(only1VersionInIDE *)
   .disablePlugins(WelcomePlugin)
   .settings(
     moduleName := "hearth-munit",
@@ -474,13 +490,14 @@ lazy val hearthMunit = projectMatrix
   .settings(settings *)
   .settings(publishSettings *)
   .settings(mimaSettings *)
+  .jvmPlatform(Seq(versions.scala3), jvmOnlySettings)
   .dependsOn(hearth)
 
 // Test normal use cases
 
 lazy val hearthTests = projectMatrix
   .in(file("hearth-tests"))
-  .someVariations(versions.scalas, versions.platforms)((dev.only1VersionInIDE ++ useCrossQuotes) *)
+  .someVariations(versions.scalas, versions.platforms)((only1VersionInIDE ++ useCrossQuotes) *)
   .enablePlugins(SourceGenPlugin)
   .disablePlugins(WelcomePlugin)
   .settings(
@@ -545,6 +562,7 @@ lazy val hearthTests = projectMatrix
       "hearth.TotallyFailedMacroExtension"
     )
   )
+  .jvmPlatform(Seq(versions.scala3), jvmOnlySettings)
   .dependsOn(hearth)
   .dependsOn(hearthMunit)
 
@@ -575,10 +593,11 @@ lazy val hearthSandwichExamples3 = projectMatrix
     name := "hearth-sandwich-examples-3",
     description := "Tests cases compiled with Scala 3 to test macros in 2.13x3 cross-compilation (non-publishable)"
   )
+  .jvmPlatform(Seq(versions.scala3), jvmOnlySettings)
 
 lazy val hearthSandwichTests = projectMatrix
   .in(file("hearth-sandwich-tests"))
-  .someVariations(List(versions.scala213, versions.scala3), List(VirtualAxis.jvm))(dev.only1VersionInIDE *)
+  .someVariations(List(versions.scala213, versions.scala3), List(VirtualAxis.jvm))(only1VersionInIDE *)
   .settings(settings *)
   .settings(scalaNewestSettings *)
   .settings(publishSettings *)
@@ -590,6 +609,7 @@ lazy val hearthSandwichTests = projectMatrix
     name := "hearth-sandwich-tests",
     description := "Tests macros in 2.13x3 cross-compilation (non-publishable)"
   )
+  .jvmPlatform(Seq(versions.scala3), jvmOnlySettings)
   .dependsOn(hearth % s"$Test->$Test;$Compile->$Compile")
   .dependsOn(hearthSandwichExamples213 % s"$Test->$Test;$Compile->$Compile")
   .dependsOn(hearthSandwichExamples3 % s"$Test->$Test;$Compile->$Compile")
@@ -599,7 +619,7 @@ lazy val hearthSandwichTests = projectMatrix
 
 lazy val debugHearthBetterPrinters = projectMatrix
   .in(file("debug-hearth-better-printers"))
-  .someVariations(List(versions.scala213, versions.scala3), List(VirtualAxis.jvm))(dev.only1VersionInIDE *)
+  .someVariations(List(versions.scala213, versions.scala3), List(VirtualAxis.jvm))(only1VersionInIDE *)
   .settings(settings *)
   .settings(publishSettings *)
   .settings(noPublishSettings *)
@@ -609,11 +629,12 @@ lazy val debugHearthBetterPrinters = projectMatrix
     name := "debug-hearth-better-printers",
     description := "Debugging module for hearth-better-printers, intended to recompile as little as possible when working on better-printers issue, should not be published not contain any commited code"
   )
+  .jvmPlatform(Seq(versions.scala3), jvmOnlySettings)
   .dependsOn(hearthBetterPrinters)
 
 lazy val debugHearth = projectMatrix
   .in(file("debug-hearth"))
-  .someVariations(List(versions.scala213, versions.scala3), List(VirtualAxis.jvm))(dev.only1VersionInIDE *)
+  .someVariations(List(versions.scala213, versions.scala3), List(VirtualAxis.jvm))(only1VersionInIDE *)
   .settings(settings *)
   .settings(publishSettings *)
   .settings(noPublishSettings *)
@@ -623,6 +644,7 @@ lazy val debugHearth = projectMatrix
     name := "debug-hearth",
     description := "Debugging module for hearth, intended to recompile as little as possible when working on hearth issue, should not be published not contain any commited code"
   )
+  .jvmPlatform(Seq(versions.scala3), jvmOnlySettings)
   .dependsOn(hearth)
 
 // when having memory/GC-related errors during build, uncommenting this may be useful:

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val isNewestScalaTests = sys.env.get("NEWEST_SCALA_TESTS").contains("true")
 val versions = new {
   // Versions we are publishing for.
   val scala213 = "2.13.16"
-  val scala3 = "3.3.8-RC2"
+  val scala3 = "3.3.8"
 
   // Versions we can compile tests against if needed, to check for regressions.
   val scala213Newest = "2.13.18"
@@ -23,7 +23,7 @@ val versions = new {
 
   // Dependencies.
   val kindProjector = "0.13.4"
-  val munit = "1.3.2"
+  val munit = "1.3.3"
   val scalacheck = "1.19.0"
   val scalaXml = "2.4.0"
 }
@@ -328,7 +328,7 @@ lazy val root = (project in file("."))
          |${if (isNewestScalaTests)
           s" - Testing against Scala ${versions.scala213Newest} and ${versions.scala3Newest} for forward compatibility and newest features support\n"
         else ""}
-         |This build uses sbt-projectmatrix with sbt-commandmatrix helper:
+         |This build uses sbt-projectmatrix with sbt-commdmatrix helper:
          | - Scala JVM adds no suffix to a project name seen in build.sbt
          | - Scala.js adds the "JS" suffix to a project name seen in build.sbt
          | - Scala Native adds the "Native" suffix to a project name seen in build.sbt

--- a/docs/contributing/guidelines-for-tests.md
+++ b/docs/contributing/guidelines-for-tests.md
@@ -30,24 +30,24 @@ By default, tests should be placed in `hearthTests/src/test/scala`, so that:
 however there are exceptions:
 
  - `scala-newest` directories are used for tests that should only run on the **newest** supported Scala versions
-   (currently 2.13.18 and 3.8.3 for regression testing). These are used for:
+   (currently 2.13.18 and 3.8.4 for regression testing). These are used for:
 
      - **Demo/example code** that showcases advanced features or complex macro implementations (e.g., `FastShowPrettySpec`)
-     - **Features that require newer Scala versions** not available in the primary versions (2.13.16 and 3.3.7)
+     - **Features that require newer Scala versions** not available in the primary versions (2.13.16 and 3.3.8)
      - **Regression tests** for newer compiler versions
 
    Directory variants:
-     - `hearthTests/src/main/scala-newest` - shared code for newest Scala versions (both 2.13.18 and 3.8.3)
+     - `hearthTests/src/main/scala-newest` - shared code for newest Scala versions (both 2.13.18 and 3.8.4)
      - `hearthTests/src/main/scala-newest-2` - Scala 2.13.18-specific code
-     - `hearthTests/src/main/scala-newest-3` - Scala 3.8.3-specific code
+     - `hearthTests/src/main/scala-newest-3` - Scala 3.8.4-specific code
      - `hearthTests/src/test/scala-newest` - shared tests for newest Scala versions
      - `hearthTests/src/test/scala-newest-2` - Scala 2.13.18-specific tests
-     - `hearthTests/src/test/scala-newest-3` - Scala 3.8.3-specific tests
+     - `hearthTests/src/test/scala-newest-3` - Scala 3.8.4-specific tests
 
    **Important:** These directories are **only included** when the `NEWEST_SCALA_TESTS=true` environment variable is set.
    When this variable is set:
      - `hearthTests` (Scala 2.13) compiles with Scala 2.13.18 instead of 2.13.16
-     - `hearthTests3` (Scala 3) compiles with Scala 3.8.3 instead of 3.3.7
+     - `hearthTests3` (Scala 3) compiles with Scala 3.8.4 instead of 3.3.8
      - The `scala-newest` directories are added to the source directories of the same project
 
    Without `NEWEST_SCALA_TESTS=true`, these directories are completely ignored and the projects use the primary versions.
@@ -78,12 +78,12 @@ however there are exceptions:
 **Use `scala-newest` when:**
 - Creating demo/example code that showcases complex macro features (like `FastShowPrettySpec`)
 - Testing features that require compiler capabilities only available in newer Scala versions
-- Writing regression tests specifically for newer compiler versions (2.13.18 or 3.8.3)
+- Writing regression tests specifically for newer compiler versions (2.13.18 or 3.8.4)
 - The code would benefit from newer language features but should not block development on primary versions
 
 **Do NOT use `scala-newest` when:**
 - Writing standard library tests (use `src/test/scala` instead)
-- The code can work on primary versions (2.13.16 and 3.3.7)
+- The code can work on primary versions (2.13.16 and 3.3.8)
 - Adding core functionality tests (these should work on primary versions)
 - The test is critical for CI/CD pipeline validation (primary versions are tested in CI)
 
@@ -305,7 +305,7 @@ To use **hearth-munit** in your tests:
 1. **Create a fixture macro** that returns `Expr[Data]`:
 
 ```scala title="MyFeatureFixtureImpl.scala"
-//> using scala 3.3.7
+//> using scala {{ scala.3 }}
 //> using dep "com.kubuszok::hearth:{{ hearth_version() }}"
 
 package myfeature
@@ -346,7 +346,7 @@ object MyFeatureFixture {
 ```
 
 ```scala title="MyFeatureFixture.scala (Scala 3)"
-//> using scala 3.3.7
+//> using scala {{ scala.3 }}
 //> using dep "com.kubuszok::hearth:{{ hearth_version() }}"
 
 package myfeature
@@ -361,7 +361,7 @@ object MyFeatureFixture {
 3. **Test multiple properties** in your spec:
 
 ```scala title="MyFeatureSpec.scala"
-//> using scala 3.3.7
+//> using scala {{ scala.3 }}
 //> using test.dep "com.kubuszok::hearth-munit:{{ hearth_version() }}"
 //> using file "MyFeatureFixtureImpl.scala"
 //> using file "MyFeatureFixture.scala"
@@ -530,9 +530,9 @@ So running `hearthTests/test ; hearthTests3/test ; hearthSandwichTests/test ; he
 
 Tests in `scala-newest` directories are **only** compiled and run when the `NEWEST_SCALA_TESTS=true` environment
 variable is set. This variable switches the `hearthTests` and `hearthTests3` projects to use newer Scala versions
-(2.13.18 and 3.8.3) and includes the `scala-newest` source directories.
+(2.13.18 and 3.8.4) and includes the `scala-newest` source directories.
 
-**For Scala 3.8.3 (scala-newest-3):**
+**For Scala 3.8.4 (scala-newest-3):**
 ```bash
 NEWEST_SCALA_TESTS=true sbt --client "hearthTests3/clean"
 NEWEST_SCALA_TESTS=true sbt --client "hearthTests3/compile"
@@ -560,13 +560,13 @@ NEWEST_SCALA_TESTS=true sbt --client "quick-test"
 
 This will test against:
 - Scala 2.13.18 (hearthTests upgraded from 2.13.16)
-- Scala 3.8.3 (hearthTests3 upgraded from 3.3.7)
+- Scala 3.8.4 (hearthTests3 upgraded from 3.3.8)
 - Cross-version sandwich tests (with newest versions)
 
 **Without the environment variable:**
 
 Running the same commands **without** `NEWEST_SCALA_TESTS=true` will:
-- Use primary versions (2.13.16 and 3.3.7)
+- Use primary versions (2.13.16 and 3.3.8)
 - Ignore all `scala-newest` directories completely
 - This is the normal development mode
 
@@ -574,8 +574,8 @@ Running the same commands **without** `NEWEST_SCALA_TESTS=true` will:
 - `scala-newest` directories are **only visible** when `NEWEST_SCALA_TESTS=true` is set
 - The environment variable doesn't create separate projects; it modifies the existing `hearthTests` and `hearthTests3` projects
 - When working on code in `scala-newest` directories, always clean the module before testing
-- The newest versions (2.13.18 and 3.8.3) are used for regression testing, not for primary development
-- Primary development versions are 2.13.16 and 3.3.7
+- The newest versions (2.13.18 and 3.8.4) are used for regression testing, not for primary development
+- Primary development versions are 2.13.16 and 3.3.8
 - **CI runs tests BOTH ways:** with `NEWEST_SCALA_TESTS=false` (primary versions) AND `NEWEST_SCALA_TESTS=true` (newest versions)
   to ensure code works on both primary and newest Scala versions
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -100,7 +100,7 @@ extra:
     2_13: "2.13.16"
     3: "3.3.7"
     newest_2_13: "2.13.18"
-    newest_3: "3.8.3"
+    newest_3: "3.8.4"
   libraries:
     kindProjector: "0.13.4"
     munit: "1.2.4"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -98,7 +98,7 @@ extra:
       link: https://twitter.com/@MateuszKubuszok
   scala:
     2_13: "2.13.16"
-    3: "3.3.7"
+    3: "3.3.8"
     newest_2_13: "2.13.18"
     newest_3: "3.8.4"
   libraries:

--- a/docs/user-guide/resources.md
+++ b/docs/user-guide/resources.md
@@ -21,7 +21,7 @@ A curated collection of external references that complement the Hearth documenta
 
 - [**Scala 3 macros documentation**](https://docs.scala-lang.org/scala3/guides/macros/macros.html)
 
-    - Additionally I suggest opening [code in a browser](https://github.com/scala/scala3/blob/3.3.7/library/src/scala/quoted/Quotes.scala) API directory and keeping the tab open (might be a good idea since in my IDE sources are NOT imported so I see no documentation)
+    - Additionally I suggest opening [code in a browser](https://github.com/scala/scala3/blob/3.3.8-RC2/library/src/scala/quoted/Quotes.scala) API directory and keeping the tab open (might be a good idea since in my IDE sources are NOT imported so I see no documentation)
 
 ### Cross-Building Background
 

--- a/docs/user-guide/resources.md
+++ b/docs/user-guide/resources.md
@@ -21,7 +21,7 @@ A curated collection of external references that complement the Hearth documenta
 
 - [**Scala 3 macros documentation**](https://docs.scala-lang.org/scala3/guides/macros/macros.html)
 
-    - Additionally I suggest opening [code in a browser](https://github.com/scala/scala3/blob/3.3.8-RC2/library/src/scala/quoted/Quotes.scala) API directory and keeping the tab open (might be a good idea since in my IDE sources are NOT imported so I see no documentation)
+    - Additionally I suggest opening [code in a browser](https://github.com/scala/scala3/blob/3.3.8/library/src/scala/quoted/Quotes.scala) API directory and keeping the tab open (might be a good idea since in my IDE sources are NOT imported so I see no documentation)
 
 ### Cross-Building Background
 

--- a/scripts/test-snippets.scala
+++ b/scripts/test-snippets.scala
@@ -1,4 +1,4 @@
-//> using scala 3.3.7
+//> using scala 3.3.8
 //> using dep com.kubuszok::scala-cli-md-spec:0.2.1
 //> using dep org.virtuslab::scala-yaml:0.3.1
 //> using jvm 17


### PR DESCRIPTION
## Summary

- Bumps primary Scala 3 version from 3.3.7 to ~~3.3.8-RC2~~ 3.3.8
- Enables `-Yfuture-lazy-vals` compiler flag for Scala 3
- Bumps newest Scala 3 regression testing version from 3.8.3 to 3.8.4
- Updates version references across docs and build configuration
- Adds `NEWEST_SCALA_TESTS` info line to sbt startup banner

## Test plan

- [x] CI passes on both primary (2.13.16 + ~~3.3.8-RC2~~ 3.3.8) and newest (2.13.18 + 3.8.4) version matrices
- [x] `sbt --client "quick-clean ; quick-test"` passes locally
- [x] Verify `-Yfuture-lazy-vals` doesn't surface new warnings or failures