### PR TITLE
0.4 hardening: union soundness + TypeTest fallback, opaque underlying types, annotation/vararg/HKT APIs, positioned reporting, issues #283 #284 #285

### DIFF
--- a/docs/user-guide/basic-utilities.md
+++ b/docs/user-guide/basic-utilities.md
@@ -485,8 +485,10 @@ Return `Some(expr)` to override the printing for that type, or `None` to use the
 1. `directChildren` and `exhaustiveChildren` work for sealed traits, Scala 3 enums, Java enums, and
    **disjoint union types** (Scala 3 only). For union types like `String | Int`, the flattened members
    are returned when they are safe for exhaustive pattern matching at runtime — meaning no subtype overlap,
-   no duplicate erasures, and no opaque types. Unsafe unions (e.g. `List[Int] | List[String]`, which
-   erase to the same runtime class) return `None`.
+   no related runtime classes (after boxing of primitives), and no opaque types. Unsafe unions
+   (e.g. `List[Int] | Seq[String]`, where a `List` value would be caught by either branch) return `None`.
+   Stable singleton members (e.g. `Color.Red.type`, case objects) are matched by value, so they are
+   accepted even when they share a runtime class.
 
 **Visibility checks**:
 
@@ -3380,18 +3382,25 @@ pipeline used by sealed traits and enums. Use `Type.isUnionType` to detect them.
 recognized by `Enum.parse`, so `matchOn`/`parMatchOn` work on them just like on sealed traits and enums.
 
 `directChildren` returns `Some` for **disjoint** unions — those whose members can be reliably
-distinguished at runtime via pattern matching:
+distinguished at runtime via pattern matching. Class-tested members must have unrelated runtime classes
+(primitives are compared after boxing, since union values are boxed), while stable singleton members
+(literal types, case objects, parameterless Scala 3 enum cases) are matched by value and are exempt
+from the runtime-class requirement:
 
 | Union type              | `directChildren`           | Reason                                    |
 |-------------------------|----------------------------|-------------------------------------------|
-| `String \| Int`         | `Some(String, Int)`        | distinct runtime classes                  |
-| `Boolean \| Double`     | `Some(Boolean, Double)`    | distinct runtime classes                  |
+| `String \| Int`         | `Some(String, Int)`        | unrelated runtime classes                 |
+| `Boolean \| Double`     | `Some(Boolean, Double)`    | unrelated runtime classes                 |
 | `String \| Int \| Boolean` | `Some(String, Int, Boolean)` | nested unions are flattened           |
+| `Color.Red.type \| Color.Blue.type` | `Some(Red, Blue)` | singletons are matched by value      |
+| `Color.Red.type \| String` | `Some(Red, String)`     | singleton + unrelated class               |
 | `String \| AnyRef`      | `None`                     | subtype overlap (`String <:< AnyRef`)     |
-| `List[Int] \| List[String]` | `None`                | same erasure (both erase to `List`)       |
+| `List[Int] \| List[String]` | `None`                | same runtime class (both are `List`)      |
+| `List[Int] \| Seq[String]` | `None`                  | related runtime classes (`List <: Seq`)   |
+| `Int \| java.lang.Integer` | `None`                  | same runtime class after boxing           |
 | `Nothing \| String`     | `None`                     | `Nothing` filtered out, leaving 1 member  |
 | `String \| String`      | `None`                     | duplicate, leaving 1 member               |
-| `OpaqueId \| String`    | `None`                     | opaque types have unknown runtime erasure |
+| `OpaqueId \| String`    | `None`                     | opaque types have unknown runtime class   |
 
 On Scala 2, `isUnionType` always returns `false` and `directChildren` is not affected.
 

--- a/docs/user-guide/cross-quotes.md
+++ b/docs/user-guide/cross-quotes.md
@@ -542,11 +542,10 @@ to a local `implicit val` or using context bounds:
 
 **Why this pattern works and alternatives don't:**
 
-1. **`implicit val evA: Type[A] = Type.of[A]` — circular resolution.** Cross Quotes expands
-   `Type.of[A]` by looking for an implicit `Type[A]` in scope. If the result is assigned to
-   an implicit val with the same type, the compiler resolves `Type.of[A]` to the val being
-   initialized — infinite recursion. This is the same issue described in
-   [the self-referential implicit gotcha](#known-issues-and-gotchas).
+1. **`implicit val evA: Type[A] = Type.of[A]` — nothing to resolve `A` from.** Cross Quotes expands
+   `Type.of[A]` by looking for an implicit `Type[A]` in scope. The val being initialized is excluded
+   from that search (see [the self-referential implicit gotcha](#known-issues-and-gotchas)), and for
+   a local type param `A` there is no other source of `Type[A]` at that point — so this cannot work.
 
 2. **`val tpeA = Type.of[A]; someHelper[A](tpeA)` — works but less ergonomic.** Using a
    non-implicit `val` avoids circular resolution, but forces the helper to take `Type` as a
@@ -954,35 +953,35 @@ While all of these are inconvenient, they can usually be worked around. The issu
 
 !!! warning "Self-referential implicit `Type` / `Type.CtorN` initialization"
 
-    Both `weakTypeTag[A]` (Scala 2) and `scala.quoted.Type.of[A]` (Scala 3) pick up an implicit if it is in scope.
-    Writing:
+    Both `weakTypeTag[A]` (Scala 2) and `scala.quoted.Type.of[A]` (Scala 3) pick up an implicit if it is in scope —
+    including the very `implicit val` being defined. Since the fix for
+    [#285](https://github.com/MateuszKubuszok/hearth/issues/285), Cross Quotes excludes the definition currently
+    being initialized from that implicit search, so for **statically-known types** the natural pattern just works:
 
     ```scala
-    implicit val A: Type[A] = Type.of[A]
-    ```
-
-    generates `implicit val A: Type[A] = A` — an infinite recursion. **Run `Type.of` in a scope where its result
-    is not being pulled in as an implicit/given.**
-
-    The same applies to `Type.CtorN` and to `Type.of` with local type params inside `Expr.splice`:
-
-    ```scala
-    // BAD — circular initialization:
+    // OK — the value being defined is excluded from the search,
+    // the Type is materialized directly from the literal type argument:
+    implicit val ConfigT: Type[Configuration] = Type.of[Configuration]
     implicit val FC: Type.Ctor1[Option] = Type.Ctor1.of[Option]
-
-    // GOOD — create the value outside, then assign:
-    val optCtor = Type.Ctor1.of[Option] // or a factory method
-    implicit val FC: Type.Ctor1[Option] = optCtor
     ```
 
+    The exclusion cannot help when the type argument is an **abstract type** whose only `Type` instance would be
+    the val itself — there is genuinely nothing to materialize it from:
+
     ```scala
-    // BAD — inside Expr.splice, this causes a forward reference error on Scala 2:
-    Expr.splice {
-      implicit val evA: Type[A] = Type.of[A]
-      someHelper[A]
+    // BAD — A is abstract and its only Type[A] would be the val being defined:
+    def body[A] = {
+      implicit val evA: Type[A] = Type.of[A] // error: no Type[A] available
+      ...
     }
 
-    // GOOD — use non-implicit vals and pass explicitly:
+    // GOOD — get Type[A] from a context bound or an implicit parameter instead:
+    def body[A: Type] = ...
+    ```
+
+    For local type params inside `Expr.splice`, prefer non-implicit vals passed explicitly:
+
+    ```scala
     Expr.splice {
       val tpeA = Type.of[A]
       val tpeB = Type.of[B]

--- a/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
+++ b/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
@@ -140,10 +140,14 @@ import scala.util.chaining.*
   *
   * ==Gotchas and limitations (Scala 2)==
   *
-  *   - '''Self-referential implicit Type/Type.CtorN:''' `implicit val A: Type[A] = Type.of[A]` generates
-  *     `implicit val A: Type[A] = A` (infinite recursion), because `weakTypeTag[A]` picks up the implicit in scope. The
-  *     same applies to `Type.CtorN` and to `Type.of` with local type params inside `Expr.splice` (forward reference
-  *     error). Use a non-implicit val or assign the result in a different scope, then pass explicitly.
+  *   - '''Self-referential implicit Type (fixed by hearth#285):'''
+  *     `implicit val ConfigT: Type[Configuration] = Type.of[Configuration]` used to generate
+  *     `implicit val ConfigT: Type[Configuration] = ConfigT` (forward-reference error in blocks, null self-assignment
+  *     in class bodies), because `weakTypeTag[Configuration]` picked up the implicit being defined. `typeOfImpl` now
+  *     emits `selfReferenceShadows` (`val ConfigT: Unit = ()`) at the top of the generated block — Scala 2 implicit
+  *     search skips shadowed implicits, so the WeakTypeTag materializer is used instead. Note that
+  *     `implicit val A: Type[A] = Type.of[A]` where `A` is an abstract type whose ONLY `Type` instance would be the val
+  *     itself still cannot work (there is genuinely no way to materialize it).
   *   - '''Free types from local type params do not cross quasiquote boundaries:''' When `Expr.splice` inside
   *     `Expr.quote` uses local type params (from methods defined inside the quote body), these are resolved via free
   *     type symbols in the quasiquote. Free types resolve only within the quasiquote where they were created. If a
@@ -243,6 +247,41 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
     def isImportedCrossTypeImplicit: Boolean = ImportedCrossTypeImplicit(name.decodedName.toString)
   }
 
+  /* [hearth#285] `implicit val ConfigT: Type[Configuration] = Type.of[Configuration]` — the very value being
+   * defined is the best implicit candidate for the `Type[Configuration]` lookup performed by the generated code
+   * (via `convertProvidedTypesForCrossQuotes`), producing `implicit val ConfigT = ConfigT` (a forward-reference
+   * error in blocks, a null self-assignment in class/trait bodies).
+   *
+   * To prevent that, we walk the owner chain from the expansion site up to the closest class/object and collect
+   * every implicit term definition we are lexically inside of (its RHS is being typechecked right now, so any
+   * reference to it would be a self-reference). For each such name `selfReferenceShadows` emits
+   * `val $name: Unit = ()` at the top of the generated block — Scala 2 implicit search ignores implicits whose
+   * simple name is shadowed by a closer definition, so the generated code falls back to the compiler's
+   * WeakTypeTag materializer instead of referencing the value being defined.
+   */
+  protected def selfReferenceShadowNames: Set[String] = {
+    // Names that the generated code itself references — never shadow them.
+    val unsafeNames = Set("Type", "Expr", "CrossQuotes")
+    var owner = c.internal.enclosingOwner
+    val names = Set.newBuilder[String]
+    while (owner != NoSymbol && !owner.isClass) {
+      if (owner.isTerm && owner.isImplicit) {
+        val name = owner.name.decodedName.toString.trim
+        if (name.nonEmpty && !name.contains("$") && !unsafeNames(name)) names += name
+      }
+      owner = owner.owner
+    }
+    names.result()
+  }
+
+  protected def selfReferenceShadows: List[c.Tree] = selfReferenceShadowNames.toList.sorted.flatMap { name =>
+    val shadow = TermName(name)
+    List(
+      q"val $shadow: _root_.scala.Unit = ()",
+      q"_root_.hearth.fp.ignore($shadow)"
+    )
+  }
+
   /* Replaces:
    *   Type.of[A]
    * with:
@@ -259,6 +298,7 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
     // is kind of a hack, because apparently these types were not sanitized during printing.
     // We should fix the printing, so that we don't have to introduce this import.
     val unchecked = q"""
+    ..$selfReferenceShadows
     val $ctx = CrossQuotes.ctx[_root_.scala.reflect.macros.blackbox.Context]
     import _root_.scala.reflect.api.{Mirror, TypeCreator, Universe}
     import $ctx.universe.{ TypeRef, TypeRefTag }
@@ -520,19 +560,30 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
         excludingSet(renamed)
       }
 
+    // [hearth#285] Implicit term definitions whose RHS we are lexically inside of — referencing them from the
+    // generated code would be a self-reference (forward-reference error or null self-assignment).
+    val selfShadowedNames = selfReferenceShadowNames
+
     val importedUnderlying = candidates.view
       .filterNot { case (_, renamed) => excludingSet(renamed) }
       .flatMap { case (tpeToReplace, renamed) =>
         try {
           val typeValue: Tree =
             c.inferImplicitValue(c.typecheck(tq"Type[$tpeToReplace]", mode = c.TYPEmode).tpe, silent = false)
-          val weakTypeTagValue = q"""$typeValue.asInstanceOf[$ctx2.WeakTypeTag[$tpeToReplace]]"""
+          typeValue match {
+            // [hearth#285] The inferred implicit is the very definition being initialized — skip the candidate,
+            // the fallback path (WeakTypeTag materializer with `selfReferenceShadows` in scope) handles it.
+            case Ident(name) if selfShadowedNames(name.decodedName.toString) =>
+              Iterable.empty
+            case _ =>
+              val weakTypeTagValue = q"""$typeValue.asInstanceOf[$ctx2.WeakTypeTag[$tpeToReplace]]"""
 
-          val paramName = freshTypeName(renamed)
-          val paramDef: TypeDef = q"type $paramName"
-          val paramVal: ValDef = q"val ${freshName(renamed)}: $ctx2.WeakTypeTag[$paramName]"
+              val paramName = freshTypeName(renamed)
+              val paramDef: TypeDef = q"type $paramName"
+              val paramVal: ValDef = q"val ${freshName(renamed)}: $ctx2.WeakTypeTag[$paramName]"
 
-          Iterable((paramDef, paramVal, tpeToReplace, weakTypeTagValue))
+              Iterable((paramDef, paramVal, tpeToReplace, weakTypeTagValue))
+          }
         } catch {
           // HKT types (F[_] from Type.CtorN[F]) can't be handled by the workaround mechanism
           // because WeakTypeTag doesn't support higher-kinded types in Scala 2.

--- a/hearth-cross-quotes/src/main/scala-3/hearth/cq/CrossQuotesPlugin.scala
+++ b/hearth-cross-quotes/src/main/scala-3/hearth/cq/CrossQuotesPlugin.scala
@@ -174,12 +174,15 @@ final class CrossQuotesPlugin extends StandardPlugin {
   *
   * ==Gotchas and limitations (Scala 3)==
   *
-  *   - '''Self-referential implicit Type:''' `implicit val A: Type[A] = Type.of[A]` generates an infinite loop, because
-  *     `scala.quoted.Type.of[A]` picks up the `given` in scope. Use a non-implicit val or assign in a different scope.
-  *   - '''Self-referential implicit Type.CtorN initialization:''' `implicit val F: Type.Ctor1[F] = Type.Ctor1.of[F]`
-  *     can cause circular initialization when the plugin injects a `given` that references the val being initialized.
-  *     Create the value outside the block:
-  *     `val optCtor = makeOptionCtor; implicit val OptionCtor: Type.Ctor1[Option] = optCtor`.
+  *   - '''Self-referential implicit Type/Type.CtorN (fixed by hearth#285):'''
+  *     `implicit val ConfigT: Type[Configuration] = Type.of[Configuration]` and
+  *     `implicit val OptionCtor: Type.Ctor1[Option] = Type.Ctor1.of[Option]` used to inject a `given` that summoned the
+  *     very value being initialized (forward-reference error in blocks, "Infinite loop in function body" or null
+  *     self-assignment in class bodies). The plugin now excludes the definition being initialized (and, in blocks, any
+  *     implicit val declared in a later statement) from the injected `casted` givens, so the type is materialized
+  *     directly from the literal type argument. Note that `implicit val A: Type[A] = Type.of[A]` where `A` is an
+  *     abstract type whose ONLY `Type` instance would be the val itself cannot work — it is now reported as a missing
+  *     `Type[A]` instead of an infinite loop.
   *   - '''`Type.of[A]` requires a parameterless given:''' `scala.quoted.Type.of[A]` and `'{ ... }: Expr[A]` ignore
   *     `Type[A]` values that require implicit resolution to obtain. Only `implicit val`/parameterless `given`
   *     definitions are picked up. The plugin uses a best-effort approach to detect such cases and create local
@@ -256,6 +259,12 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
 
       private var givenCandidates = List.empty[untpd.ValDef]
       private var givensInjected = Set.empty[untpd.ValDef]
+      // [hearth#285] Names of implicit val/def definitions whose RHS is currently being transformed.
+      // Their `casted$name` given candidates must NOT be injected inside their own RHS — the generated given
+      // would summon the very value being initialized (forward-reference error in blocks, "Infinite loop in
+      // function body" / null self-assignment in class bodies). With the candidate excluded,
+      // `scala.quoted.Type.of[A]` / `Type.CtorN.Bounded.Impl` materialize the type directly instead.
+      private var selfDefNames = Set.empty[String]
 
       private val ctorSize = (1 to 22).map(i => s"Ctor$i" -> i).toMap
       private val isCtor = ctorSize.keySet
@@ -466,6 +475,13 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
           )
           .withFlags(Flags.Given)
 
+      // [hearth#285] Does an implicit val/def with this declared type produce a `casted$name` given candidate
+      // (see blockGivenCandidates)? Used to exclude that candidate while transforming the definition itself.
+      private def producesSelfGivenCandidate(tpt: untpd.Tree): Boolean =
+        TypeAppliedTypeTree.unapply(tpt).isDefined ||
+          TypeCtorAppliedTypeTree.unapply(tpt).isDefined ||
+          TypeCtorK1AppliedTypeTree.unapply(tpt).isDefined
+
       private def blockGivenCandidates(trees: List[untpd.Tree]): List[untpd.ValDef] = trees.collect {
         // Handle imports with @ImportedCrossTypeImplicit (e.g. Underlying, Result, etc.)
         // Uses makeGivenFromUntyped which works for both Type[X] and Type.CtorN[X] values
@@ -605,9 +621,14 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
             case _ => None
           }
 
+      // [hearth#285] Drops candidates that would reference the definition whose RHS is being transformed.
+      private def withoutSelfReferences(candidates: List[untpd.ValDef]): List[untpd.ValDef] =
+        if selfDefNames.isEmpty then candidates
+        else candidates.filterNot(vd => selfDefNames.exists(name => vd.name.show == s"casted$name"))
+
       private def injectGivens(thunk: => untpd.Tree): untpd.Tree = {
         val oldGivensInjected = givensInjected
-        val newGivensInjected = givenCandidates.filterNot(givensInjected)
+        val newGivensInjected = withoutSelfReferences(givenCandidates.filterNot(givensInjected))
         val newGivensInjectedWithSuppression = newGivensInjected.flatMap { valdef =>
           /* Returns code:
            *   new_given
@@ -903,6 +924,19 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
         case Apply(Select(Ident(expr), splice), List(thunk)) if expr.show == "Expr" && splice.show == "splice" =>
           replaceExprSplice(tree, thunk)
 
+        /* [hearth#285] An implicit val/given whose declared type is Type[A]/Type.CtorN[HKT]/Type.CtorK1[HKT] is
+         * itself a given candidate (see blockGivenCandidates). While transforming ITS OWN definition (in
+         * particular its RHS, e.g. `implicit val ConfigT: Type[Configuration] = Type.of[Configuration]`), that
+         * candidate must not be injected — the generated given would summon the value being initialized.
+         */
+        case vd: untpd.ValDef if vd.isImplicit && producesSelfGivenCandidate(vd.tpt) =>
+          val oldSelfDefNames = selfDefNames
+          try {
+            selfDefNames = oldSelfDefNames + vd.name.show
+            super.transform(vd)
+          } finally
+            selfDefNames = oldSelfDefNames
+
         /* Looking for blocks with imports that contain Underlying, or implicit val/def/given returning Type[A].
          * For each such import we inject:
          *   given castedUnderlying: scala.quoted.Type[Underlying] =
@@ -911,11 +945,25 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
          *   given casted$name: scala.quoted.Type[A] = Type[A].asInstanceOf[scala.quoted.Type[A]]
          */
         case block: Block =>
-          val newGivenCandidates = blockGivenCandidates(block.stats)
           val oldGivenCandidates = givenCandidates
           try {
-            givenCandidates = oldGivenCandidates ++ newGivenCandidates
-            super.transform(block)
+            // Imports and (implicit) defs can legally be forward-referenced from earlier statements in a block,
+            // so their candidates are visible to every expansion in the block.
+            givenCandidates = oldGivenCandidates ++ blockGivenCandidates(
+              block.stats.filterNot(_.isInstanceOf[untpd.ValDef])
+            )
+            // [hearth#285] Candidates from implicit vals become visible only AFTER their defining statement —
+            // injecting them into earlier expansions would generate an illegal forward reference to the val.
+            val newStats = block.stats.map { stat =>
+              val transformed = transform(stat)
+              stat match {
+                case vd: untpd.ValDef => givenCandidates = givenCandidates ++ blockGivenCandidates(vd :: Nil)
+                case _                => ()
+              }
+              transformed
+            }
+            val newExpr = transform(block.expr)
+            cpy.Block(block)(newStats, newExpr)
           } finally
             givenCandidates = oldGivenCandidates
 
@@ -960,13 +1008,24 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
           // }
           // when found, handle new cases in CtxBoundsTypeTree.
 
+          // [hearth#285] A parameterless implicit def returning Type[A]/Type.CtorN[HKT]/Type.CtorK1[HKT] is itself
+          // a given candidate — exclude it while transforming its own body (calling it there would recurse forever).
+          val selfName =
+            if dd.isImplicit && paramss.flatten.isEmpty && producesSelfGivenCandidate(returnTpe)
+            then Some(methodName.show)
+            else None
+
           val oldGivenCandidates = givenCandidates
+          val oldSelfDefNames = selfDefNames
           try {
             givenCandidates = oldGivenCandidates ++ newGivenCandidates
+            selfDefNames = oldSelfDefNames ++ selfName
             // untpd.DefDef(methodName, paramss, returnTpe, transform(body)).withMods(dd.mods)
             super.transform(dd)
-          } finally
+          } finally {
             givenCandidates = oldGivenCandidates
+            selfDefNames = oldSelfDefNames
+          }
 
         case t =>
           super.transform(t)

--- a/hearth-tests/src/main/java/hearth/examples/classes/ExampleJavaVarargs.java
+++ b/hearth-tests/src/main/java/hearth/examples/classes/ExampleJavaVarargs.java
@@ -1,0 +1,15 @@
+package hearth.examples.classes;
+
+/** Java varargs example: {@code int... xs} erases to {@code int[]}, unlike Scala's {@code Seq[Int]}. */
+public class ExampleJavaVarargs {
+
+  public ExampleJavaVarargs() {}
+
+  public int sum(int... xs) {
+    int total = 0;
+    for (int x : xs) {
+      total += x;
+    }
+    return total;
+  }
+}

--- a/hearth-tests/src/main/scala-2/hearth/EnvironmentFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/EnvironmentFixtures.scala
@@ -15,6 +15,12 @@ final private class EnvironmentFixtures(val c: blackbox.Context)
 
   def testErrorAndAbortImpl: c.Expr[Any] = testErrorAndAbort
 
+  def testReportInfoAtPositionImpl[A: c.WeakTypeTag]: c.Expr[Data] = testReportInfoAtPosition[A]
+
+  def testReportErrorAtPositionImpl: c.Expr[Data] = testReportErrorAtPosition
+
+  def testReportErrorAndAbortAtPositionImpl: c.Expr[Any] = testReportErrorAndAbortAtPosition
+
   def testIsExpandedAtImpl(position: c.Expr[String]): c.Expr[Boolean] = testIsExpandedAt(position)
 
   def testLoadingExtensionsImpl: c.Expr[Data] = testLoadingExtensions
@@ -31,6 +37,9 @@ object EnvironmentFixtures {
   def testPosition: Data = macro EnvironmentFixtures.testPositionImpl
   def testEnvironment: Data = macro EnvironmentFixtures.testEnvironmentImpl
   def testErrorAndAbort: Any = macro EnvironmentFixtures.testErrorAndAbortImpl
+  def testReportInfoAtPosition[A]: Data = macro EnvironmentFixtures.testReportInfoAtPositionImpl[A]
+  def testReportErrorAtPosition: Data = macro EnvironmentFixtures.testReportErrorAtPositionImpl
+  def testReportErrorAndAbortAtPosition: Any = macro EnvironmentFixtures.testReportErrorAndAbortAtPositionImpl
   def testIsExpandedAt(position: String): Boolean = macro EnvironmentFixtures.testIsExpandedAtImpl
   def testLoadingExtensions: Data = macro EnvironmentFixtures.testLoadingExtensionsImpl
   def testLoadingExtensionsExcluding: Data = macro EnvironmentFixtures.testLoadingExtensionsExcludingImpl

--- a/hearth-tests/src/main/scala-2/hearth/crossquotes/CrossTypeSelfRefFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/crossquotes/CrossTypeSelfRefFixtures.scala
@@ -1,0 +1,23 @@
+package hearth
+package crossquotes
+
+import hearth.data.Data
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+final private class CrossTypeSelfRefFixtures(val c: blackbox.Context)
+    extends MacroCommonsScala2
+    with CrossTypeSelfRefFixturesImpl {
+
+  def testSelfReferentialImplicitTypeImpl: c.Expr[Data] = testSelfReferentialImplicitType
+
+  def testSelfReferentialImplicitCtorImpl: c.Expr[Data] = testSelfReferentialImplicitCtor
+}
+
+object CrossTypeSelfRefFixtures {
+
+  def testSelfReferentialImplicitType: Data = macro CrossTypeSelfRefFixtures.testSelfReferentialImplicitTypeImpl
+
+  def testSelfReferentialImplicitCtor: Data = macro CrossTypeSelfRefFixtures.testSelfReferentialImplicitCtorImpl
+}

--- a/hearth-tests/src/main/scala-2/hearth/typed/AnonymousInstanceFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/AnonymousInstanceFixtures.scala
@@ -37,6 +37,15 @@ final private class AnonymousInstanceFixtures(val c: blackbox.Context)
       finalMethodName: c.Expr[String]
   ): c.Expr[String] =
     testAnonymousInstanceConstructOverridingFinal[A](finalMethodName)
+
+  def testAnonymousInstanceCapturedOverrideImpl(captured: c.Expr[String]): c.Expr[String] =
+    testAnonymousInstanceCapturedOverride(captured)
+
+  def testAnonymousInstanceOverrideUsingParamsImpl(captured: c.Expr[String]): c.Expr[String] =
+    testAnonymousInstanceOverrideUsingParams(captured)
+
+  def testAnonymousInstanceOverrideReferencingQuoteParamImpl: c.Expr[String => String] =
+    testAnonymousInstanceOverrideReferencingQuoteParam
 }
 
 object AnonymousInstanceFixtures {
@@ -66,4 +75,13 @@ object AnonymousInstanceFixtures {
 
   def testAnonymousInstanceConstructOverridingFinal[A](finalMethodName: String): String =
     macro AnonymousInstanceFixtures.testAnonymousInstanceConstructOverridingFinalImpl[A]
+
+  def testAnonymousInstanceCapturedOverride(captured: String): String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceCapturedOverrideImpl
+
+  def testAnonymousInstanceOverrideUsingParams(captured: String): String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceOverrideUsingParamsImpl
+
+  def testAnonymousInstanceOverrideReferencingQuoteParam: String => String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceOverrideReferencingQuoteParamImpl
 }

--- a/hearth-tests/src/main/scala-2/hearth/typed/AnonymousInstanceFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/AnonymousInstanceFixtures.scala
@@ -24,6 +24,19 @@ final private class AnonymousInstanceFixtures(val c: blackbox.Context)
       ctorIndex: c.Expr[Int]
   ): c.Expr[String] =
     testAnonymousInstanceConstructWithCtorIndex[A](ctorIndex)
+
+  def testAnonymousInstanceParseInaccessibleImpl: c.Expr[Data] = testAnonymousInstanceParseInaccessible
+
+  def testAnonymousInstanceConstructNoOverridesImpl[A: c.WeakTypeTag]: c.Expr[String] =
+    testAnonymousInstanceConstructNoOverrides[A]
+
+  def testAnonymousInstanceConstructNoOverridesWithMixinsImpl[A: c.WeakTypeTag, M1: c.WeakTypeTag]: c.Expr[String] =
+    testAnonymousInstanceConstructNoOverridesWithMixins[A](Type.of[M1].as_??)
+
+  def testAnonymousInstanceConstructOverridingFinalImpl[A: c.WeakTypeTag](
+      finalMethodName: c.Expr[String]
+  ): c.Expr[String] =
+    testAnonymousInstanceConstructOverridingFinal[A](finalMethodName)
 }
 
 object AnonymousInstanceFixtures {
@@ -41,4 +54,16 @@ object AnonymousInstanceFixtures {
 
   def testAnonymousInstanceConstructWithCtorIndex[A](ctorIndex: Int): String =
     macro AnonymousInstanceFixtures.testAnonymousInstanceConstructWithCtorIndexImpl[A]
+
+  def testAnonymousInstanceParseInaccessible: Data =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceParseInaccessibleImpl
+
+  def testAnonymousInstanceConstructNoOverrides[A]: String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceConstructNoOverridesImpl[A]
+
+  def testAnonymousInstanceConstructNoOverridesWithMixins[A, M1]: String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceConstructNoOverridesWithMixinsImpl[A, M1]
+
+  def testAnonymousInstanceConstructOverridingFinal[A](finalMethodName: String): String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceConstructOverridingFinalImpl[A]
 }

--- a/hearth-tests/src/main/scala-2/hearth/typed/ClassesFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ClassesFixtures.scala
@@ -24,6 +24,9 @@ final private class ClassesFixtures(val c: blackbox.Context) extends MacroCommon
   def testCaseClassCaseFieldValuesAtCallSiteImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[String] =
     testCaseClassCaseFieldValuesAtCallSite[A](expr)
 
+  def testCaseClassCaseFieldValuesAtEverywhereImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[String] =
+    testCaseClassCaseFieldValuesAtEverywhere[A](expr)
+
   def testEnumParMatchOnNestedQuoteImpl[A: c.WeakTypeTag](expr: c.Expr[A], suffix: c.Expr[String]): c.Expr[String] =
     testEnumParMatchOnNestedQuote[A](expr, suffix)
 
@@ -72,6 +75,9 @@ object ClassesFixtures {
 
   def testCaseClassCaseFieldValuesAtCallSite[A](expr: A): String =
     macro ClassesFixtures.testCaseClassCaseFieldValuesAtCallSiteImpl[A]
+
+  def testCaseClassCaseFieldValuesAtEverywhere[A](expr: A): String =
+    macro ClassesFixtures.testCaseClassCaseFieldValuesAtEverywhereImpl[A]
 
   def testEnumParMatchOnNestedQuote[A](expr: A, suffix: String): String =
     macro ClassesFixtures.testEnumParMatchOnNestedQuoteImpl[A]

--- a/hearth-tests/src/main/scala-2/hearth/typed/ClassesFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ClassesFixtures.scala
@@ -42,6 +42,9 @@ final private class ClassesFixtures(val c: blackbox.Context) extends MacroCommon
   def testCaseClassConstructRoundTripImpl[A: c.WeakTypeTag]: c.Expr[String] =
     testCaseClassConstructRoundTrip[A]
 
+  def testVarargCaseClassConstructImpl[A: c.WeakTypeTag](expected: c.Expr[A]): c.Expr[Data] =
+    testVarargCaseClassConstruct[A](expected)
+
   def testSingletonRoundTripImpl[A: c.WeakTypeTag]: c.Expr[String] =
     testSingletonRoundTrip[A]
 
@@ -86,6 +89,9 @@ object ClassesFixtures {
 
   def testCaseClassConstructRoundTrip[A]: String =
     macro ClassesFixtures.testCaseClassConstructRoundTripImpl[A]
+
+  def testVarargCaseClassConstruct[A](expected: A): Data =
+    macro ClassesFixtures.testVarargCaseClassConstructImpl[A]
 
   def testSingletonRoundTrip[A]: String =
     macro ClassesFixtures.testSingletonRoundTripImpl[A]

--- a/hearth-tests/src/main/scala-2/hearth/typed/ClassesFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ClassesFixtures.scala
@@ -21,6 +21,12 @@ final private class ClassesFixtures(val c: blackbox.Context) extends MacroCommon
   def testCaseClassCaseFieldValuesAtImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[String] =
     testCaseClassCaseFieldValuesAt[A](expr)
 
+  def testCaseClassCaseFieldValuesAtCallSiteImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[String] =
+    testCaseClassCaseFieldValuesAtCallSite[A](expr)
+
+  def testEnumParMatchOnNestedQuoteImpl[A: c.WeakTypeTag](expr: c.Expr[A], suffix: c.Expr[String]): c.Expr[String] =
+    testEnumParMatchOnNestedQuote[A](expr, suffix)
+
   def testEnumMatchOnAndParMatchOnImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[String] =
     testEnumMatchOnAndParMatchOn[A](expr)
 
@@ -60,6 +66,12 @@ object ClassesFixtures {
     macro ClassesFixtures.testSingletonExprImpl[A]
 
   def testCaseClassCaseFieldValuesAt[A](expr: A): String = macro ClassesFixtures.testCaseClassCaseFieldValuesAtImpl[A]
+
+  def testCaseClassCaseFieldValuesAtCallSite[A](expr: A): String =
+    macro ClassesFixtures.testCaseClassCaseFieldValuesAtCallSiteImpl[A]
+
+  def testEnumParMatchOnNestedQuote[A](expr: A, suffix: String): String =
+    macro ClassesFixtures.testEnumParMatchOnNestedQuoteImpl[A]
 
   def testEnumMatchOnAndParMatchOn[A](expr: A): String = macro ClassesFixtures.testEnumMatchOnAndParMatchOnImpl[A]
 

--- a/hearth-tests/src/main/scala-2/hearth/typed/ExprCodecFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ExprCodecFixtures.scala
@@ -22,6 +22,8 @@ final private class ExprCodecFixtures(val c: blackbox.Context) extends MacroComm
   def testSemiQuoteWithOverrideImpl: c.Expr[Data] = testSemiQuoteWithOverride
 
   def testSemiQuoteFailureImpl: c.Expr[Data] = testSemiQuoteFailure
+
+  def testBuiltInCodecExprTypesImpl: c.Expr[Data] = testBuiltInCodecExprTypes
 }
 
 object ExprCodecFixtures {
@@ -40,4 +42,6 @@ object ExprCodecFixtures {
   def testSemiQuoteWithOverride: Data = macro ExprCodecFixtures.testSemiQuoteWithOverrideImpl
 
   def testSemiQuoteFailure: Data = macro ExprCodecFixtures.testSemiQuoteFailureImpl
+
+  def testBuiltInCodecExprTypes: Data = macro ExprCodecFixtures.testBuiltInCodecExprTypesImpl
 }

--- a/hearth-tests/src/main/scala-2/hearth/typed/ExprCodecFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ExprCodecFixtures.scala
@@ -10,10 +10,34 @@ final private class ExprCodecFixtures(val c: blackbox.Context) extends MacroComm
 
   def testExprCodecRoundTripImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[Data] =
     testExprCodecRoundTrip[A](expr)
+
+  def testSemiQuotePrimitivesImpl: c.Expr[Data] = testSemiQuotePrimitives
+
+  def testSemiQuoteCaseClassImpl: c.Expr[Data] = testSemiQuoteCaseClass
+
+  def testSemiQuoteSealedChildImpl: c.Expr[Data] = testSemiQuoteSealedChild
+
+  def testSemiQuoteSingletonImpl: c.Expr[Data] = testSemiQuoteSingleton
+
+  def testSemiQuoteWithOverrideImpl: c.Expr[Data] = testSemiQuoteWithOverride
+
+  def testSemiQuoteFailureImpl: c.Expr[Data] = testSemiQuoteFailure
 }
 
 object ExprCodecFixtures {
 
   def testExprCodecRoundTrip[A](expr: A): Data =
     macro ExprCodecFixtures.testExprCodecRoundTripImpl[A]
+
+  def testSemiQuotePrimitives: Data = macro ExprCodecFixtures.testSemiQuotePrimitivesImpl
+
+  def testSemiQuoteCaseClass: Data = macro ExprCodecFixtures.testSemiQuoteCaseClassImpl
+
+  def testSemiQuoteSealedChild: Data = macro ExprCodecFixtures.testSemiQuoteSealedChildImpl
+
+  def testSemiQuoteSingleton: Data = macro ExprCodecFixtures.testSemiQuoteSingletonImpl
+
+  def testSemiQuoteWithOverride: Data = macro ExprCodecFixtures.testSemiQuoteWithOverrideImpl
+
+  def testSemiQuoteFailure: Data = macro ExprCodecFixtures.testSemiQuoteFailureImpl
 }

--- a/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
@@ -31,6 +31,9 @@ final private class ExprsFixtures(val c: blackbox.Context) extends MacroCommonsS
 
   def testMatchCaseTypeMatchImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[Data] = testMatchCaseTypeMatch[A](expr)
 
+  def testMatchOnWithNestedQuoteImpl[A: c.WeakTypeTag](expr: c.Expr[A], suffix: c.Expr[String]): c.Expr[String] =
+    testMatchOnWithNestedQuote[A](expr, suffix)
+
   def testMatchCaseEqValueImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[Data] =
     testMatchCaseEqValue[A](expr)
 
@@ -174,6 +177,9 @@ object ExprsFixtures {
   def testVarArgs[A](exprs: A*): Data = macro ExprsFixtures.testVarArgsImpl[A]
 
   def testMatchCaseTypeMatch[A](expr: A): Data = macro ExprsFixtures.testMatchCaseTypeMatchImpl[A]
+
+  def testMatchOnWithNestedQuote[A](expr: A, suffix: String): String =
+    macro ExprsFixtures.testMatchOnWithNestedQuoteImpl[A]
 
   def testMatchCaseEqValue[A](expr: A): Data = macro ExprsFixtures.testMatchCaseEqValueImpl[A]
 

--- a/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
@@ -101,6 +101,9 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
   def testAnnotationValueDecodedImpl[A: c.WeakTypeTag]: c.Expr[Data] =
     testAnnotationValueDecoded[A]
 
+  def testSplicedAnnotationValueImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
+    testSplicedAnnotationValue[A](methodName)
+
   def testDefaultValueOnGenericMethodImpl[A: c.WeakTypeTag](
       instance: c.Expr[A],
       methodName: c.Expr[String]
@@ -189,6 +192,9 @@ object MethodsFixtures {
 
   def testAnnotationValueDecoded[A]: Data =
     macro MethodsFixtures.testAnnotationValueDecodedImpl[A]
+
+  def testSplicedAnnotationValue[A](methodName: String): Data =
+    macro MethodsFixtures.testSplicedAnnotationValueImpl[A]
 
   def testDefaultValueOnGenericMethod[A](instance: A, methodName: String): Data =
     macro MethodsFixtures.testDefaultValueOnGenericMethodImpl[A]

--- a/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
@@ -65,6 +65,12 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
   def testAnnotationDestructuringImpl[A: c.WeakTypeTag]: c.Expr[Data] =
     testAnnotationDestructuring[A]
 
+  def testParameterAnnotationsImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
+    testParameterAnnotations[A](methodName)
+
+  def testConstructorParameterAnnotationsImpl[A: c.WeakTypeTag]: c.Expr[Data] =
+    testConstructorParameterAnnotations[A]
+
   def testDefaultValueOnGenericMethodImpl[A: c.WeakTypeTag](
       instance: c.Expr[A],
       methodName: c.Expr[String]
@@ -123,6 +129,12 @@ object MethodsFixtures {
 
   def testAnnotationDestructuring[A]: Data =
     macro MethodsFixtures.testAnnotationDestructuringImpl[A]
+
+  def testParameterAnnotations[A](methodName: String): Data =
+    macro MethodsFixtures.testParameterAnnotationsImpl[A]
+
+  def testConstructorParameterAnnotations[A]: Data =
+    macro MethodsFixtures.testConstructorParameterAnnotationsImpl[A]
 
   def testDefaultValueOnGenericMethod[A](instance: A, methodName: String): Data =
     macro MethodsFixtures.testDefaultValueOnGenericMethodImpl[A]

--- a/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
@@ -101,6 +101,9 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
   def testAnnotationValueDecodedImpl[A: c.WeakTypeTag]: c.Expr[Data] =
     testAnnotationValueDecoded[A]
 
+  def testFieldNameReproducerImpl[A: c.WeakTypeTag]: c.Expr[Data] =
+    testFieldNameReproducer[A]
+
   def testSplicedAnnotationValueImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
     testSplicedAnnotationValue[A](methodName)
 
@@ -192,6 +195,9 @@ object MethodsFixtures {
 
   def testAnnotationValueDecoded[A]: Data =
     macro MethodsFixtures.testAnnotationValueDecodedImpl[A]
+
+  def testFieldNameReproducer[A]: Data =
+    macro MethodsFixtures.testFieldNameReproducerImpl[A]
 
   def testSplicedAnnotationValue[A](methodName: String): Data =
     macro MethodsFixtures.testSplicedAnnotationValueImpl[A]

--- a/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
@@ -43,6 +43,14 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
   def testParameterPropertiesImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
     testParameterProperties[A](methodName)
 
+  def testCallVarargIntMethodImpl[A: c.WeakTypeTag](instance: c.Expr[A])(methodName: c.Expr[String])(
+      params: c.Expr[Int]*
+  ): c.Expr[Int] =
+    testCallVarargIntMethod[A](instance)(methodName)(params)
+
+  def testConstructVarargCtorImpl[A: c.WeakTypeTag](params: c.Expr[String]*): c.Expr[Data] =
+    testConstructVarargCtor[A](params)
+
   def testMethodOrderingImpl[A: c.WeakTypeTag]: c.Expr[Data] = testMethodOrdering[A]
 
   def testMethodExpectationsImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
@@ -110,6 +118,12 @@ object MethodsFixtures {
 
   def testParameterProperties[A](methodName: String): Data =
     macro MethodsFixtures.testParameterPropertiesImpl[A]
+
+  def testCallVarargIntMethod[A](instance: A)(methodName: String)(params: Int*): Int =
+    macro MethodsFixtures.testCallVarargIntMethodImpl[A]
+
+  def testConstructVarargCtor[A](params: String*): Data =
+    macro MethodsFixtures.testConstructVarargCtorImpl[A]
 
   def testMethodOrdering[A]: Data = macro MethodsFixtures.testMethodOrderingImpl[A]
 

--- a/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
@@ -79,6 +79,12 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
   def testConstructorParameterAnnotationsImpl[A: c.WeakTypeTag]: c.Expr[Data] =
     testConstructorParameterAnnotations[A]
 
+  def testAnnotationsOfTypeImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
+    testAnnotationsOfType[A](methodName)
+
+  def testAnnotationValueDecodedImpl[A: c.WeakTypeTag]: c.Expr[Data] =
+    testAnnotationValueDecoded[A]
+
   def testDefaultValueOnGenericMethodImpl[A: c.WeakTypeTag](
       instance: c.Expr[A],
       methodName: c.Expr[String]
@@ -149,6 +155,12 @@ object MethodsFixtures {
 
   def testConstructorParameterAnnotations[A]: Data =
     macro MethodsFixtures.testConstructorParameterAnnotationsImpl[A]
+
+  def testAnnotationsOfType[A](methodName: String): Data =
+    macro MethodsFixtures.testAnnotationsOfTypeImpl[A]
+
+  def testAnnotationValueDecoded[A]: Data =
+    macro MethodsFixtures.testAnnotationValueDecodedImpl[A]
 
   def testDefaultValueOnGenericMethod[A](instance: A, methodName: String): Data =
     macro MethodsFixtures.testDefaultValueOnGenericMethodImpl[A]

--- a/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
@@ -43,6 +43,12 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
   def testParameterPropertiesImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
     testParameterProperties[A](methodName)
 
+  def testMethodPropertiesImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
+    testMethodProperties[A](methodName)
+
+  def testMethodVisibilityImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
+    testMethodVisibility[A](methodName)
+
   def testCallVarargIntMethodImpl[A: c.WeakTypeTag](instance: c.Expr[A])(methodName: c.Expr[String])(
       params: c.Expr[Int]*
   ): c.Expr[Int] =
@@ -134,6 +140,12 @@ object MethodsFixtures {
 
   def testParameterProperties[A](methodName: String): Data =
     macro MethodsFixtures.testParameterPropertiesImpl[A]
+
+  def testMethodProperties[A](methodName: String): Data =
+    macro MethodsFixtures.testMethodPropertiesImpl[A]
+
+  def testMethodVisibility[A](methodName: String): Data =
+    macro MethodsFixtures.testMethodVisibilityImpl[A]
 
   def testCallVarargIntMethod[A](instance: A)(methodName: String)(params: Int*): Int =
     macro MethodsFixtures.testCallVarargIntMethodImpl[A]

--- a/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
@@ -70,6 +70,16 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
   def testCallConstructorViaFoldImpl[A: c.WeakTypeTag](params: c.Expr[Int]*): c.Expr[Data] =
     testCallConstructorViaFold[A](params)
 
+  def testCallInstanceViaFoldFImpl[A: c.WeakTypeTag](instance: c.Expr[A])(methodName: c.Expr[String])(
+      params: c.Expr[Int]*
+  ): c.Expr[Data] =
+    testCallInstanceViaFoldF[A](instance)(methodName)(params)
+
+  def testCallInstanceViaFoldMissingArgsImpl[A: c.WeakTypeTag](instance: c.Expr[A])(
+      methodName: c.Expr[String]
+  ): c.Expr[Data] =
+    testCallInstanceViaFoldMissingArgs[A](instance)(methodName)
+
   def testAnnotationDestructuringImpl[A: c.WeakTypeTag]: c.Expr[Data] =
     testAnnotationDestructuring[A]
 
@@ -146,6 +156,12 @@ object MethodsFixtures {
 
   def testCallConstructorViaFold[A](params: Int*): Data =
     macro MethodsFixtures.testCallConstructorViaFoldImpl[A]
+
+  def testCallInstanceViaFoldF[A](instance: A)(methodName: String)(params: Int*): Data =
+    macro MethodsFixtures.testCallInstanceViaFoldFImpl[A]
+
+  def testCallInstanceViaFoldMissingArgs[A](instance: A)(methodName: String): Data =
+    macro MethodsFixtures.testCallInstanceViaFoldMissingArgsImpl[A]
 
   def testAnnotationDestructuring[A]: Data =
     macro MethodsFixtures.testAnnotationDestructuringImpl[A]

--- a/hearth-tests/src/main/scala-2/hearth/typed/TypesFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/TypesFixtures.scala
@@ -37,6 +37,8 @@ final private class TypesFixtures(val c: blackbox.Context) extends MacroCommonsS
   def testOneWayCodecsImpl: c.Expr[Data] = testOneWayCodecs
 
   def testUnionMembersImpl[A: c.WeakTypeTag]: c.Expr[Data] = testUnionMembers[A]
+
+  def testOpaqueUnderlyingTypeImpl[A: c.WeakTypeTag]: c.Expr[Data] = testOpaqueUnderlyingType[A]
 }
 
 object TypesFixtures {
@@ -68,4 +70,6 @@ object TypesFixtures {
   def testOneWayCodecs: Data = macro TypesFixtures.testOneWayCodecsImpl
 
   def testUnionMembers[A]: Data = macro TypesFixtures.testUnionMembersImpl[A]
+
+  def testOpaqueUnderlyingType[A]: Data = macro TypesFixtures.testOpaqueUnderlyingTypeImpl[A]
 }

--- a/hearth-tests/src/main/scala-2/hearth/typed/TypesFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/TypesFixtures.scala
@@ -39,6 +39,18 @@ final private class TypesFixtures(val c: blackbox.Context) extends MacroCommonsS
   def testUnionMembersImpl[A: c.WeakTypeTag]: c.Expr[Data] = testUnionMembers[A]
 
   def testOpaqueUnderlyingTypeImpl[A: c.WeakTypeTag]: c.Expr[Data] = testOpaqueUnderlyingType[A]
+
+  def testTypeArgumentsImpl[A: c.WeakTypeTag]: c.Expr[Data] = testTypeArguments[A]
+
+  def testDecompose1Impl[A: c.WeakTypeTag]: c.Expr[Data] = testDecompose1[A]
+
+  def testDecompose2Impl[A: c.WeakTypeTag]: c.Expr[Data] = testDecompose2[A]
+
+  def testMiniFunctorDerivationImpl[A: c.WeakTypeTag]: c.Expr[Data] = testMiniFunctorDerivation[A]
+
+  def testDecomposeSummonNameImpl[A: c.WeakTypeTag]: c.Expr[String] = testDecomposeSummonName[A]
+
+  def testCtorK1FromDiscoveredPartsImpl[A: c.WeakTypeTag]: c.Expr[Data] = testCtorK1FromDiscoveredParts[A]
 }
 
 object TypesFixtures {
@@ -72,4 +84,16 @@ object TypesFixtures {
   def testUnionMembers[A]: Data = macro TypesFixtures.testUnionMembersImpl[A]
 
   def testOpaqueUnderlyingType[A]: Data = macro TypesFixtures.testOpaqueUnderlyingTypeImpl[A]
+
+  def testTypeArguments[A]: Data = macro TypesFixtures.testTypeArgumentsImpl[A]
+
+  def testDecompose1[A]: Data = macro TypesFixtures.testDecompose1Impl[A]
+
+  def testDecompose2[A]: Data = macro TypesFixtures.testDecompose2Impl[A]
+
+  def testMiniFunctorDerivation[A]: Data = macro TypesFixtures.testMiniFunctorDerivationImpl[A]
+
+  def testDecomposeSummonName[A]: String = macro TypesFixtures.testDecomposeSummonNameImpl[A]
+
+  def testCtorK1FromDiscoveredParts[A]: Data = macro TypesFixtures.testCtorK1FromDiscoveredPartsImpl[A]
 }

--- a/hearth-tests/src/main/scala-3/hearth/EnvironmentFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/EnvironmentFixtures.scala
@@ -19,6 +19,18 @@ object EnvironmentFixtures {
   inline def testErrorAndAbort: Any = ${ testErrorAndAbortImpl }
   private def testErrorAndAbortImpl(using q: Quotes): Expr[Any] = new EnvironmentFixtures(q).testErrorAndAbort
 
+  inline def testReportInfoAtPosition[A]: Data = ${ testReportInfoAtPositionImpl[A] }
+  private def testReportInfoAtPositionImpl[A: Type](using q: Quotes): Expr[Data] =
+    new EnvironmentFixtures(q).testReportInfoAtPosition[A]
+
+  inline def testReportErrorAtPosition: Data = ${ testReportErrorAtPositionImpl }
+  private def testReportErrorAtPositionImpl(using q: Quotes): Expr[Data] =
+    new EnvironmentFixtures(q).testReportErrorAtPosition
+
+  inline def testReportErrorAndAbortAtPosition: Any = ${ testReportErrorAndAbortAtPositionImpl }
+  private def testReportErrorAndAbortAtPositionImpl(using q: Quotes): Expr[Any] =
+    new EnvironmentFixtures(q).testReportErrorAndAbortAtPosition
+
   inline def testIsExpandedAt(inline position: String): Boolean = ${ testIsExpandedAtImpl('position) }
   private def testIsExpandedAtImpl(position: Expr[String])(using q: Quotes): Expr[Boolean] =
     new EnvironmentFixtures(q).testIsExpandedAt(position)

--- a/hearth-tests/src/main/scala-3/hearth/crossquotes/CrossTypeSelfRefFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/crossquotes/CrossTypeSelfRefFixtures.scala
@@ -1,0 +1,21 @@
+package hearth
+package crossquotes
+
+import hearth.data.Data
+
+import scala.quoted.*
+
+final private class CrossTypeSelfRefFixtures(q: Quotes)
+    extends MacroCommonsScala3(using q),
+      CrossTypeSelfRefFixturesImpl
+
+object CrossTypeSelfRefFixtures {
+
+  inline def testSelfReferentialImplicitType: Data = ${ testSelfReferentialImplicitTypeImpl }
+  private def testSelfReferentialImplicitTypeImpl(using q: Quotes): Expr[Data] =
+    new CrossTypeSelfRefFixtures(q).testSelfReferentialImplicitType
+
+  inline def testSelfReferentialImplicitCtor: Data = ${ testSelfReferentialImplicitCtorImpl }
+  private def testSelfReferentialImplicitCtorImpl(using q: Quotes): Expr[Data] =
+    new CrossTypeSelfRefFixtures(q).testSelfReferentialImplicitCtor
+}

--- a/hearth-tests/src/main/scala-3/hearth/examples/opaque-s3.scala.scala
+++ b/hearth-tests/src/main/scala-3/hearth/examples/opaque-s3.scala.scala
@@ -19,6 +19,29 @@ object opaqueid {
   }
 }
 
+/** Example opaque types for testing `Type.opaqueUnderlyingType`. */
+object opaqueunderlying {
+
+  /** Bounded opaque type - the underlying type should be the RHS (`Int`), not the bound. */
+  opaque type Bounded <: Int = Int
+  object Bounded { def apply(v: Int): Bounded = v }
+
+  /** Innermost opaque type of a nested chain. */
+  opaque type Inner = Int
+  object Inner { def apply(v: Int): Inner = v }
+
+  /** Opaque type whose RHS is another opaque type - should resolve to the innermost underlying (`Int`). */
+  opaque type Outer = Inner
+  object Outer { def apply(v: Inner): Outer = v }
+
+  /** Parameterized opaque type - `Wrapper[Int]` should resolve to `List[Int]`, NOT the bare `List` constructor. */
+  opaque type Wrapper[A] = List[A]
+  object Wrapper { def apply[A](v: List[A]): Wrapper[A] = v }
+
+  /** Plain (non-opaque) alias to an opaque type - should resolve to the opaque's underlying type (`Long`). */
+  type AliasToOpaque = opaqueid.OpaqueId
+}
+
 /** Example opaque type with only [[CtorLikeOf.PlainValue]] smart constructor. */
 object plainctor {
 

--- a/hearth-tests/src/main/scala-3/hearth/examples/unions-s3.scala.scala
+++ b/hearth-tests/src/main/scala-3/hearth/examples/unions-s3.scala.scala
@@ -34,4 +34,36 @@ object unions {
   type OpaqueIdOrString = OpaqueId | String // can't prove disjoint at runtime
   type OpaqueIdOrLong = OpaqueId | Long // same runtime erasure (both Long)
   type OpaqueIdOrOpaqueName = OpaqueId | OpaqueName // two opaques, can't prove disjoint
+
+  // --- Same-erasure members, accepted ONLY with user-provided TypeTests in scope at the macro call site ---
+  type RedOrListIntOrListString = Color.Red.type | List[Int] | List[String] // mixed: eqValue + TypeTest members
+
+  /** Honest runtime discriminators for the `List[Int]` / `List[String]` union members.
+    *
+    * `scala.reflect.TypeTest` is contravariant in its scrutinee type, so instances defined for `Any` satisfy implicit
+    * searches for any union scrutinee (`TypeTest[Any, T] <: TypeTest[Union, T]`) - the same two givens serve both
+    * `ListIntOrListString` and `RedOrListIntOrListString`.
+    *
+    * Empty lists are runtime-AMBIGUOUS (`List[Int]` and `List[String]` erase to the same class, and an empty list
+    * carries no element to inspect), so a deterministic policy is needed: empty lists are claimed by the `List[Int]`
+    * instance, and the `List[String]` instance only accepts non-empty lists with a `String` head.
+    */
+  object typetests {
+
+    given listOfInt: scala.reflect.TypeTest[Any, List[Int]] with {
+      override def unapply(value: Any): Option[value.type & List[Int]] = value match {
+        case list: List[?] if list.isEmpty || list.head.isInstanceOf[Int] =>
+          Some(value.asInstanceOf[value.type & List[Int]])
+        case _ => None
+      }
+    }
+
+    given listOfString: scala.reflect.TypeTest[Any, List[String]] with {
+      override def unapply(value: Any): Option[value.type & List[String]] = value match {
+        case list: List[?] if list.nonEmpty && list.head.isInstanceOf[String] =>
+          Some(value.asInstanceOf[value.type & List[String]])
+        case _ => None
+      }
+    }
+  }
 }

--- a/hearth-tests/src/main/scala-3/hearth/examples/unions-s3.scala.scala
+++ b/hearth-tests/src/main/scala-3/hearth/examples/unions-s3.scala.scala
@@ -11,15 +11,21 @@ object unions {
   opaque type OpaqueName = String
   object OpaqueName { def apply(v: String): OpaqueName = v }
 
+  object Marker
+
   // --- Disjoint (should return Some from directChildren) ---
   type StringOrInt = String | Int
   type BooleanOrDouble = Boolean | Double
-  type RedOrBlue = Color.Red.type | Color.Blue.type
+  type RedOrBlue = Color.Red.type | Color.Blue.type // singletons matched by value, not by class
   type StringOrIntOrBoolean = String | Int | Boolean
+  type RedOrString = Color.Red.type | String // mixed: singleton matched by value + class test
+  type MarkerOrInt = Marker.type | Int // mixed: module singleton matched by value + class test
 
   // --- NOT disjoint (should return None) ---
   type StringOrAnyRef = String | AnyRef // subtype overlap
   type ListIntOrListString = List[Int] | List[String] // same erasure
+  type ListIntOrSeqString = List[Int] | Seq[String] // related runtime classes (List <: Seq)
+  type IntOrJavaInteger = Int | java.lang.Integer // same runtime class after boxing
   type NothingOrString = Nothing | String // Nothing simplifies away → < 2 members
   type StringOrString = String | String // duplicate → < 2 members
   type IntOrAnyVal = Int | AnyVal // subtype overlap

--- a/hearth-tests/src/main/scala-3/hearth/typed/AnonymousInstanceFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/AnonymousInstanceFixtures.scala
@@ -70,4 +70,22 @@ object AnonymousInstanceFixtures {
       finalMethodName: Expr[String]
   )(using q: Quotes): Expr[String] =
     new AnonymousInstanceFixtures(q).testAnonymousInstanceConstructOverridingFinal[A](finalMethodName)
+
+  inline def testAnonymousInstanceCapturedOverride(inline captured: String): String = ${
+    testAnonymousInstanceCapturedOverrideImpl('captured)
+  }
+  private def testAnonymousInstanceCapturedOverrideImpl(captured: Expr[String])(using q: Quotes): Expr[String] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceCapturedOverride(captured)
+
+  inline def testAnonymousInstanceOverrideUsingParams(inline captured: String): String = ${
+    testAnonymousInstanceOverrideUsingParamsImpl('captured)
+  }
+  private def testAnonymousInstanceOverrideUsingParamsImpl(captured: Expr[String])(using q: Quotes): Expr[String] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceOverrideUsingParams(captured)
+
+  inline def testAnonymousInstanceOverrideReferencingQuoteParam: String => String = ${
+    testAnonymousInstanceOverrideReferencingQuoteParamImpl
+  }
+  private def testAnonymousInstanceOverrideReferencingQuoteParamImpl(using q: Quotes): Expr[String => String] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceOverrideReferencingQuoteParam
 }

--- a/hearth-tests/src/main/scala-3/hearth/typed/AnonymousInstanceFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/AnonymousInstanceFixtures.scala
@@ -42,4 +42,32 @@ object AnonymousInstanceFixtures {
       ctorIndex: Expr[Int]
   )(using q: Quotes): Expr[String] =
     new AnonymousInstanceFixtures(q).testAnonymousInstanceConstructWithCtorIndex[A](ctorIndex)
+
+  inline def testAnonymousInstanceParseInaccessible: Data = ${ testAnonymousInstanceParseInaccessibleImpl }
+  private def testAnonymousInstanceParseInaccessibleImpl(using q: Quotes): Expr[Data] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceParseInaccessible
+
+  inline def testAnonymousInstanceConstructNoOverrides[A]: String = ${
+    testAnonymousInstanceConstructNoOverridesImpl[A]
+  }
+  private def testAnonymousInstanceConstructNoOverridesImpl[A: Type](using q: Quotes): Expr[String] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceConstructNoOverrides[A]
+
+  inline def testAnonymousInstanceConstructNoOverridesWithMixins[A, M1]: String = ${
+    testAnonymousInstanceConstructNoOverridesWithMixinsImpl[A, M1]
+  }
+  private def testAnonymousInstanceConstructNoOverridesWithMixinsImpl[A: Type, M1: Type](using
+      q: Quotes
+  ): Expr[String] = {
+    val mc = new AnonymousInstanceFixtures(q)
+    mc.testAnonymousInstanceConstructNoOverridesWithMixins[A](mc.UntypedType.fromTyped[M1].as_??)
+  }
+
+  inline def testAnonymousInstanceConstructOverridingFinal[A](inline finalMethodName: String): String = ${
+    testAnonymousInstanceConstructOverridingFinalImpl[A]('finalMethodName)
+  }
+  private def testAnonymousInstanceConstructOverridingFinalImpl[A: Type](
+      finalMethodName: Expr[String]
+  )(using q: Quotes): Expr[String] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceConstructOverridingFinal[A](finalMethodName)
 }

--- a/hearth-tests/src/main/scala-3/hearth/typed/ClassesFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ClassesFixtures.scala
@@ -29,6 +29,20 @@ object ClassesFixtures {
   private def testCaseClassCaseFieldValuesAtImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[String] =
     new ClassesFixtures(q).testCaseClassCaseFieldValuesAt[A](expr)
 
+  inline def testCaseClassCaseFieldValuesAtCallSite[A](inline expr: A): String = ${
+    testCaseClassCaseFieldValuesAtCallSiteImpl[A]('expr)
+  }
+  private def testCaseClassCaseFieldValuesAtCallSiteImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[String] =
+    new ClassesFixtures(q).testCaseClassCaseFieldValuesAtCallSite[A](expr)
+
+  inline def testEnumParMatchOnNestedQuote[A](inline expr: A, inline suffix: String): String = ${
+    testEnumParMatchOnNestedQuoteImpl[A]('expr, 'suffix)
+  }
+  private def testEnumParMatchOnNestedQuoteImpl[A: Type](expr: Expr[A], suffix: Expr[String])(using
+      q: Quotes
+  ): Expr[String] =
+    new ClassesFixtures(q).testEnumParMatchOnNestedQuote[A](expr, suffix)
+
   inline def testEnumMatchOnAndParMatchOn[A](inline expr: A): String = ${
     testEnumMatchOnAndParMatchOnImpl[A]('expr)
   }

--- a/hearth-tests/src/main/scala-3/hearth/typed/ClassesFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ClassesFixtures.scala
@@ -49,6 +49,10 @@ object ClassesFixtures {
   private def testEnumMatchOnAndParMatchOnImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[String] =
     new ClassesFixtures(q).testEnumMatchOnAndParMatchOn[A](expr)
 
+  inline def testEnumParseDiagnostic[A]: String = ${ testEnumParseDiagnosticImpl[A] }
+  private def testEnumParseDiagnosticImpl[A: Type](using q: Quotes): Expr[String] =
+    new ClassesFixtures(q).testEnumParseDiagnostic[A]
+
   inline def testDependentEnumDiagnostic[A]: String = ${ testDependentEnumDiagnosticImpl[A] }
   private def testDependentEnumDiagnosticImpl[A: Type](using q: Quotes): Expr[String] =
     new ClassesFixtures(q).testDependentEnumDiagnostic[A]

--- a/hearth-tests/src/main/scala-3/hearth/typed/ClassesFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ClassesFixtures.scala
@@ -35,6 +35,12 @@ object ClassesFixtures {
   private def testCaseClassCaseFieldValuesAtCallSiteImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[String] =
     new ClassesFixtures(q).testCaseClassCaseFieldValuesAtCallSite[A](expr)
 
+  inline def testCaseClassCaseFieldValuesAtEverywhere[A](inline expr: A): String = ${
+    testCaseClassCaseFieldValuesAtEverywhereImpl[A]('expr)
+  }
+  private def testCaseClassCaseFieldValuesAtEverywhereImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[String] =
+    new ClassesFixtures(q).testCaseClassCaseFieldValuesAtEverywhere[A](expr)
+
   inline def testEnumParMatchOnNestedQuote[A](inline expr: A, inline suffix: String): String = ${
     testEnumParMatchOnNestedQuoteImpl[A]('expr, 'suffix)
   }

--- a/hearth-tests/src/main/scala-3/hearth/typed/ClassesFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ClassesFixtures.scala
@@ -164,6 +164,12 @@ object ClassesFixtures {
   private def testCaseClassConstructRoundTripImpl[A: Type](using q: Quotes): Expr[String] =
     new ClassesFixtures(q).testCaseClassConstructRoundTrip[A]
 
+  inline def testVarargCaseClassConstruct[A](inline expected: A): Data = ${
+    testVarargCaseClassConstructImpl[A]('expected)
+  }
+  private def testVarargCaseClassConstructImpl[A: Type](expected: Expr[A])(using q: Quotes): Expr[Data] =
+    new ClassesFixtures(q).testVarargCaseClassConstruct[A](expected)
+
   inline def testSingletonRoundTrip[A]: String = ${ testSingletonRoundTripImpl[A] }
   private def testSingletonRoundTripImpl[A: Type](using q: Quotes): Expr[String] =
     new ClassesFixtures(q).testSingletonRoundTrip[A]

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprCodecFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprCodecFixtures.scala
@@ -38,4 +38,8 @@ object ExprCodecFixtures {
   inline def testSemiQuoteFailure: Data = ${ testSemiQuoteFailureImpl }
   private def testSemiQuoteFailureImpl(using q: Quotes): Expr[Data] =
     new ExprCodecFixtures(q).testSemiQuoteFailure
+
+  inline def testBuiltInCodecExprTypes: Data = ${ testBuiltInCodecExprTypesImpl }
+  private def testBuiltInCodecExprTypesImpl(using q: Quotes): Expr[Data] =
+    new ExprCodecFixtures(q).testBuiltInCodecExprTypes
 }

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprCodecFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprCodecFixtures.scala
@@ -14,4 +14,28 @@ object ExprCodecFixtures {
   }
   private def testExprCodecRoundTripImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[Data] =
     new ExprCodecFixtures(q).testExprCodecRoundTrip[A](expr)
+
+  inline def testSemiQuotePrimitives: Data = ${ testSemiQuotePrimitivesImpl }
+  private def testSemiQuotePrimitivesImpl(using q: Quotes): Expr[Data] =
+    new ExprCodecFixtures(q).testSemiQuotePrimitives
+
+  inline def testSemiQuoteCaseClass: Data = ${ testSemiQuoteCaseClassImpl }
+  private def testSemiQuoteCaseClassImpl(using q: Quotes): Expr[Data] =
+    new ExprCodecFixtures(q).testSemiQuoteCaseClass
+
+  inline def testSemiQuoteSealedChild: Data = ${ testSemiQuoteSealedChildImpl }
+  private def testSemiQuoteSealedChildImpl(using q: Quotes): Expr[Data] =
+    new ExprCodecFixtures(q).testSemiQuoteSealedChild
+
+  inline def testSemiQuoteSingleton: Data = ${ testSemiQuoteSingletonImpl }
+  private def testSemiQuoteSingletonImpl(using q: Quotes): Expr[Data] =
+    new ExprCodecFixtures(q).testSemiQuoteSingleton
+
+  inline def testSemiQuoteWithOverride: Data = ${ testSemiQuoteWithOverrideImpl }
+  private def testSemiQuoteWithOverrideImpl(using q: Quotes): Expr[Data] =
+    new ExprCodecFixtures(q).testSemiQuoteWithOverride
+
+  inline def testSemiQuoteFailure: Data = ${ testSemiQuoteFailureImpl }
+  private def testSemiQuoteFailureImpl(using q: Quotes): Expr[Data] =
+    new ExprCodecFixtures(q).testSemiQuoteFailure
 }

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
@@ -67,6 +67,14 @@ object ExprsFixtures {
   private def testMatchCaseTypeMatchImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[Data] =
     new ExprsFixtures(q).testMatchCaseTypeMatch[A](expr)
 
+  inline def testMatchOnWithNestedQuote[A](inline expr: A, inline suffix: String): String = ${
+    testMatchOnWithNestedQuoteImpl[A]('expr, 'suffix)
+  }
+  private def testMatchOnWithNestedQuoteImpl[A: Type](expr: Expr[A], suffix: Expr[String])(using
+      q: Quotes
+  ): Expr[String] =
+    new ExprsFixtures(q).testMatchOnWithNestedQuote[A](expr, suffix)
+
   inline def testMatchCaseEqValue[A](inline expr: A): Data = ${ testMatchCaseEqValueImpl[A]('expr) }
   private def testMatchCaseEqValueImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[Data] =
     new ExprsFixtures(q).testMatchCaseEqValue[A](expr)

--- a/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
@@ -133,6 +133,16 @@ object MethodsFixtures {
   private def testAnnotationDestructuringImpl[A: Type](using q: Quotes): Expr[Data] =
     new MethodsFixtures(q).testAnnotationDestructuring[A]
 
+  inline def testParameterAnnotations[A](inline methodName: String): Data = ${
+    testParameterAnnotationsImpl[A]('methodName)
+  }
+  private def testParameterAnnotationsImpl[A: Type](methodName: Expr[String])(using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testParameterAnnotations[A](methodName)
+
+  inline def testConstructorParameterAnnotations[A]: Data = ${ testConstructorParameterAnnotationsImpl[A] }
+  private def testConstructorParameterAnnotationsImpl[A: Type](using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testConstructorParameterAnnotations[A]
+
   inline def testFoldAnonymousInstanceMethod[A](inline instance: A, inline methodName: String): Data = ${
     testFoldAnonymousInstanceMethodImpl[A]('instance, 'methodName)
   }

--- a/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
@@ -159,6 +159,16 @@ object MethodsFixtures {
   private def testConstructorParameterAnnotationsImpl[A: Type](using q: Quotes): Expr[Data] =
     new MethodsFixtures(q).testConstructorParameterAnnotations[A]
 
+  inline def testAnnotationsOfType[A](inline methodName: String): Data = ${
+    testAnnotationsOfTypeImpl[A]('methodName)
+  }
+  private def testAnnotationsOfTypeImpl[A: Type](methodName: Expr[String])(using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testAnnotationsOfType[A](methodName)
+
+  inline def testAnnotationValueDecoded[A]: Data = ${ testAnnotationValueDecodedImpl[A] }
+  private def testAnnotationValueDecodedImpl[A: Type](using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testAnnotationValueDecoded[A]
+
   inline def testFoldAnonymousInstanceMethod[A](inline instance: A, inline methodName: String): Data = ${
     testFoldAnonymousInstanceMethodImpl[A]('instance, 'methodName)
   }

--- a/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
@@ -194,6 +194,12 @@ object MethodsFixtures {
   private def testAnnotationValueDecodedImpl[A: Type](using q: Quotes): Expr[Data] =
     new MethodsFixtures(q).testAnnotationValueDecoded[A]
 
+  inline def testSplicedAnnotationValue[A](inline methodName: String): Data = ${
+    testSplicedAnnotationValueImpl[A]('methodName)
+  }
+  private def testSplicedAnnotationValueImpl[A: Type](methodName: Expr[String])(using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testSplicedAnnotationValue[A](methodName)
+
   inline def testFoldAnonymousInstanceMethod[A](inline instance: A, inline methodName: String): Data = ${
     testFoldAnonymousInstanceMethodImpl[A]('instance, 'methodName)
   }

--- a/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
@@ -194,6 +194,10 @@ object MethodsFixtures {
   private def testAnnotationValueDecodedImpl[A: Type](using q: Quotes): Expr[Data] =
     new MethodsFixtures(q).testAnnotationValueDecoded[A]
 
+  inline def testFieldNameReproducer[A]: Data = ${ testFieldNameReproducerImpl[A] }
+  private def testFieldNameReproducerImpl[A: Type](using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testFieldNameReproducer[A]
+
   inline def testSplicedAnnotationValue[A](inline methodName: String): Data = ${
     testSplicedAnnotationValueImpl[A]('methodName)
   }

--- a/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
@@ -99,6 +99,12 @@ object MethodsFixtures {
   private def testMethodPropertiesImpl[A: Type](methodName: Expr[String])(using q: Quotes): Expr[Data] =
     new MethodsFixtures(q).testMethodProperties[A](methodName)
 
+  inline def testMethodVisibility[A](inline methodName: String): Data = ${
+    testMethodVisibilityImpl[A]('methodName)
+  }
+  private def testMethodVisibilityImpl[A: Type](methodName: Expr[String])(using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testMethodVisibility[A](methodName)
+
   inline def testMethodExpectations[A](inline methodName: String): Data = ${
     testMethodExpectationsImpl[A]('methodName)
   }

--- a/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
@@ -135,6 +135,25 @@ object MethodsFixtures {
   private def testCallConstructorViaFoldImpl[A: Type](params: Expr[Seq[Int]])(using q: Quotes): Expr[Data] =
     new MethodsFixtures(q).testCallConstructorViaFold[A](params)
 
+  inline def testCallInstanceViaFoldF[A](inline instance: A)(inline methodName: String)(inline params: Int*): Data = ${
+    testCallInstanceViaFoldFImpl[A]('instance, 'methodName, 'params)
+  }
+  private def testCallInstanceViaFoldFImpl[A: Type](
+      instance: Expr[A],
+      methodName: Expr[String],
+      params: Expr[Seq[Int]]
+  )(using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testCallInstanceViaFoldF[A](instance)(methodName)(params)
+
+  inline def testCallInstanceViaFoldMissingArgs[A](inline instance: A)(inline methodName: String): Data = ${
+    testCallInstanceViaFoldMissingArgsImpl[A]('instance, 'methodName)
+  }
+  private def testCallInstanceViaFoldMissingArgsImpl[A: Type](
+      instance: Expr[A],
+      methodName: Expr[String]
+  )(using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testCallInstanceViaFoldMissingArgs[A](instance)(methodName)
+
   inline def testConstructNamedTuple[A]: Data = ${ testConstructNamedTupleImpl[A] }
   private def testConstructNamedTupleImpl[A: Type](using q: Quotes): Expr[Data] =
     new MethodsFixtures(q).testConstructNamedTuple[A]

--- a/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
@@ -77,6 +77,22 @@ object MethodsFixtures {
   private def testParameterPropertiesImpl[A: Type](methodName: Expr[String])(using q: Quotes): Expr[Data] =
     new MethodsFixtures(q).testParameterProperties[A](methodName)
 
+  inline def testCallVarargIntMethod[A](inline instance: A)(inline methodName: String)(inline params: Int*): Int = ${
+    testCallVarargIntMethodImpl[A]('instance, 'methodName, 'params)
+  }
+  private def testCallVarargIntMethodImpl[A: Type](
+      instance: Expr[A],
+      methodName: Expr[String],
+      params: Expr[Seq[Int]]
+  )(using q: Quotes): Expr[Int] =
+    new MethodsFixtures(q).testCallVarargIntMethod[A](instance)(methodName)(params)
+
+  inline def testConstructVarargCtor[A](inline params: String*): Data = ${
+    testConstructVarargCtorImpl[A]('params)
+  }
+  private def testConstructVarargCtorImpl[A: Type](params: Expr[Seq[String]])(using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testConstructVarargCtor[A](params)
+
   inline def testMethodProperties[A](inline methodName: String): Data = ${
     testMethodPropertiesImpl[A]('methodName)
   }

--- a/hearth-tests/src/main/scala-3/hearth/typed/TypesFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/TypesFixtures.scala
@@ -136,4 +136,28 @@ object TypesFixtures {
 
   inline def testTupleXXLCodec: Data = ${ testTupleXXLCodecImpl }
   private def testTupleXXLCodecImpl(using q: Quotes): Expr[Data] = new TypesFixtures(q).testTupleXXLCodec
+
+  inline def testTypeArguments[A]: Data = ${ testTypeArgumentsImpl[A] }
+  private def testTypeArgumentsImpl[A: Type](using q: Quotes): Expr[Data] =
+    new TypesFixtures(q).testTypeArguments[A]
+
+  inline def testDecompose1[A]: Data = ${ testDecompose1Impl[A] }
+  private def testDecompose1Impl[A: Type](using q: Quotes): Expr[Data] =
+    new TypesFixtures(q).testDecompose1[A]
+
+  inline def testDecompose2[A]: Data = ${ testDecompose2Impl[A] }
+  private def testDecompose2Impl[A: Type](using q: Quotes): Expr[Data] =
+    new TypesFixtures(q).testDecompose2[A]
+
+  inline def testMiniFunctorDerivation[A]: Data = ${ testMiniFunctorDerivationImpl[A] }
+  private def testMiniFunctorDerivationImpl[A: Type](using q: Quotes): Expr[Data] =
+    new TypesFixtures(q).testMiniFunctorDerivation[A]
+
+  inline def testDecomposeSummonName[A]: String = ${ testDecomposeSummonNameImpl[A] }
+  private def testDecomposeSummonNameImpl[A: Type](using q: Quotes): Expr[String] =
+    new TypesFixtures(q).testDecomposeSummonName[A]
+
+  inline def testCtorK1FromDiscoveredParts[A]: Data = ${ testCtorK1FromDiscoveredPartsImpl[A] }
+  private def testCtorK1FromDiscoveredPartsImpl[A: Type](using q: Quotes): Expr[Data] =
+    new TypesFixtures(q).testCtorK1FromDiscoveredParts[A]
 }

--- a/hearth-tests/src/main/scala-3/hearth/typed/TypesFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/TypesFixtures.scala
@@ -130,6 +130,10 @@ object TypesFixtures {
   private def testUnionMembersImpl[A: Type](using q: Quotes): Expr[Data] =
     new TypesFixtures(q).testUnionMembers[A]
 
+  inline def testOpaqueUnderlyingType[A]: Data = ${ testOpaqueUnderlyingTypeImpl[A] }
+  private def testOpaqueUnderlyingTypeImpl[A: Type](using q: Quotes): Expr[Data] =
+    new TypesFixtures(q).testOpaqueUnderlyingType[A]
+
   inline def testTupleXXLCodec: Data = ${ testTupleXXLCodecImpl }
   private def testTupleXXLCodecImpl(using q: Quotes): Expr[Data] = new TypesFixtures(q).testTupleXXLCodec
 }

--- a/hearth-tests/src/main/scala/hearth/EnvironmentFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/EnvironmentFixturesImpl.scala
@@ -45,6 +45,23 @@ trait EnvironmentFixturesImpl { this: MacroCommons =>
 
   def testErrorAndAbort: Expr[Any] = Environment.reportErrorAndAbort("Error and abort message")
 
+  def testReportInfoAtPosition[A: Type]: Expr[Data] = {
+    // Scala 2 does not store positions for symbols from a previous compilation unit (they would be None),
+    // so we fall back to the macro expansion position to keep the test cross-platform.
+    val methodPosition = Type[A].methods.flatMap(_.position).headOption
+    val position = methodPosition.getOrElse(Environment.currentPosition)
+    Environment.reportInfo(s"Position-targeted info message at ${position.prettyPrint}", position)
+    Expr(Data.map("infoReported" -> Data(true)))
+  }
+
+  def testReportErrorAtPosition: Expr[Data] = {
+    Environment.reportError("Error at position message", Environment.currentPosition)
+    Expr(Data.map("errorReported" -> Data(true)))
+  }
+
+  def testReportErrorAndAbortAtPosition: Expr[Any] =
+    Environment.reportErrorAndAbort("Error and abort at position message", Environment.currentPosition)
+
   def testIsExpandedAt(position: Expr[String]): Expr[Boolean] = Expr
     .unapply(position)
     .fold(

--- a/hearth-tests/src/main/scala/hearth/crossquotes/CrossTypeSelfRefFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/CrossTypeSelfRefFixturesImpl.scala
@@ -1,0 +1,52 @@
+package hearth
+package crossquotes
+
+import hearth.data.Data
+
+/** Fixtures for testing [[CrossTypeSelfRefSpec]].
+  *
+  * Regression tests for hearth#285: `implicit val ConfigT: Type[Configuration] = Type.of[Configuration]` used to make
+  * the generated implicit/given lookup resolve to the very value being defined:
+  *   - Scala 2: `weakTypeTag` picked up the in-definition implicit via `convertProvidedTypesForCrossQuotes`, producing
+  *     `implicit val ConfigT = ConfigT` (forward-reference error in blocks, null/infinite recursion in class bodies),
+  *   - Scala 3: the plugin injected `given castedConfigT: scala.quoted.Type[...] = Type[...]...` which summoned the
+  *     val being initialized (forward-reference error in blocks, null at runtime in class bodies).
+  *
+  * The fix excludes the definition currently being initialized from the implicit search performed by the generated
+  * code, so `Type.of`/`Type.CtorN.of` fall back to direct materialization from the literal type argument.
+  */
+trait CrossTypeSelfRefFixturesImpl { this: MacroTypedCommons =>
+
+  /** Mirrors the downstream `StandardMacroExtension` pattern from hearth#285: a class-level `implicit val` whose own
+    * RHS calls `Type.of` for the very type the val provides.
+    */
+  implicit val classLevelSelfRefType: Type[examples.classes.ExampleClass] =
+    Type.of[examples.classes.ExampleClass]
+
+  def testSelfReferentialImplicitType: Expr[Data] = {
+    implicit val methodLocalSelfRefType: Type[examples.classes.ExampleTrait] =
+      Type.of[examples.classes.ExampleTrait]
+    // A second self-referential val in the same block: its expansion must neither resolve to itself nor
+    // forward-reference candidates injected for statements that follow it.
+    implicit val secondLocalSelfRefType: Type[examples.classes.ExampleClassWithTypeParam[Int]] =
+      Type.of[examples.classes.ExampleClassWithTypeParam[Int]]
+    Expr(
+      Data.map(
+        "classLevelVal" -> Data(classLevelSelfRefType.plainPrint),
+        "methodLocalVal" -> Data(methodLocalSelfRefType.plainPrint),
+        "secondLocalVal" -> Data(secondLocalSelfRefType.plainPrint),
+        // The self-referential implicit must still be a usable implicit for subsequent expansions.
+        "implicitStillUsable" -> Data(Type.of[Option[examples.classes.ExampleTrait]].plainPrint)
+      )
+    )
+  }
+
+  def testSelfReferentialImplicitCtor: Expr[Data] = {
+    implicit val selfRefOptionCtor: Type.Ctor1[Option] = Type.Ctor1.of[Option]
+    Expr(
+      Data.map(
+        "appliedCtor" -> Data(selfRefOptionCtor.apply[Int](using Type.of[Int]).plainPrint)
+      )
+    )
+  }
+}

--- a/hearth-tests/src/main/scala/hearth/crossquotes/CrossTypeSelfRefFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/CrossTypeSelfRefFixturesImpl.scala
@@ -9,8 +9,8 @@ import hearth.data.Data
   * the generated implicit/given lookup resolve to the very value being defined:
   *   - Scala 2: `weakTypeTag` picked up the in-definition implicit via `convertProvidedTypesForCrossQuotes`, producing
   *     `implicit val ConfigT = ConfigT` (forward-reference error in blocks, null/infinite recursion in class bodies),
-  *   - Scala 3: the plugin injected `given castedConfigT: scala.quoted.Type[...] = Type[...]...` which summoned the
-  *     val being initialized (forward-reference error in blocks, null at runtime in class bodies).
+  *   - Scala 3: the plugin injected `given castedConfigT: scala.quoted.Type[...] = Type[...]...` which summoned the val
+  *     being initialized (forward-reference error in blocks, null at runtime in class bodies).
   *
   * The fix excludes the definition currently being initialized from the implicit search performed by the generated
   * code, so `Type.of`/`Type.CtorN.of` fall back to direct materialization from the literal type argument.

--- a/hearth-tests/src/main/scala/hearth/examples/anonymous_instances.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/anonymous_instances.scala
@@ -101,3 +101,7 @@ abstract class PackagePrivateConstructor private[anonymous_instances] (val x: In
 abstract class AbstractClassWithDefaults(val x: Int, val y: String = "default") {
   def abstractMethod: Int
 }
+
+trait TraitWithVarargMethod {
+  def sum(xs: Int*): Int
+}

--- a/hearth-tests/src/main/scala/hearth/examples/anonymous_instances.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/anonymous_instances.scala
@@ -105,3 +105,10 @@ abstract class AbstractClassWithDefaults(val x: Int, val y: String = "default") 
 trait TraitWithVarargMethod {
   def sum(xs: Int*): Int
 }
+
+/** Only visible inside `hearth.examples.anonymous_instances` — test fixtures resolve it via `UntypedType.fromClassName`
+  * to exercise the `TypeInaccessible` error (the call site cannot even name it).
+  */
+private[anonymous_instances] trait PackagePrivateTrait {
+  def value: Int
+}

--- a/hearth-tests/src/main/scala/hearth/examples/classes.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/classes.scala
@@ -14,3 +14,8 @@ final class ExampleClassWithTypeParam[A]
 case class ExampleCaseClass(a: Int)
 case class ExampleCaseClassWithTypeParam[A](a: A)
 case class ExampleCaseClassWithDefaults(a: Int, b: String = "default-b")
+
+// Regression example for commit 68e1781: caseFieldValuesAt(instance, visibility) filters fields
+// by accessibility. `b` is accessible from within the `hearth` package (so AtCallSite keeps it when
+// expanding inside hearth), but it is not accessible "everywhere" (so Everywhere skips it).
+case class ExampleCaseClassWithPrivateField(a: Int, private[hearth] val b: String)

--- a/hearth-tests/src/main/scala/hearth/examples/classes.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/classes.scala
@@ -12,6 +12,7 @@ final class ExampleClass
 final class ExampleClassWithTypeParam[A]
 
 case class ExampleCaseClass(a: Int)
+case class ExampleCaseClassWithVarargs(xs: Int*)
 case class ExampleCaseClassWithTypeParam[A](a: A)
 case class ExampleCaseClassWithDefaults(a: Int, b: String = "default-b")
 

--- a/hearth-tests/src/main/scala/hearth/examples/classes.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/classes.scala
@@ -17,6 +17,7 @@ case class ExampleCaseClassWithTypeParam[A](a: A)
 case class ExampleCaseClassWithDefaults(a: Int, b: String = "default-b")
 
 // Regression example for commit 68e1781: caseFieldValuesAt(instance, visibility) filters fields
-// by accessibility. `b` is accessible from within the `hearth` package (so AtCallSite keeps it when
-// expanding inside hearth), but it is not accessible "everywhere" (so Everywhere skips it).
+// by accessibility. By default (Unrestricted) `b` is always returned; it is accessible from within
+// the `hearth` package (so AtCallSite keeps it when expanding inside hearth), but it is not
+// accessible "everywhere" (so explicit Everywhere skips it).
 case class ExampleCaseClassWithPrivateField(a: Int, private[hearth] val b: String)

--- a/hearth-tests/src/main/scala/hearth/examples/expr_codecs.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/expr_codecs.scala
@@ -17,6 +17,8 @@ case object Sentinel
 
 case class DataHolder(label: String, payload: hearth.data.Data)
 
+case class VarargNumbers(xs: Int*)
+
 case class ConfigWithFunctions(
     mapper: String => String = identity,
     flag: Boolean = false,

--- a/hearth-tests/src/main/scala/hearth/examples/expr_codecs.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/expr_codecs.scala
@@ -27,3 +27,6 @@ class Preference[A]
 object Preference {
   def apply[A]: Preference[A] = new Preference[A]
 }
+
+/** Not a case class, not a singleton, not a sealed hierarchy — nothing in `semiQuoteInternal` can handle it. */
+class NotQuotable(val value: Int)

--- a/hearth-tests/src/main/scala/hearth/examples/kinds.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/kinds.scala
@@ -31,6 +31,31 @@ trait Arity23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, 
 
 trait HigherKinded1[F[_]]
 
+/** Non-generic supertype of [[MyTC]], so that macro fixtures can splice `instance.name` without referencing the phantom
+  * constructor label in generated trees (issue #284).
+  */
+trait HasName {
+  def name: String
+}
+
+/** Tiny type class for testing summoning of instances for type constructors discovered via `Type.decompose1` (issue
+  * #284).
+  */
+trait MyTC[F[_]] extends HasName
+object MyTC {
+  implicit val myTCForList: MyTC[List] = new MyTC[List] {
+    def name: String = "MyTC[List]"
+  }
+  implicit val myTCForOption: MyTC[Option] = new MyTC[Option] {
+    def name: String = "MyTC[Option]"
+  }
+}
+
+/** Mini-Functor-derivation test case: each field is some `G[A]` where `G` is only discovered during expansion (issue
+  * #284).
+  */
+final case class Box[A](items: List[A], maybe: Option[A])
+
 // format: off
 object Alias {
   type Renamed1[A] = Arity1[A]

--- a/hearth-tests/src/main/scala/hearth/examples/methods.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/methods.scala
@@ -103,3 +103,15 @@ class WithImplicits {
   implicit def implicitConversion(x: Int): String = x.toString
   def methodWithImplicitParam(implicit x: Int): String = x.toString
 }
+
+// Regression examples for commit 68e1781: setters (name_=) must not be marked as
+// constructor arguments nor case fields, and visibility declared on a var must
+// propagate from the getter/val to the synthesized setter.
+
+final class WithVarCtorParam(var name: String)
+
+case class CaseClassWithVarCtorParam(var name: String)
+
+class WithRestrictedVar {
+  private[examples] var counter: Int = 0
+}

--- a/hearth-tests/src/main/scala/hearth/examples/methods.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/methods.scala
@@ -108,6 +108,18 @@ class WithImplicits {
 // constructor arguments nor case fields, and visibility declared on a var must
 // propagate from the getter/val to the synthesized setter.
 
+// Reproducer for issue #283: a plain (non-case) `final` annotation class with `val` constructor
+// parameters, attached to a case class constructor parameter; literal args must be readable
+// cross-platform (String, Boolean, Double — not just Int).
+
+final class fieldName(val name: String) extends scala.annotation.StaticAnnotation
+final class fieldFlags(val enabled: Boolean, val weight: Double) extends scala.annotation.StaticAnnotation
+
+final case class Person(
+    @fieldName("first_name") firstName: String,
+    @fieldName("age") @fieldFlags(true, 1.5) age: Int
+)
+
 final class WithVarCtorParam(var name: String)
 
 case class CaseClassWithVarCtorParam(var name: String)

--- a/hearth-tests/src/main/scala/hearth/examples/methods.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/methods.scala
@@ -5,6 +5,20 @@ package methods
 class ExampleAnnotation extends scala.annotation.StaticAnnotation
 class ExampleAnnotation2(val value: Int) extends scala.annotation.StaticAnnotation
 
+class ParentAnnotation extends scala.annotation.StaticAnnotation
+class ChildAnnotation extends ParentAnnotation
+
+@ChildAnnotation
+class WithChildAnnotation {
+
+  @ChildAnnotation
+  def annotatedMethod(@ChildAnnotation arg: Int): Int = arg
+
+  @ExampleAnnotation2(42)
+  @ParentAnnotation
+  def annotatedMethod2(arg: Int): Int = arg
+}
+
 @ExampleAnnotation
 trait Trait {
 

--- a/hearth-tests/src/main/scala/hearth/examples/methods.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/methods.scala
@@ -35,6 +35,12 @@ class NoCompanionClass extends Trait {
   override def inheritedAbstractMethod(arg: Int): Int = arg + 1
 }
 
+case class WithAnnotatedParams(
+    @ExampleAnnotation a: Int,
+    @ExampleAnnotation2(1) b: String,
+    c: Double
+)
+
 final class WithCompanion(arg: Int) {
 
   def method(arg2: Int): Int = arg + arg2

--- a/hearth-tests/src/main/scala/hearth/examples/methods_overhaul.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/methods_overhaul.scala
@@ -91,3 +91,13 @@ trait SimpleAlg {
 class SimpleAlgImpl extends SimpleAlg {
   def getUser(id: Int): String = s"user:$id"
 }
+
+class WithVarargs {
+  def varargMethod(xs: Int*): Int = xs.sum
+  def normalMethod(x: Int): Int = x
+  def byNameMethod(x: => Int): Int = x
+}
+
+class WithVarargsCtor(val xs: String*) {
+  override def toString(): String = s"WithVarargsCtor(${xs.mkString(",")})"
+}

--- a/hearth-tests/src/main/scala/hearth/typed/AnonymousInstanceFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/AnonymousInstanceFixturesImpl.scala
@@ -128,6 +128,93 @@ trait AnonymousInstanceFixturesImpl { this: MacroCommons =>
     }
   }
 
+  def testAnonymousInstanceParseInaccessible: Expr[Data] = {
+    val inaccessible =
+      UntypedType.fromClassName("hearth.examples.anonymous_instances.PackagePrivateTrait").as_??
+    import inaccessible.Underlying as Inaccessible
+    AnonymousInstance.parse[Inaccessible] match {
+      case ClassViewResult.Compatible(_) =>
+        Expr(Data.map("result" -> Data("compatible")))
+      case ClassViewResult.Incompatible(reason) =>
+        Expr(Data.map("result" -> Data("incompatible"), "reason" -> Data(reason)))
+    }
+  }
+
+  def testAnonymousInstanceConstructNoOverrides[A: Type]: Expr[String] = {
+    implicit val IntType: Type[Int] = intTypeAI
+    implicit val StringType: Type[String] = stringTypeAI
+    implicit val BooleanType: Type[Boolean] = booleanTypeAI
+
+    AnonymousInstance.parse[A] match {
+      case ClassViewResult.Compatible(ai) =>
+        val ctor = ai.classParent.flatMap(_._2.headOption)
+        val ctorArgs: Arguments = ctor match {
+          case Some(c) => buildDefaultCtorArgs(c)
+          case None    => Map.empty
+        }
+        constructAndSplice(ai, ctor, ctorArgs, Map.empty)
+      case ClassViewResult.Incompatible(reason) =>
+        Expr(s"incompatible: $reason")
+    }
+  }
+
+  def testAnonymousInstanceConstructNoOverridesWithMixins[A: Type](mixin1: ??): Expr[String] = {
+    implicit val IntType: Type[Int] = intTypeAI
+    implicit val StringType: Type[String] = stringTypeAI
+    implicit val BooleanType: Type[Boolean] = booleanTypeAI
+
+    AnonymousInstance.parseWithMixins[A](List(mixin1)) match {
+      case ClassViewResult.Compatible(ai) =>
+        val ctor = ai.classParent.flatMap(_._2.headOption)
+        val ctorArgs: Arguments = ctor match {
+          case Some(c) => buildDefaultCtorArgs(c)
+          case None    => Map.empty
+        }
+        constructAndSplice(ai, ctor, ctorArgs, Map.empty)
+      case ClassViewResult.Incompatible(reason) =>
+        Expr(s"incompatible: $reason")
+    }
+  }
+
+  def testAnonymousInstanceConstructOverridingFinal[A: Type](finalMethodName: Expr[String]): Expr[String] = {
+    implicit val IntType: Type[Int] = intTypeAI
+    implicit val StringType: Type[String] = stringTypeAI
+    implicit val BooleanType: Type[Boolean] = booleanTypeAI
+
+    val name = Expr
+      .unapply(finalMethodName)
+      .getOrElse(
+        Environment.reportErrorAndAbort(s"Method name must be a string literal, got ${finalMethodName.prettyPrint}")
+      )
+
+    AnonymousInstance.parse[A] match {
+      case ClassViewResult.Compatible(ai) =>
+        val finalOverrides: Map[UntypedMethod, OverrideBody] = ai.cannotOverride.collect {
+          case cm if cm.method.name == name =>
+            cm.method.asUntyped -> new OverrideBody {
+              def apply(ctx: OverrideContext): Expr_?? = {
+                import ctx.returnType.Underlying as R
+                if (Type[R] <:< Type[Int]) Expr(0).as_??
+                else if (Type[R] <:< Type[String]) Expr("stub").as_??
+                else if (Type[R] <:< Type[Boolean]) Expr(false).as_??
+                else Expr.quote(null.asInstanceOf[R]).as_??
+              }
+            }
+        }.toMap
+        if (finalOverrides.isEmpty)
+          Environment.reportErrorAndAbort(s"No final (CannotOverride) method named $name found")
+        val overrides = buildDefaultOverrides(ai) ++ finalOverrides
+        val ctor = ai.classParent.flatMap(_._2.headOption)
+        val ctorArgs: Arguments = ctor match {
+          case Some(c) => buildDefaultCtorArgs(c)
+          case None    => Map.empty
+        }
+        constructAndSplice(ai, ctor, ctorArgs, overrides)
+      case ClassViewResult.Incompatible(reason) =>
+        Expr(s"incompatible: $reason")
+    }
+  }
+
   private def constructWithDefaults[A: Type](ai: AnonymousInstance[A])(implicit
       IntType: Type[Int],
       StringType: Type[String],

--- a/hearth-tests/src/main/scala/hearth/typed/AnonymousInstanceFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/AnonymousInstanceFixturesImpl.scala
@@ -8,6 +8,10 @@ trait AnonymousInstanceFixturesImpl { this: MacroCommons =>
   private val intTypeAI: Type[Int] = Type.of[Int]
   private val stringTypeAI: Type[String] = Type.of[String]
   private val booleanTypeAI: Type[Boolean] = Type.of[Boolean]
+  private val traitWithConcreteMethodTypeAI: Type[examples.anonymous_instances.TraitWithConcreteMethod] =
+    Type.of[examples.anonymous_instances.TraitWithConcreteMethod]
+  private val genericParentOfStringTypeAI: Type[examples.anonymous_instances.GenericParent[String]] =
+    Type.of[examples.anonymous_instances.GenericParent[String]]
 
   private val jvmInheritedMethodNames: Set[String] = Set(
     "clone",
@@ -210,6 +214,106 @@ trait AnonymousInstanceFixturesImpl { this: MacroCommons =>
           case None    => Map.empty
         }
         constructAndSplice(ai, ctor, ctorArgs, overrides)
+      case ClassViewResult.Incompatible(reason) =>
+        Expr(s"incompatible: $reason")
+    }
+  }
+
+  /** Regression for commit 7c82fc9 (Scala 2 anonymous instance scope): the override body splices an expression captured
+    * at the call site (a reference to a local val), and the constructed instance's overridden method is called at
+    * runtime. A premature `c.typecheck` of the generated `new ... { ... }` tree must not break this.
+    */
+  def testAnonymousInstanceCapturedOverride(captured: Expr[String]): Expr[String] = {
+    implicit val StringType: Type[String] = stringTypeAI
+    implicit val TraitType: Type[examples.anonymous_instances.TraitWithConcreteMethod] =
+      traitWithConcreteMethodTypeAI
+
+    AnonymousInstance.parse[examples.anonymous_instances.TraitWithConcreteMethod] match {
+      case ClassViewResult.Compatible(ai) =>
+        val overrides: Map[UntypedMethod, OverrideBody] = ai.mustOverride.map { cm =>
+          cm.method.asUntyped -> new OverrideBody {
+            def apply(ctx: OverrideContext): Expr_?? =
+              Expr.quote(Expr.splice(captured) + "!").as_??
+          }
+        }.toMap
+        ai.construct(None, Map.empty, overrides) match {
+          case Right(constructed) =>
+            Expr.quote {
+              Expr.splice(constructed).abstractMethod
+            }
+          case Left(errors) =>
+            Expr(s"errors: ${errors.toVector.mkString("; ")}")
+        }
+      case ClassViewResult.Incompatible(reason) =>
+        Expr(s"incompatible: $reason")
+    }
+  }
+
+  /** Regression for commit 7c82fc9 (the cats-tagless pattern): the anonymous instance is constructed inside
+    * `Expr.splice`, and its override body references a lambda parameter bound by the enclosing [[Expr.quote]]. A
+    * premature `c.typecheck` of the generated `new` tree cannot resolve such a reference (the binding only exists in
+    * the quote under construction), so construct must keep the tree untyped until final splicing.
+    */
+  def testAnonymousInstanceOverrideReferencingQuoteParam: Expr[String => String] =
+    Expr.quote { (prefix: String) =>
+      val _ = prefix
+      Expr.splice {
+        buildInstanceReturning(Expr.quote(prefix))
+      }
+    }
+
+  private def buildInstanceReturning(prefixExpr: Expr[String]): Expr[String] = {
+    implicit val StringType: Type[String] = stringTypeAI
+    implicit val TraitType: Type[examples.anonymous_instances.TraitWithConcreteMethod] =
+      traitWithConcreteMethodTypeAI
+
+    AnonymousInstance.parse[examples.anonymous_instances.TraitWithConcreteMethod] match {
+      case ClassViewResult.Compatible(ai) =>
+        val overrides: Map[UntypedMethod, OverrideBody] = ai.mustOverride.map { cm =>
+          cm.method.asUntyped -> new OverrideBody {
+            def apply(ctx: OverrideContext): Expr_?? =
+              Expr.quote(Expr.splice(prefixExpr) + "!").as_??
+          }
+        }.toMap
+        ai.construct(None, Map.empty, overrides) match {
+          case Right(constructed) =>
+            Expr.quote {
+              Expr.splice(constructed).abstractMethod
+            }
+          case Left(errors) =>
+            Expr(s"errors: ${errors.toVector.mkString("; ")}")
+        }
+      case ClassViewResult.Incompatible(reason) =>
+        Expr(s"incompatible: $reason")
+    }
+  }
+
+  /** Companion regression for commit 7c82fc9: override bodies that use the override's own parameters (`Ident` refs to
+    * the generated method's params) together with a captured call-site expression.
+    */
+  def testAnonymousInstanceOverrideUsingParams(captured: Expr[String]): Expr[String] = {
+    implicit val StringType: Type[String] = stringTypeAI
+    implicit val ParentType: Type[examples.anonymous_instances.GenericParent[String]] =
+      genericParentOfStringTypeAI
+
+    AnonymousInstance.parse[examples.anonymous_instances.GenericParent[String]] match {
+      case ClassViewResult.Compatible(ai) =>
+        val overrides: Map[UntypedMethod, OverrideBody] = ai.mustOverride.map { cm =>
+          cm.method.asUntyped -> new OverrideBody {
+            def apply(ctx: OverrideContext): Expr_?? =
+              if (cm.method.name == "transform") ctx.parameters.head
+              else Expr.quote(Expr.splice(captured) + "!").as_??
+          }
+        }.toMap
+        ai.construct(None, Map.empty, overrides) match {
+          case Right(constructed) =>
+            Expr.quote {
+              val instance = Expr.splice(constructed)
+              instance.value + " " + instance.transform("echo")
+            }
+          case Left(errors) =>
+            Expr(s"errors: ${errors.toVector.mkString("; ")}")
+        }
       case ClassViewResult.Incompatible(reason) =>
         Expr(s"incompatible: $reason")
     }

--- a/hearth-tests/src/main/scala/hearth/typed/ClassesFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ClassesFixturesImpl.scala
@@ -190,6 +190,20 @@ trait ClassesFixturesImpl { this: MacroCommons =>
         .fold(errors => Expr(s"<failed to construct: ${errors.mkString(", ")}>"), identity)
     }
 
+  /** Surfaces the full [[Enum.parse]] result: the (ANSI-stripped) error message when the type is rejected, or the
+    * direct children when it parses. Used to assert union refusal diagnostics (e.g. which
+    * `scala.reflect.TypeTest[Union, Member]` instances are missing).
+    */
+  def testEnumParseDiagnostic[A: Type]: Expr[String] = Expr(
+    Enum
+      .parse[A]
+      .toEither
+      .fold(
+        error => removeAnsiColors(error),
+        enumm => s"parsed with children: ${enumm.directChildren.keys.mkString(", ")}"
+      )
+  )
+
   /** Regression for commit 68e1781 (splice isolation): parMatchOn handlers whose results are built from nested
     * [[Expr.quote]] calls splicing the matched expression must not leak splice ownership across case boundaries.
     */

--- a/hearth-tests/src/main/scala/hearth/typed/ClassesFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ClassesFixturesImpl.scala
@@ -149,6 +149,22 @@ trait ClassesFixturesImpl { this: MacroCommons =>
     }
   }
 
+  /** Like [[testCaseClassCaseFieldValuesAt]] but passes `AtCallSite` visibility, so fields inaccessible at the macro
+    * expansion point should be skipped (regression for commit 68e1781).
+    */
+  def testCaseClassCaseFieldValuesAtCallSite[A: Type](expr: Expr[A]): Expr[String] = Expr {
+    CaseClass.parse[A].toOption.fold("<no case class>") { caseClass =>
+      caseClass
+        .caseFieldValuesAt(expr, visibility = AtCallSite)
+        .toList
+        .sortBy(_._1)
+        .map { case (name, value) =>
+          s"$name: ${value.plainPrint}"
+        }
+        .mkString("(", ", ", ")")
+    }
+  }
+
   def testEnumMatchOnAndParMatchOn[A: Type](expr: Expr[A]): Expr[String] =
     Enum.parse[A].toOption.fold(Expr("<no enum>")) { enumm =>
       implicit val StringType: Type[String] = stringType
@@ -168,6 +184,27 @@ trait ClassesFixturesImpl { this: MacroCommons =>
             s"sequential: ${Expr.splice(sequential)}, parallel: ${Expr.splice(parallel)}"
           }
         }
+        .unsafe
+        .runSync
+        ._2
+        .fold(errors => Expr(s"<failed to construct: ${errors.mkString(", ")}>"), identity)
+    }
+
+  /** Regression for commit 68e1781 (splice isolation): parMatchOn handlers whose results are built from nested
+    * [[Expr.quote]] calls splicing the matched expression must not leak splice ownership across case boundaries.
+    */
+  def testEnumParMatchOnNestedQuote[A: Type](expr: Expr[A], suffix: Expr[String]): Expr[String] =
+    Enum.parse[A].toOption.fold(Expr("<no enum>")) { enumm =>
+      implicit val StringType: Type[String] = stringType
+      val handle: Expr_??<:[A] => MIO[Expr[String]] = matched => {
+        import matched.{Underlying as Subtype, value as matchedExpr}
+        MIO.pure(Expr.quote {
+          Expr.splice(matchedExpr).toString + Expr.splice(suffix)
+        })
+      }
+      enumm
+        .parMatchOn(expr)(handle)
+        .map(_.getOrElse(Expr("<failed to perform exhaustive match>")))
         .unsafe
         .runSync
         ._2
@@ -194,7 +231,7 @@ trait ClassesFixturesImpl { this: MacroCommons =>
         val hasSingleton = singletonExpr.isDefined
         val singletonPrint = singletonExpr.fold("<none>")(_.plainPrint)
         val typePrint = Type.plainPrint[A0]
-        val prettyPrint = Type.prettyPrint[A0]
+        val prettyPrint = removeAnsiColors(Type.prettyPrint[A0])
         s"child=$name: type=$typePrint, pretty=$prettyPrint, isVal=$isVal, isObject=$isObject, " +
           s"isCaseClass=$isCaseClass, isCaseObject=$isCaseObject, isCaseVal=$isCaseVal, " +
           s"hasSingleton=$hasSingleton, singletonPrint=$singletonPrint"

--- a/hearth-tests/src/main/scala/hearth/typed/ClassesFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ClassesFixturesImpl.scala
@@ -334,6 +334,41 @@ trait ClassesFixturesImpl { this: MacroCommons =>
     }
   }
 
+  private val seqIntType: Type[Seq[Int]] = Type.of[Seq[Int]]
+
+  /** Vararg case-class coverage: parses the case class, pins the primary-constructor signature (the vararg parameter
+    * type is normalized to `scala.collection.immutable.Seq[A]`) and the case-field accessor types, then constructs an
+    * instance through the vararg-aware [[Method.ApplyValues]] path and compares it with `expected` at runtime.
+    */
+  def testVarargCaseClassConstruct[A: Type](expected: Expr[A]): Expr[Data] = {
+    implicit val SeqIntType: Type[Seq[Int]] = seqIntType
+    CaseClass.parse[A].toOption.fold(Expr(Data("<no case class>"))) { caseClass =>
+      val signature = caseClass.primaryConstructor.totalParameters.flatten
+        .map { case (name, param) => s"$name: ${param.tpe.plainPrint}${if (param.isVararg) " (vararg)" else ""}" }
+        .mkString("(", ", ", ")")
+      val fields = caseClass.caseFields
+        .map(field => s"${field.name}: ${field.knownReturning.fold("<unknown>")(_.plainPrint)}")
+        .mkString("(", ", ", ")")
+      val makeArgument: Parameter => MIO[Expr_??] = param =>
+        if (param.isVararg) MIO.pure(Expr.quote(Seq(1, 2, 3)).as_??)
+        else MIO.fail(new Exception(s"Expected only a vararg parameter, got ${param.name}: ${param.tpe.plainPrint}"))
+      caseClass.construct(makeArgument).unsafe.runSync._2 match {
+        case Right(Some(constructedExpr)) =>
+          val signatureExpr = Expr(signature)
+          val fieldsExpr = Expr(fields)
+          Expr.quote {
+            Data.map(
+              "primaryConstructor" -> Data(Expr.splice(signatureExpr)),
+              "caseFields" -> Data(Expr.splice(fieldsExpr)),
+              "constructedEqualsExpected" -> Data(Expr.splice(constructedExpr) == Expr.splice(expected))
+            )
+          }
+        case Right(None)  => Expr(Data("<not constructible>"))
+        case Left(errors) => Expr(Data(s"<failed: ${errors.mkString(", ")}>"))
+      }
+    }
+  }
+
   /** Evaluates the singleton expression at runtime and returns its `.toString`.
     */
   def testSingletonRoundTrip[A: Type]: Expr[String] =

--- a/hearth-tests/src/main/scala/hearth/typed/ClassesFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ClassesFixturesImpl.scala
@@ -165,6 +165,22 @@ trait ClassesFixturesImpl { this: MacroCommons =>
     }
   }
 
+  /** Like [[testCaseClassCaseFieldValuesAt]] but passes `Everywhere` visibility explicitly, so non-public fields should
+    * be skipped on both platforms.
+    */
+  def testCaseClassCaseFieldValuesAtEverywhere[A: Type](expr: Expr[A]): Expr[String] = Expr {
+    CaseClass.parse[A].toOption.fold("<no case class>") { caseClass =>
+      caseClass
+        .caseFieldValuesAt(expr, visibility = Everywhere)
+        .toList
+        .sortBy(_._1)
+        .map { case (name, value) =>
+          s"$name: ${value.plainPrint}"
+        }
+        .mkString("(", ", ", ")")
+    }
+  }
+
   def testEnumMatchOnAndParMatchOn[A: Type](expr: Expr[A]): Expr[String] =
     Enum.parse[A].toOption.fold(Expr("<no enum>")) { enumm =>
       implicit val StringType: Type[String] = stringType

--- a/hearth-tests/src/main/scala/hearth/typed/DestructuredExprsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/DestructuredExprsFixturesImpl.scala
@@ -95,6 +95,7 @@ trait DestructuredExprsFixturesImpl { this: MacroCommons =>
       case _: DestructuredExpr.Literal           => "Literal"
       case _: DestructuredExpr.Singleton         => "Singleton"
       case _: DestructuredExpr.Block             => "Block"
+      case _: DestructuredExpr.Varargs           => "Varargs"
       case _: DestructuredExpr.NonDestructurable => "NonDestructurable"
     }
     val extra: List[(String, Data)] = parsed match {
@@ -144,6 +145,12 @@ trait DestructuredExprsFixturesImpl { this: MacroCommons =>
         "nodeType" -> Data("Block"),
         "statements" -> Data(b.statements.map(renderDetailed)),
         "result" -> renderDetailed(b.result)
+      )
+    case va: DestructuredExpr.Varargs =>
+      Data.map(
+        "nodeType" -> Data("Varargs"),
+        "type" -> Data(va.tpe.plainPrint),
+        "elements" -> Data(va.elements.map(renderDetailed))
       )
     case nd: DestructuredExpr.NonDestructurable =>
       Data.map("nodeType" -> Data("NonDestructurable"), "description" -> Data(nd.description))

--- a/hearth-tests/src/main/scala/hearth/typed/ExprCodecFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ExprCodecFixturesImpl.scala
@@ -24,6 +24,10 @@ trait ExprCodecFixturesImpl { this: MacroCommons =>
     Type.of[hearth.examples.expr_codecs.Sentinel.type]
   private val notQuotableTypeEC: Type[hearth.examples.expr_codecs.NotQuotable] =
     Type.of[hearth.examples.expr_codecs.NotQuotable]
+  private val seqIntTypeEC: Type[Seq[Int]] = Type.of[Seq[Int]]
+  private val listIntTypeEC: Type[List[Int]] = Type.of[List[Int]]
+  private val optionIntTypeEC: Type[Option[Int]] = Type.of[Option[Int]]
+  private val mapStringIntTypeEC: Type[Map[String, Int]] = Type.of[Map[String, Int]]
 
   private def renderSemiQuote[A: Type](result: Either[String, Expr[A]]): Data =
     result.fold(error => Data(s"<failed: ${removeAnsiColors(error)}>"), expr => Data(expr.plainPrint))
@@ -110,6 +114,38 @@ trait ExprCodecFixturesImpl { this: MacroCommons =>
     Expr(
       Data.map(
         "notQuotable" -> renderSemiQuote(Expr.semiQuote(new hearth.examples.expr_codecs.NotQuotable(1)))
+      )
+    )
+  }
+
+  // -- Expr.typeOf on exprs produced by built-in parameterized codecs --
+
+  def testBuiltInCodecExprTypes: Expr[Data] = {
+    implicit val intType: Type[Int] = intTypeEC
+    implicit val stringType: Type[String] = stringTypeEC
+
+    // Regression test: on Scala 2, ExprCodec.make used to let c.Expr[A](tree) materialize a WeakTypeTag for the
+    // codec's own free type parameter A, so Expr.typeOf on the produced expr reported `A` instead of the concrete
+    // instantiated type (e.g. Seq[Int]), breaking downstream upcasts.
+    def reportedType[A: ExprCodec](value: A)(implicit expected: Type[A]): Data = {
+      val reported = Expr.typeOf(ExprCodec[A].toExpr(value))
+      if (reported <:< expected) Data("ok")
+      else Data(s"<reported ${reported.plainPrint} which is not a subtype of ${expected.plainPrint}>")
+    }
+
+    val seqOfInt = { implicit val tpe: Type[Seq[Int]] = seqIntTypeEC; reportedType(Seq(1, 2, 3)) }
+    val listOfInt = { implicit val tpe: Type[List[Int]] = listIntTypeEC; reportedType(List(1, 2, 3)) }
+    val optionOfInt = { implicit val tpe: Type[Option[Int]] = optionIntTypeEC; reportedType(Option(42)) }
+    val mapOfStringInt = {
+      implicit val tpe: Type[Map[String, Int]] = mapStringIntTypeEC; reportedType(Map("a" -> 1))
+    }
+
+    Expr(
+      Data.map(
+        "Seq[Int]" -> seqOfInt,
+        "List[Int]" -> listOfInt,
+        "Option[Int]" -> optionOfInt,
+        "Map[String, Int]" -> mapOfStringInt
       )
     )
   }

--- a/hearth-tests/src/main/scala/hearth/typed/ExprCodecFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ExprCodecFixturesImpl.scala
@@ -5,6 +5,117 @@ import hearth.data.Data
 
 trait ExprCodecFixturesImpl { this: MacroCommons =>
 
+  // -- Expr.semiQuote direct tests --
+
+  // Cross-quotes Type.of cannot be assigned directly to a local implicit val (the expansion would self-reference
+  // the implicit being defined on Scala 2), so we follow the same pattern as AnonymousInstanceFixturesImpl.
+  private val intTypeEC: Type[Int] = Type.of[Int]
+  private val stringTypeEC: Type[String] = Type.of[String]
+  private val booleanTypeEC: Type[Boolean] = Type.of[Boolean]
+  private val doubleTypeEC: Type[Double] = Type.of[Double]
+  private val anyTypeEC: Type[Any] = Type.of[Any]
+  private val serverConfigTypeEC: Type[hearth.examples.expr_codecs.ServerConfig] =
+    Type.of[hearth.examples.expr_codecs.ServerConfig]
+  private val appConfigTypeEC: Type[hearth.examples.expr_codecs.AppConfig] =
+    Type.of[hearth.examples.expr_codecs.AppConfig]
+  private val shapeTypeEC: Type[hearth.examples.expr_codecs.Shape] =
+    Type.of[hearth.examples.expr_codecs.Shape]
+  private val sentinelTypeEC: Type[hearth.examples.expr_codecs.Sentinel.type] =
+    Type.of[hearth.examples.expr_codecs.Sentinel.type]
+  private val notQuotableTypeEC: Type[hearth.examples.expr_codecs.NotQuotable] =
+    Type.of[hearth.examples.expr_codecs.NotQuotable]
+
+  private def renderSemiQuote[A: Type](result: Either[String, Expr[A]]): Data =
+    result.fold(error => Data(s"<failed: ${removeAnsiColors(error)}>"), expr => Data(expr.plainPrint))
+
+  def testSemiQuotePrimitives: Expr[Data] = {
+    implicit val intType: Type[Int] = intTypeEC
+    implicit val stringType: Type[String] = stringTypeEC
+    implicit val booleanType: Type[Boolean] = booleanTypeEC
+    implicit val doubleType: Type[Double] = doubleTypeEC
+    Expr(
+      Data.map(
+        "int" -> renderSemiQuote(Expr.semiQuote(42)),
+        "string" -> renderSemiQuote(Expr.semiQuote("quoted")),
+        "boolean" -> renderSemiQuote(Expr.semiQuote(true)),
+        "double" -> renderSemiQuote(Expr.semiQuote(3.14))
+      )
+    )
+  }
+
+  def testSemiQuoteCaseClass: Expr[Data] = {
+    implicit val serverConfigType: Type[hearth.examples.expr_codecs.ServerConfig] = serverConfigTypeEC
+    implicit val appConfigType: Type[hearth.examples.expr_codecs.AppConfig] = appConfigTypeEC
+    Expr(
+      Data.map(
+        "simple" -> renderSemiQuote(
+          Expr.semiQuote(hearth.examples.expr_codecs.ServerConfig("localhost", 8080))
+        ),
+        "nested" -> renderSemiQuote(
+          Expr.semiQuote(
+            hearth.examples.expr_codecs.AppConfig(hearth.examples.expr_codecs.ServerConfig("db.local", 5432), true)
+          )
+        )
+      )
+    )
+  }
+
+  def testSemiQuoteSealedChild: Expr[Data] = {
+    implicit val shapeType: Type[hearth.examples.expr_codecs.Shape] = shapeTypeEC
+    Expr(
+      Data.map(
+        "caseClassChild" -> renderSemiQuote(
+          Expr.semiQuote[hearth.examples.expr_codecs.Shape](hearth.examples.expr_codecs.Shape.Circle(3.14))
+        ),
+        "caseObjectChild" -> renderSemiQuote(
+          Expr.semiQuote[hearth.examples.expr_codecs.Shape](hearth.examples.expr_codecs.Shape.Origin)
+        )
+      )
+    )
+  }
+
+  def testSemiQuoteSingleton: Expr[Data] = {
+    implicit val sentinelType: Type[hearth.examples.expr_codecs.Sentinel.type] = sentinelTypeEC
+    Expr(
+      Data.map(
+        "caseObject" -> renderSemiQuote(Expr.semiQuote(hearth.examples.expr_codecs.Sentinel))
+      )
+    )
+  }
+
+  def testSemiQuoteWithOverride: Expr[Data] = {
+    implicit val stringType: Type[String] = stringTypeEC
+    implicit val serverConfigType: Type[hearth.examples.expr_codecs.ServerConfig] = serverConfigTypeEC
+    val noOverride: Existential[QuoteOverride] = {
+      implicit val anyType: Type[Any] = anyTypeEC
+      Existential[QuoteOverride, Any](QuoteOverride.none[Any])
+    }
+    val overrides: UntypedType => Existential[QuoteOverride] = { tpe =>
+      if (tpe =:= UntypedType.fromTyped[String])
+        Existential[QuoteOverride, String](QuoteOverride[String](value => Right(Expr(value.toUpperCase))))
+      else noOverride
+    }
+    Expr(
+      Data.map(
+        "direct" -> renderSemiQuote(Expr.semiQuote("hello", overrides)),
+        "nested" -> renderSemiQuote(
+          Expr.semiQuote(hearth.examples.expr_codecs.ServerConfig("localhost", 8080), overrides)
+        )
+      )
+    )
+  }
+
+  def testSemiQuoteFailure: Expr[Data] = {
+    implicit val notQuotableType: Type[hearth.examples.expr_codecs.NotQuotable] = notQuotableTypeEC
+    Expr(
+      Data.map(
+        "notQuotable" -> renderSemiQuote(Expr.semiQuote(new hearth.examples.expr_codecs.NotQuotable(1)))
+      )
+    )
+  }
+
+  // -- ExprCodec.derived round-trip --
+
   def testExprCodecRoundTrip[A: Type](expr: Expr[A]): Expr[Data] = {
     val codec: ExprCodec[A] = ExprCodec.derived[A]
     codec.fromExpr(expr) match {

--- a/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
@@ -9,6 +9,8 @@ import hearth.fp.syntax.*
 /** Fixtures for testing [[ExprsSpec]]. */
 trait ExprsFixturesImpl { this: MacroCommons =>
 
+  private val stringTypeEF: Type[String] = Type.of[String]
+
   // Expr methods
 
   def testExprPrinters[A: Type](expr: Expr[A]): Expr[Data] = Expr(
@@ -152,6 +154,26 @@ trait ExprsFixturesImpl { this: MacroCommons =>
                 "matchCase" -> Data(matchedExpr.plainPrint)
               )
             )
+          }
+        })
+      }
+  }
+
+  /** Regression for commit 68e1781 (splice isolation): each case body is built via a nested [[Expr.quote]] that splices
+    * both the matched expression and the inline-macro argument (which on Scala 3 arrives as an `Inlined` tree).
+    * `matchOn` must not let splice ownership of such nested quotes leak across the match-case boundary.
+    */
+  def testMatchOnWithNestedQuote[A: Type](expr: Expr[A], suffix: Expr[String]): Expr[String] = {
+    implicit val StringType: Type[String] = stringTypeEF
+
+    Type[A].exhaustiveChildren
+      .fold(Expr("<no exhaustive children>")) { children =>
+        expr.matchOn(children.toNonEmptyList.map { case (name, child) =>
+          import child.Underlying as Child
+          MatchCase.typeMatch[Child](FreshName.FromType).map { matchedExpr =>
+            Expr.quote {
+              Expr.splice(Expr(name)) + ": " + Expr.splice(matchedExpr).toString + Expr.splice(suffix)
+            }
           }
         })
       }

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -265,6 +265,10 @@ trait MethodsFixturesImpl { this: MacroCommons =>
     Type.of[hearth.examples.methods.ParentAnnotation]
   private val ChildAnnotationType: Type[hearth.examples.methods.ChildAnnotation] =
     Type.of[hearth.examples.methods.ChildAnnotation]
+  private val FieldNameType: Type[hearth.examples.methods.fieldName] =
+    Type.of[hearth.examples.methods.fieldName]
+  private val FieldFlagsType: Type[hearth.examples.methods.fieldFlags] =
+    Type.of[hearth.examples.methods.fieldFlags]
 
   private def applyAndBuild(method: Method, arguments: Arguments): Either[String, Expr_??] =
     method match {
@@ -894,6 +898,45 @@ trait MethodsFixturesImpl { this: MacroCommons =>
           .getOrElse("<no constructor arguments>")
         Expr(Data.map("wholeAnnotation" -> Data(wholeAnnotation), "firstArgument" -> Data(firstArgument)))
       case other => Expr(Data(s"<expected exactly one ExampleAnnotation2, got ${other.size}>"))
+    }
+  }
+
+  /** Reproducer for issue #283: read literal annotation arguments (String/Boolean/Double, not just Int) off a plain
+    * (non-case) annotation class with `val` constructor parameters, attached to case class constructor parameters.
+    *
+    * `fieldNames` uses the exact composition recommended to users (annotationsOfType + decodedConstructorArguments);
+    * `fieldFlags` decodes every argument, exercising Boolean and Double literals.
+    */
+  def testFieldNameReproducer[A: Type]: Expr[Data] = {
+    implicit val fieldNameType: Type[hearth.examples.methods.fieldName] = this.FieldNameType
+    implicit val fieldFlagsType: Type[hearth.examples.methods.fieldFlags] = this.FieldFlagsType
+
+    Type[A].primaryConstructor match {
+      case Some(ctor) =>
+        val params = ctor.totalParameters.flatten.map { case (paramName, param) =>
+          val names = param
+            .annotationsOfType[hearth.examples.methods.fieldName]
+            .flatMap { ann =>
+              Annotations
+                .decodedConstructorArguments(ann)
+                .flatMap(_.headOption.flatMap(_.toOption))
+                .collect { case s: String => s }
+            }
+          val flags = param.annotationsOfType[hearth.examples.methods.fieldFlags].map { ann =>
+            Annotations.decodedConstructorArguments(ann) match {
+              case Some(args) =>
+                Data.list(args.map(_.fold(error => Data(s"<failed: $error>"), value => Data(value.toString)))*)
+              case None => Data("<not a constructor call>")
+            }
+          }
+          Data.map(
+            "name" -> Data(paramName),
+            "fieldNames" -> Data.list(names.map(Data(_))*),
+            "fieldFlags" -> Data.list(flags*)
+          )
+        }
+        Expr(Data.list(params*))
+      case None => Expr(Data("<no primary constructor>"))
     }
   }
 

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -146,7 +146,9 @@ trait MethodsFixturesImpl { this: MacroCommons =>
         method.totalParameters.flatten.map { case (paramName, param) =>
           paramName -> Data.map(
             "isImplicit" -> Data(param.isImplicit),
-            "hasDefault" -> Data(param.hasDefault)
+            "hasDefault" -> Data(param.hasDefault),
+            "isByName" -> Data(param.isByName),
+            "isVararg" -> Data(param.isVararg)
           )
         }
       }
@@ -236,6 +238,8 @@ trait MethodsFixturesImpl { this: MacroCommons =>
   private val IntType: Type[Int] = Type.of[Int]
   private val StringType: Type[String] = Type.of[String]
   private val ProductType: Type[Product] = Type.of[Product]
+  private val SeqIntType: Type[Seq[Int]] = Type.of[Seq[Int]]
+  private val SeqStringType: Type[Seq[String]] = Type.of[Seq[String]]
 
   private def applyAndBuild(method: Method, arguments: Arguments): Either[String, Expr_??] =
     method match {
@@ -557,6 +561,57 @@ trait MethodsFixturesImpl { this: MacroCommons =>
         result.asTyped[Int]
       case _ =>
         Environment.reportErrorAndAbort(s"Method $name is not an instance method")
+    }
+  }
+
+  def testCallVarargIntMethod[A: Type](instance: Expr[A])(methodName: Expr[String])(params: VarArgs[Int]): Expr[Int] = {
+    implicit val SeqIntType: Type[Seq[Int]] = this.SeqIntType
+    val name = Expr
+      .unapply(methodName)
+      .getOrElse(
+        Environment.reportErrorAndAbort(s"Method name must be a string literal, got ${methodName.prettyPrint}")
+      )
+    val method = Type[A].methods.filter(_.name == name) match {
+      case Nil           => Environment.reportErrorAndAbort(s"Method $name not found")
+      case method :: Nil => method
+      case _             => Environment.reportErrorAndAbort(s"Method $name is ambiguous")
+    }
+    val seqExpr: Expr[Seq[Int]] = params.toVector.foldLeft(Expr.quote(Seq.empty[Int])) { (acc, value) =>
+      Expr.quote(Expr.splice(acc) :+ Expr.splice(value))
+    }
+    val result = method.fold(
+      onInstance = _ => instance.as_??,
+      onTypes = _ => Map.empty,
+      onValues = av =>
+        av.parameters.flatten.map { case (pName, param) =>
+          if (param.isVararg) pName -> seqExpr.as_??
+          else Environment.reportErrorAndAbort(s"Expected a vararg parameter, got $pName: ${param.tpe.plainPrint}")
+        }.toMap
+    )
+    result match {
+      case Right(expr) => expr.value.asInstanceOf[Expr[Int]]
+      case Left(error) => Environment.reportErrorAndAbort(s"Failed to call method $name: $error")
+    }
+  }
+
+  def testConstructVarargCtor[A: Type](params: VarArgs[String]): Expr[Data] = {
+    implicit val SeqStringType: Type[Seq[String]] = this.SeqStringType
+    Type[A].primaryConstructor match {
+      case Some(ctor) =>
+        val seqExpr: Expr[Seq[String]] = params.toVector.foldLeft(Expr.quote(Seq.empty[String])) { (acc, value) =>
+          Expr.quote(Expr.splice(acc) :+ Expr.splice(value))
+        }
+        val arguments: Arguments = ctor.totalParameters.flatten.map { case (pName, param) =>
+          if (param.isVararg) pName -> seqExpr.as_??
+          else Environment.reportErrorAndAbort(s"Expected a vararg parameter, got $pName: ${param.tpe.plainPrint}")
+        }.toMap
+        applyAndBuild(ctor, arguments) match {
+          case Right(result) =>
+            import result.Underlying as R
+            Expr.quote(Data(Expr.splice(result.value.asInstanceOf[Expr[R]]).toString))
+          case Left(error) => Expr(Data(s"FAILED: $error"))
+        }
+      case None => Expr(Data("<no primary constructor>"))
     }
   }
 

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -897,6 +897,47 @@ trait MethodsFixturesImpl { this: MacroCommons =>
     }
   }
 
+  /** Splices annotation exprs into the macro OUTPUT (not just reading them at macro time): the generated code calls
+    * `.value` on the spliced annotation instance at runtime. On Scala 3, annotation trees carry no source spans, so
+    * this verifies that Hearth makes them spliceable (would otherwise fail `-Xcheck-macros` with "position not set").
+    */
+  def testSplicedAnnotationValue[A: Type](methodName: Expr[String]): Expr[Data] = {
+    implicit val exampleAnnotation2Type: Type[hearth.examples.methods.ExampleAnnotation2] = this.ExampleAnnotation2Type
+
+    def spliceFirst(annotations: List[Expr[hearth.examples.methods.ExampleAnnotation2]]): Expr[Int] =
+      annotations match {
+        case ann :: _ => Expr.quote(Expr.splice(ann).value)
+        case Nil      => Expr(-1)
+      }
+
+    val typeValue = spliceFirst(Type[A].annotationsOfType[hearth.examples.methods.ExampleAnnotation2])
+
+    val methodValue = Expr.unapply(methodName).filter(_.nonEmpty) match {
+      case Some(name) =>
+        Type[A].methods.filter(_.name == name) match {
+          case method :: Nil => spliceFirst(method.annotationsOfType[hearth.examples.methods.ExampleAnnotation2])
+          case _             => Expr(-2)
+        }
+      case None => Expr(-1)
+    }
+
+    val parameterValue = Type[A].primaryConstructor match {
+      case Some(constructor) =>
+        spliceFirst(constructor.totalParameters.flatten.toList.flatMap { case (_, param) =>
+          param.annotationsOfType[hearth.examples.methods.ExampleAnnotation2]
+        })
+      case None => Expr(-1)
+    }
+
+    Expr.quote {
+      Data.map(
+        "typeValue" -> Data(Expr.splice(typeValue)),
+        "methodValue" -> Data(Expr.splice(methodValue)),
+        "parameterValue" -> Data(Expr.splice(parameterValue))
+      )
+    }
+  }
+
   def testDefaultValueOnGenericMethod[A: Type](
       instance: Expr[A],
       methodName: Expr[String]

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -240,6 +240,14 @@ trait MethodsFixturesImpl { this: MacroCommons =>
   private val ProductType: Type[Product] = Type.of[Product]
   private val SeqIntType: Type[Seq[Int]] = Type.of[Seq[Int]]
   private val SeqStringType: Type[Seq[String]] = Type.of[Seq[String]]
+  private val ExampleAnnotationType: Type[hearth.examples.methods.ExampleAnnotation] =
+    Type.of[hearth.examples.methods.ExampleAnnotation]
+  private val ExampleAnnotation2Type: Type[hearth.examples.methods.ExampleAnnotation2] =
+    Type.of[hearth.examples.methods.ExampleAnnotation2]
+  private val ParentAnnotationType: Type[hearth.examples.methods.ParentAnnotation] =
+    Type.of[hearth.examples.methods.ParentAnnotation]
+  private val ChildAnnotationType: Type[hearth.examples.methods.ChildAnnotation] =
+    Type.of[hearth.examples.methods.ChildAnnotation]
 
   private def applyAndBuild(method: Method, arguments: Arguments): Either[String, Expr_??] =
     method match {
@@ -615,20 +623,11 @@ trait MethodsFixturesImpl { this: MacroCommons =>
     }
   }
 
-  private def destructureAnnotationValues(ann: Expr_??): String = {
-    val destructured = DestructuredExpr.parseUntyped(ann.value.asUntyped)
-    destructured match {
-      case mc: DestructuredExpr.MethodCall =>
-        mc.applied
-          .flatMap {
-            case av: DestructuredExpr.MethodCall.AppliedValues =>
-              av.args.map(_.plainPrint)
-            case _ => Nil
-          }
-          .mkString(", ")
-      case _ => "<not a method call>"
+  private def destructureAnnotationValues(ann: Expr_??): String =
+    Annotations.constructorArguments(ann) match {
+      case Some(args) => args.map(_.plainPrint).mkString(", ")
+      case None       => "<not a method call>"
     }
-  }
 
   def testAnnotationDestructuring[A: Type]: Expr[Data] = {
     val typeAnnotations = Type.annotations[A].flatMap { ann =>
@@ -710,6 +709,98 @@ trait MethodsFixturesImpl { this: MacroCommons =>
       case Some(constructor) => Expr(renderParameterAnnotations(constructor.totalParameters))
       case None              => Expr(Data("<no primary constructor>"))
     }
+
+  def testAnnotationsOfType[A: Type](methodName: Expr[String]): Expr[Data] = {
+    implicit val exampleAnnotationType: Type[hearth.examples.methods.ExampleAnnotation] = this.ExampleAnnotationType
+    implicit val exampleAnnotation2Type: Type[hearth.examples.methods.ExampleAnnotation2] = this.ExampleAnnotation2Type
+    implicit val parentAnnotationType: Type[hearth.examples.methods.ParentAnnotation] = this.ParentAnnotationType
+    implicit val childAnnotationType: Type[hearth.examples.methods.ChildAnnotation] = this.ChildAnnotationType
+
+    def decodeArgs(ann: Expr_??): Data =
+      Annotations.constructorArguments(ann) match {
+        case Some(args) =>
+          Data.list(args.map { arg =>
+            arg.value.semiEval.fold(errors => Data(s"<failed: ${errors.head}>"), value => Data(value.toString))
+          }*)
+        case None => Data("<not a constructor call>")
+      }
+
+    val typeSection = Data.map(
+      "hasExampleAnnotation" -> Data(Type[A].hasAnnotationOfType[hearth.examples.methods.ExampleAnnotation]),
+      "hasExampleAnnotation2" -> Data(Type[A].hasAnnotationOfType[hearth.examples.methods.ExampleAnnotation2]),
+      "exampleAnnotation2Args" -> Data.list(
+        Type[A].annotationsOfType[hearth.examples.methods.ExampleAnnotation2].map(ann => decodeArgs(ann.as_??))*
+      ),
+      "parentAnnotations" -> Data(Type[A].annotationsOfType[hearth.examples.methods.ParentAnnotation].size),
+      "childAnnotations" -> Data(Type[A].annotationsOfType[hearth.examples.methods.ChildAnnotation].size)
+    )
+
+    def describeParameter(paramName: String, param: Parameter): Data = Data.map(
+      "name" -> Data(paramName),
+      "hasExampleAnnotation" -> Data(param.hasAnnotationOfType[hearth.examples.methods.ExampleAnnotation]),
+      "exampleAnnotation2Args" -> Data.list(
+        param.annotationsOfType[hearth.examples.methods.ExampleAnnotation2].map(ann => decodeArgs(ann.as_??))*
+      ),
+      "parentAnnotations" -> Data(param.annotationsOfType[hearth.examples.methods.ParentAnnotation].size),
+      "childAnnotations" -> Data(param.annotationsOfType[hearth.examples.methods.ChildAnnotation].size)
+    )
+
+    val methodSection = Expr.unapply(methodName).filter(_.nonEmpty) match {
+      case None       => Data("<no method requested>")
+      case Some(name) =>
+        Type[A].methods.filter(_.name == name) match {
+          case method :: Nil =>
+            Data.map(
+              "hasExampleAnnotation" -> Data(method.hasAnnotationOfType[hearth.examples.methods.ExampleAnnotation]),
+              "hasExampleAnnotation2" -> Data(method.hasAnnotationOfType[hearth.examples.methods.ExampleAnnotation2]),
+              "exampleAnnotation2Args" -> Data.list(
+                method.annotationsOfType[hearth.examples.methods.ExampleAnnotation2].map(ann => decodeArgs(ann.as_??))*
+              ),
+              "parentAnnotations" -> Data(method.annotationsOfType[hearth.examples.methods.ParentAnnotation].size),
+              "childAnnotations" -> Data(method.annotationsOfType[hearth.examples.methods.ChildAnnotation].size),
+              "parameters" -> Data.list(method.totalParameters.flatten.map { case (paramName, param) =>
+                describeParameter(paramName, param)
+              }*)
+            )
+          case Nil => Data("<method not found>")
+          case _   => Data("<method ambiguous>")
+        }
+    }
+
+    val constructorSection = Type[A].primaryConstructor match {
+      case Some(constructor) =>
+        Data.list(constructor.totalParameters.flatten.map { case (paramName, param) =>
+          describeParameter(paramName, param)
+        }*)
+      case None => Data("<no primary constructor>")
+    }
+
+    Expr(
+      Data.map(
+        "type" -> typeSection,
+        "method" -> methodSection,
+        "constructor" -> constructorSection
+      )
+    )
+  }
+
+  def testAnnotationValueDecoded[A: Type]: Expr[Data] = {
+    implicit val exampleAnnotation2Type: Type[hearth.examples.methods.ExampleAnnotation2] = this.ExampleAnnotation2Type
+    Type[A].annotationsOfType[hearth.examples.methods.ExampleAnnotation2] match {
+      case ann :: Nil =>
+        // `ann` is a properly typed `Expr[ExampleAnnotation2]`, so it can be evaluated as a whole at macro time...
+        val wholeAnnotation =
+          ann.semiEval.fold(errors => s"<failed: ${errors.head}>", instance => instance.value.toString)
+        // ... and its constructor arguments can be extracted and decoded one by one.
+        val firstArgument = Annotations
+          .constructorArguments(ann)
+          .flatMap(_.headOption)
+          .map(arg => arg.value.semiEval.fold(errors => s"<failed: ${errors.head}>", value => value.toString))
+          .getOrElse("<no constructor arguments>")
+        Expr(Data.map("wholeAnnotation" -> Data(wholeAnnotation), "firstArgument" -> Data(firstArgument)))
+      case other => Expr(Data(s"<expected exactly one ExampleAnnotation2, got ${other.size}>"))
+    }
+  }
 
   def testDefaultValueOnGenericMethod[A: Type](
       instance: Expr[A],

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -412,6 +412,84 @@ trait MethodsFixturesImpl { this: MacroCommons =>
     }
   }
 
+  def testCallInstanceViaFoldF[A: Type](instance: Expr[A])(methodName: Expr[String])(
+      params: VarArgs[Int]
+  ): Expr[Data] = {
+    implicit val IntType: Type[Int] = this.IntType
+    implicit val StringType: Type[String] = this.StringType
+    val name = Expr
+      .unapply(methodName)
+      .getOrElse(
+        Environment.reportErrorAndAbort(s"Method name must be a string literal, got ${methodName.prettyPrint}")
+      )
+    val method = Type[A].methods.filter(_.name == name) match {
+      case Nil           => Environment.reportErrorAndAbort(s"Method $name not found")
+      case method :: Nil => method
+      case _             => Environment.reportErrorAndAbort(s"Method $name is ambiguous")
+    }
+    val providedParams = params.toVector
+    var paramIdx = 0
+    val result: Option[Either[String, Expr_??]] = method.foldF[Option](
+      onInstance = _ => Some(instance.as_??),
+      onTypes = _ => Some(Map.empty),
+      onValues = av => {
+        val resolved = av.parameters.flatten.foldLeft[Option[List[(String, Expr_??)]]](Some(List.empty)) {
+          case (None, _)                   => None
+          case (Some(acc), (pName, param)) =>
+            import param.tpe.Underlying
+            if (param.hasDefault && paramIdx >= providedParams.size) {
+              paramIdx += 1
+              Some(acc)
+            } else if (Underlying <:< Type.of[Int] && paramIdx < providedParams.size) {
+              val v = providedParams(paramIdx)
+              paramIdx += 1
+              Some(acc :+ (pName -> v.as_??))
+            } else if (Underlying <:< Type.of[String]) {
+              paramIdx += 1
+              Some(acc :+ (pName -> Expr("test").as_??))
+            } else {
+              None // unsupported parameter type or not enough arguments - short-circuit the whole foldF
+            }
+        }
+        resolved.map(_.toMap)
+      }
+    )
+    result match {
+      case Some(Right(expr)) =>
+        import expr.Underlying as R
+        Expr.quote(Data(Expr.splice(expr.value.asInstanceOf[Expr[R]]).toString))
+      case Some(Left(error)) => Expr(Data(s"FAILED: $error"))
+      case None              => Expr(Data("<not applicable>"))
+    }
+  }
+
+  def testCallInstanceViaFoldMissingArgs[A: Type](instance: Expr[A])(methodName: Expr[String]): Expr[Data] = {
+    val name = Expr
+      .unapply(methodName)
+      .getOrElse(
+        Environment.reportErrorAndAbort(s"Method name must be a string literal, got ${methodName.prettyPrint}")
+      )
+    val method = Type[A].methods.filter(_.name == name) match {
+      case Nil           => Environment.reportErrorAndAbort(s"Method $name not found")
+      case method :: Nil => method
+      case _             => Environment.reportErrorAndAbort(s"Method $name is ambiguous")
+    }
+    val result =
+      try
+        method.fold(
+          onInstance = _ => instance.as_??,
+          onTypes = _ => Map.empty,
+          onValues = _ => Map.empty // wrong application: no arguments provided at all
+        ) match {
+          case Right(_)    => "UNEXPECTED SUCCESS"
+          case Left(error) => s"LEFT: $error"
+        }
+      catch {
+        case e: HearthRequirementError => s"REQUIREMENT FAILED: ${removeAnsiColors(e.description)}"
+      }
+    Expr(Data(result))
+  }
+
   private def buildPartialArguments(parameters: Parameters, providedParams: Vector[Expr[Int]]): Arguments = {
     implicit val IntType: Type[Int] = this.IntType
     parameters.flatten.zipWithIndex.flatMap { case ((name, param), index) =>

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -615,6 +615,47 @@ trait MethodsFixturesImpl { this: MacroCommons =>
     Expr(Data.list((typeAnnotations ++ methodAnnotations)*))
   }
 
+  private def renderParameterAnnotations(parameters: Parameters): Data = {
+    val rendered = parameters.flatten.map { case (paramName, param) =>
+      val annotations = param.annotations.flatMap { ann =>
+        import ann.Underlying as AnnType
+        val isExampleAnnotation = ann.Underlying =:= Type.of[hearth.examples.methods.ExampleAnnotation]
+        val isExampleAnnotation2 = ann.Underlying =:= Type.of[hearth.examples.methods.ExampleAnnotation2]
+        if (!isExampleAnnotation && !isExampleAnnotation2) None
+        else
+          Some(
+            Data.map(
+              "isExampleAnnotation" -> Data(isExampleAnnotation),
+              "isExampleAnnotation2" -> Data(isExampleAnnotation2),
+              "destructuredArgs" -> Data(destructureAnnotationValues(ann))
+            )
+          )
+      }
+      Data.map(
+        "name" -> Data(paramName),
+        "annotations" -> Data.list(annotations*)
+      )
+    }
+    Data.list(rendered*)
+  }
+
+  def testParameterAnnotations[A: Type](methodName: Expr[String]): Expr[Data] = methodName match {
+    case Expr(name) =>
+      Type[A].methods.filter(_.name == name) match {
+        case method :: Nil => Expr(renderParameterAnnotations(method.totalParameters))
+        case Nil           => Environment.reportErrorAndAbort(s"Method $name not found")
+        case _             => Environment.reportErrorAndAbort(s"Method $name is not unique")
+      }
+    case _ =>
+      Environment.reportErrorAndAbort(s"Method name must be a string literal, got ${methodName.prettyPrint}")
+  }
+
+  def testConstructorParameterAnnotations[A: Type]: Expr[Data] =
+    Type[A].primaryConstructor match {
+      case Some(constructor) => Expr(renderParameterAnnotations(constructor.totalParameters))
+      case None              => Expr(Data("<no primary constructor>"))
+    }
+
   def testDefaultValueOnGenericMethod[A: Type](
       instance: Expr[A],
       methodName: Expr[String]

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -157,6 +157,23 @@ trait MethodsFixturesImpl { this: MacroCommons =>
       Environment.reportErrorAndAbort(s"Method name must be a string literal, got ${methodName.prettyPrint}")
   }
 
+  /** Reports only availability of the matching methods — usable for types from precompiled libraries, where pinning
+    * positions or full signatures would not be stable.
+    */
+  def testMethodVisibility[A: Type](methodName: Expr[String]): Expr[Data] = methodName match {
+    case Expr(name) =>
+      val methods = Type[A].methods.filter(_.name == name)
+      val rendered = methods.map { method =>
+        method.name -> Data.map(
+          "isAvailable(Everywhere)" -> Data(method.isAvailable(Everywhere)),
+          "isAvailable(AtCallSite)" -> Data(method.isAvailable(AtCallSite))
+        )
+      }
+      Expr(Data(rendered.toMap))
+    case _ =>
+      Environment.reportErrorAndAbort(s"Method name must be a string literal, got ${methodName.prettyPrint}")
+  }
+
   def testMethodOrdering[A: Type]: Expr[Data] = {
     val methods = Type[A].methods
     val names = methods.map(_.name)

--- a/hearth-tests/src/main/scala/hearth/typed/TypesFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/TypesFixturesImpl.scala
@@ -4,7 +4,7 @@ package typed
 import hearth.data.Data
 
 /** Fixtures for testing [[TypesSpec]] and [[TypesJvmSpec]]. */
-trait TypesFixturesImpl { this: MacroTypedCommons =>
+trait TypesFixturesImpl { this: MacroCommons =>
 
   // Type methods
 
@@ -630,10 +630,136 @@ trait TypesFixturesImpl { this: MacroTypedCommons =>
     )
   }
 
+  // Type constructor discovery (issue #284):
+  // Type.{typeArguments, decompose1, decompose2}, Ctor.sameTypeConstructorAs, CtorK1 + summoning
+
+  def testTypeArguments[A: Type]: Expr[Data] = Expr(
+    Data.map(
+      "Type.typeArguments" -> Data.list(Type.typeArguments[A].map(arg => Data(arg.plainPrint))*)
+    )
+  )
+
+  def testDecompose1[A: Type]: Expr[Data] = {
+    val listCtor = Type.Ctor1.of[List]
+    val optionCtor = Type.Ctor1.of[Option]
+    Type.decompose1[A] match {
+      case Some((ctor, arg)) =>
+        implicit val StringType: Type[String] = stringType
+        Expr(
+          Data.map(
+            "decomposed" -> Data(true),
+            "arg" -> Data(arg.plainPrint),
+            "reappliedToString" -> Data(ctor.apply[String].plainPrint),
+            "sameCtorAsList" -> Data(ctor.sameTypeConstructorAs(listCtor.asUntyped)),
+            "sameCtorAsOption" -> Data(ctor.sameTypeConstructorAs(optionCtor.asUntyped)),
+            "sameCtorAsSelf" -> Data(ctor.sameTypeConstructorAs(UntypedType.fromTyped[A]))
+          )
+        )
+      case None => Expr(Data.map("decomposed" -> Data(false)))
+    }
+  }
+
+  def testDecompose2[A: Type]: Expr[Data] = {
+    val mapCtor = Type.Ctor2.of[Map]
+    val eitherCtor = Type.Ctor2.of[Either]
+    Type.decompose2[A] match {
+      case Some((ctor, (arg1, arg2))) =>
+        implicit val StringType: Type[String] = stringType
+        implicit val IntType: Type[Int] = intType
+        Expr(
+          Data.map(
+            "decomposed" -> Data(true),
+            "arg1" -> Data(arg1.plainPrint),
+            "arg2" -> Data(arg2.plainPrint),
+            "reappliedToStringInt" -> Data(ctor.apply[String, Int].plainPrint),
+            "sameCtorAsMap" -> Data(ctor.sameTypeConstructorAs(mapCtor.asUntyped)),
+            "sameCtorAsEither" -> Data(ctor.sameTypeConstructorAs(eitherCtor.asUntyped))
+          )
+        )
+      case None => Expr(Data.map("decomposed" -> Data(false)))
+    }
+  }
+
+  /** Mini-Functor-derivation flow: for each field `g: G[X]` of a case class, discovers `G` and `X` via
+    * `Type.decompose1`, compares `G` against literal constructors, re-applies `G` to another type, and summons
+    * `MyTC[G]` for the discovered `G` (via `Type.CtorK1`).
+    */
+  def testMiniFunctorDerivation[A: Type]: Expr[Data] = {
+    import hearth.examples.kinds.MyTC
+    implicit val StringType: Type[String] = stringType
+    val listCtor = Type.Ctor1.of[List]
+    val optionCtor = Type.Ctor1.of[Option]
+    val myTCCtor = Type.CtorK1.of[MyTC]
+    CaseClass.parse[A].toOption.fold(Expr(Data.map("error" -> Data("not a case class")))) { caseClass =>
+      val fields = caseClass.primaryConstructor.parameters.flatten.toList.map { case (name, param) =>
+        import param.tpe.Underlying as FieldType
+        val fieldData = Type.decompose1[FieldType] match {
+          case Some((gCtor, arg)) =>
+            implicit val MyTCofG: Type[MyTC[AnyK1]] = myTCCtor.apply(using gCtor)
+            Data.map(
+              "arg" -> Data(arg.plainPrint),
+              "reappliedToString" -> Data(gCtor.apply[String].plainPrint),
+              "isList" -> Data(gCtor.sameTypeConstructorAs(listCtor.asUntyped)),
+              "isOption" -> Data(gCtor.sameTypeConstructorAs(optionCtor.asUntyped)),
+              "myTCInstanceFound" -> Data(Expr.summonImplicit[MyTC[AnyK1]].isDefined)
+            )
+          case None => Data("not an applied type")
+        }
+        name -> fieldData
+      }
+      Expr(Data.map(fields*))
+    }
+  }
+
+  /** Summons `MyTC[G]` for `G` discovered via `Type.decompose1` and splices the instance's `name` into the result, so
+    * the test asserts that the RIGHT instance was found (not just that something was found).
+    */
+  def testDecomposeSummonName[A: Type]: Expr[String] = {
+    import hearth.examples.kinds.{HasName, MyTC}
+    val myTCCtor = Type.CtorK1.of[MyTC]
+    Type.decompose1[A] match {
+      case Some((gCtor, _)) =>
+        implicit val MyTCofG: Type[MyTC[AnyK1]] = myTCCtor.apply(using gCtor)
+        Expr.summonImplicit[MyTC[AnyK1]].toOption match {
+          case Some(instance) =>
+            implicit val HasNameType: Type[HasName] = hasNameType
+            val upcasted = Expr.upcast[MyTC[AnyK1], HasName](instance)
+            Expr.quote(Expr.splice(upcasted).name)
+          case None => Expr("<no instance found>")
+        }
+      case None => Expr("<not an applied type>")
+    }
+  }
+
+  /** Builds `Type[Alg[G]]` where BOTH `Alg` (kind `(* -> *) -> *`) and `G` (kind `* -> *`) are discovered during
+    * expansion: `Alg` via `UntypedType.typeConstructor` + `Type.CtorK1.fromUntyped`, `G` via `Type.decompose1`.
+    */
+  def testCtorK1FromDiscoveredParts[A: Type]: Expr[Data] = {
+    import hearth.examples.kinds.HigherKinded1
+    val optionCtor = Type.Ctor1.of[Option]
+    val appliedHK1: Type[HigherKinded1[Option]] = Type.CtorK1.of[HigherKinded1].apply[Option](using optionCtor)
+    val algUntyped = UntypedType.typeConstructor(UntypedType.fromTyped(using appliedHK1))
+    val alg = Type.CtorK1.fromUntyped[HigherKinded1](algUntyped)
+    Type.decompose1[A] match {
+      case Some((gCtor, _)) =>
+        val algOfG = alg.apply(using gCtor)
+        Expr(
+          Data.map(
+            "appliedSameCtorAsAlg" -> Data(alg.sameTypeConstructorAs(UntypedType.fromTyped(using algOfG))),
+            "memberCtorMatches" -> Data(
+              alg.unapply(algOfG).fold(false)(g => UntypedType.sameTypeConstructorAs(g, gCtor.asUntyped))
+            )
+          )
+        )
+      case None => Expr(Data.map("error" -> Data("not an applied type")))
+    }
+  }
+
   // types using in fixtures
 
   private val aStringType = Type.of["a"]
   private val bStringType = Type.of["b"]
   private val intType = Type.of[Int]
   private val stringType = Type.of[String]
+  private val hasNameType = Type.of[hearth.examples.kinds.HasName]
 }

--- a/hearth-tests/src/main/scala/hearth/typed/TypesFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/TypesFixturesImpl.scala
@@ -96,6 +96,15 @@ trait TypesFixturesImpl { this: MacroTypedCommons =>
     )
   )
 
+  def testOpaqueUnderlyingType[A: Type]: Expr[Data] = Expr(
+    Data.map(
+      "Type.isOpaqueType" -> Data(Type[A].isOpaqueType),
+      "Type.opaqueUnderlyingType" -> Type[A].opaqueUnderlyingType
+        .map(underlying => Data(underlying.plainPrint))
+        .getOrElse(Data("<no underlying type>"))
+    )
+  )
+
   def testUnionMembers[A: Type]: Expr[Data] = Expr(
     Data.map(
       "Type.isUnionType" -> Data(Type[A].isUnionType),

--- a/hearth-tests/src/test/scala-2/hearth/treeprinter/ShowCodePrettyScala2Spec.scala
+++ b/hearth-tests/src/test/scala-2/hearth/treeprinter/ShowCodePrettyScala2Spec.scala
@@ -1743,6 +1743,31 @@ final class ShowCodePrettyScala2Spec extends MacroSuite {
                    |}] with hearth.treeprinter.ShowCodePrettyScala2Spec.Outer#Inner""".stripMargin
   }
 
+  // Regression for commit 481f734: Scala 2.13 uses LiteralType for explicit literal type annotations
+  // (distinct from FoldableConstantType, used for constant folding) — showCodePretty must render
+  // literal types used as type arguments (as in Witness-based refined predicates like Greater[5]).
+  test("showCodePretty should render literal types (LiteralType) on Scala 2") {
+
+    ShowCodePrettyFixtures.testTypePlainPrint[(5, "[a-z]+", 3.14f)] <==>
+      """scala.Tuple3[5, "[a-z]+", 3.14f]"""
+
+    @scala.annotation.nowarn
+    val printed = ShowCodePrettyFixtures.testExprPlainPrint {
+      val five: 5 = 5
+      val word: "[a-z]+" = "[a-z]+"
+      val pi: 3.14f = 3.14f
+      (five, word, pi)
+    }
+
+    printed <==>
+      """{
+        |  val five: 5.type = 5;
+        |  val word: "[a-z]+".type = "[a-z]+";
+        |  val pi: 3.14f.type = 3.14f;
+        |  scala.Tuple3.apply[scala.Int, java.lang.String, scala.Float](five, word, pi)
+        |}""".stripMargin
+  }
+
   test("showCodePretty(..., SyntaxHighlight.plain) should handle kind-projector placeholder syntax on Scala 2") {
 
     @scala.annotation.nowarn

--- a/hearth-tests/src/test/scala-3/hearth/typed/ClassesScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/ClassesScala3Spec.scala
@@ -135,6 +135,27 @@ final class ClassesScala3Spec extends MacroSuite {
     }
 
     test(
+      "Enum[A].{matchOn and parMatchOn} should match on the union with an opaque member with disjoint underlying class (OpaqueId | String)"
+    ) {
+      import ClassesFixtures.testEnumMatchOnAndParMatchOn
+
+      def code(input: examples.unions.OpaqueIdOrString) = testEnumMatchOnAndParMatchOn(input)
+      code(examples.unions.OpaqueId(42L)) <==>
+        "sequential: subtype name: hearth.examples.unions.OpaqueId, expr: hearth.examples.unions.OpaqueId, parallel: subtype name: hearth.examples.unions.OpaqueId, expr: hearth.examples.unions.OpaqueId"
+      code("hello") <==>
+        "sequential: subtype name: java.lang.String, expr: java.lang.String, parallel: subtype name: java.lang.String, expr: java.lang.String"
+    }
+
+    test(
+      "Enum[A].{matchOn and parMatchOn} should return <no enum> for union of an opaque member and its underlying type (OpaqueId | Long)"
+    ) {
+      import ClassesFixtures.testEnumMatchOnAndParMatchOn
+
+      def code(input: examples.unions.OpaqueIdOrLong) = testEnumMatchOnAndParMatchOn(input)
+      code(42L) <==> "<no enum>"
+    }
+
+    test(
       "Enum[A].{matchOn and parMatchOn} should return <no enum> for non-disjoint union type (List[Int] | List[String])"
     ) {
       import ClassesFixtures.testEnumMatchOnAndParMatchOn

--- a/hearth-tests/src/test/scala-3/hearth/typed/ClassesScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/ClassesScala3Spec.scala
@@ -224,5 +224,78 @@ final class ClassesScala3Spec extends MacroSuite {
       testEnumParseDiagnostic[examples.unions.ListIntOrListString] <==>
         "parsed with children: scala.collection.immutable.List[scala.Int], scala.collection.immutable.List[java.lang.String]"
     }
+
+    // Regression for the union-member disjointness check (research-hardening-0.4): the member types of these
+    // unions are defined IN THIS COMPILATION UNIT, so no classfile exists at macro-expansion time. A runtime
+    // `Class.forName`-style disjointness check fails (returns None → ByTypeTest → union refused), but a
+    // compiler-symbol-level check correctly accepts/refuses them. See ClassesScala3Spec.LocalUnions.
+    test(
+      "Enum[A].{matchOn and parMatchOn} should match on a disjoint union of types from the SAME compilation run (regression)"
+    ) {
+      import ClassesFixtures.testEnumMatchOnAndParMatchOn
+      import ClassesScala3Spec.LocalUnions.*
+
+      def code(input: LocalParrot | LocalHamster) = testEnumMatchOnAndParMatchOn(input)
+      code(LocalParrot("Polly", 7)) <==>
+        "sequential: subtype name: hearth.typed.ClassesScala3Spec.LocalUnions.LocalParrot, expr: hearth.typed.ClassesScala3Spec.LocalUnions.LocalParrot, parallel: subtype name: hearth.typed.ClassesScala3Spec.LocalUnions.LocalParrot, expr: hearth.typed.ClassesScala3Spec.LocalUnions.LocalParrot"
+      code(LocalHamster("Hammy", 4.5)) <==>
+        "sequential: subtype name: hearth.typed.ClassesScala3Spec.LocalUnions.LocalHamster, expr: hearth.typed.ClassesScala3Spec.LocalUnions.LocalHamster, parallel: subtype name: hearth.typed.ClassesScala3Spec.LocalUnions.LocalHamster, expr: hearth.typed.ClassesScala3Spec.LocalUnions.LocalHamster"
+    }
+
+    test(
+      "Type.directChildren should accept a disjoint union of types from the SAME compilation run (regression)"
+    ) {
+      import TypesFixtures.testUnionMembers
+      import ClassesScala3Spec.LocalUnions.*
+
+      testUnionMembers[LocalParrot | LocalHamster] <==> Data.map(
+        "Type.isUnionType" -> Data(true),
+        "Type.directChildren" -> Data.map(
+          "hearth.typed.ClassesScala3Spec.LocalUnions.LocalParrot" -> Data(
+            "hearth.typed.ClassesScala3Spec.LocalUnions.LocalParrot"
+          ),
+          "hearth.typed.ClassesScala3Spec.LocalUnions.LocalHamster" -> Data(
+            "hearth.typed.ClassesScala3Spec.LocalUnions.LocalHamster"
+          )
+        ),
+        "Type.exhaustiveChildren" -> Data.map(
+          "hearth.typed.ClassesScala3Spec.LocalUnions.LocalParrot" -> Data(
+            "hearth.typed.ClassesScala3Spec.LocalUnions.LocalParrot"
+          ),
+          "hearth.typed.ClassesScala3Spec.LocalUnions.LocalHamster" -> Data(
+            "hearth.typed.ClassesScala3Spec.LocalUnions.LocalHamster"
+          )
+        )
+      )
+    }
+
+    test(
+      "Type.directChildren should still REFUSE a related-class union of SAME-compilation-run types (LocalBox[Int] | LocalBoxSub[String]) (regression)"
+    ) {
+      import TypesFixtures.testUnionMembers
+      import ClassesScala3Spec.LocalUnions.*
+
+      // LocalBoxSub <: LocalBox at the class level (but the MEMBERS themselves have no subtype relation, since
+      // LocalBox[Int] is not <:< LocalBoxSub[String]), so symbol-level relatedness must still refuse this union.
+      testUnionMembers[LocalBox[Int] | LocalBoxSub[String]] <==> Data.map(
+        "Type.isUnionType" -> Data(true),
+        "Type.directChildren" -> Data("<no direct children>"),
+        "Type.exhaustiveChildren" -> Data("<no exhaustive children>")
+      )
+    }
+  }
+}
+
+object ClassesScala3Spec {
+
+  /** Union member types defined in the SAME compilation unit as the spec that expands the macro - exercising the
+    * compiler-symbol-level disjointness check (no classfile exists at macro-expansion time).
+    */
+  object LocalUnions {
+    case class LocalParrot(name: String, vocabulary: Int)
+    case class LocalHamster(name: String, wheelSize: Double)
+
+    class LocalBox[A](val value: A)
+    class LocalBoxSub[A](value: A) extends LocalBox[A](value)
   }
 }

--- a/hearth-tests/src/test/scala-3/hearth/typed/ClassesScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/ClassesScala3Spec.scala
@@ -172,5 +172,57 @@ final class ClassesScala3Spec extends MacroSuite {
       def code(input: examples.unions.ListIntOrSeqString) = testEnumMatchOnAndParMatchOn(input)
       code(List("a")) <==> "<no enum>"
     }
+
+    test(
+      "Enum[A].{matchOn and parMatchOn} should match on the same-erasure union (List[Int] | List[String]) when TypeTests are provided at the call site"
+    ) {
+      import ClassesFixtures.testEnumMatchOnAndParMatchOn
+      import examples.unions.typetests.given
+
+      def code(input: examples.unions.ListIntOrListString) = testEnumMatchOnAndParMatchOn(input)
+      code(List(1, 2, 3)) <==>
+        "sequential: subtype name: scala.collection.immutable.List[scala.Int], expr: scala.collection.immutable.List[scala.Int], parallel: subtype name: scala.collection.immutable.List[scala.Int], expr: scala.collection.immutable.List[scala.Int]"
+      code(List("a", "b")) <==>
+        "sequential: subtype name: scala.collection.immutable.List[java.lang.String], expr: scala.collection.immutable.List[java.lang.String], parallel: subtype name: scala.collection.immutable.List[java.lang.String], expr: scala.collection.immutable.List[java.lang.String]"
+      // Empty lists are runtime-ambiguous; the TypeTest givens deterministically claim them for List[Int]
+      code(Nil) <==>
+        "sequential: subtype name: scala.collection.immutable.List[scala.Int], expr: scala.collection.immutable.List[scala.Int], parallel: subtype name: scala.collection.immutable.List[scala.Int], expr: scala.collection.immutable.List[scala.Int]"
+    }
+
+    test(
+      "Enum[A].{matchOn and parMatchOn} should match on the mixed union (Color.Red.type | List[Int] | List[String]) when TypeTests are provided at the call site"
+    ) {
+      import ClassesFixtures.testEnumMatchOnAndParMatchOn
+      import examples.unions.typetests.given
+
+      def code(input: examples.unions.RedOrListIntOrListString) = testEnumMatchOnAndParMatchOn(input)
+      code(examples.Color.Red) <==>
+        "sequential: subtype name: hearth.examples.Color.Red.type, expr: hearth.examples.Color.Red.type, parallel: subtype name: hearth.examples.Color.Red.type, expr: hearth.examples.Color.Red.type"
+      code(List(1)) <==>
+        "sequential: subtype name: scala.collection.immutable.List[scala.Int], expr: scala.collection.immutable.List[scala.Int], parallel: subtype name: scala.collection.immutable.List[scala.Int], expr: scala.collection.immutable.List[scala.Int]"
+      code(List("a")) <==>
+        "sequential: subtype name: scala.collection.immutable.List[java.lang.String], expr: scala.collection.immutable.List[java.lang.String], parallel: subtype name: scala.collection.immutable.List[java.lang.String], expr: scala.collection.immutable.List[java.lang.String]"
+    }
+
+    test(
+      "Enum.parse should name the missing TypeTest instances for the same-erasure union (List[Int] | List[String]) without givens"
+    ) {
+      import ClassesFixtures.testEnumParseDiagnostic
+
+      testEnumParseDiagnostic[examples.unions.ListIntOrListString] <==>
+        "scala.collection.immutable.List[scala.Int] | scala.collection.immutable.List[scala.Predef.String] is sealed/enumeration/union but has no direct children: " +
+        "union member scala.collection.immutable.List[scala.Int] is not runtime-distinguishable; provide an implicit scala.reflect.TypeTest[scala.collection.immutable.List[scala.Int] | scala.collection.immutable.List[scala.Predef.String], scala.collection.immutable.List[scala.Int]], " +
+        "union member scala.collection.immutable.List[java.lang.String] is not runtime-distinguishable; provide an implicit scala.reflect.TypeTest[scala.collection.immutable.List[scala.Int] | scala.collection.immutable.List[scala.Predef.String], scala.collection.immutable.List[java.lang.String]]"
+    }
+
+    test(
+      "Enum.parse should accept the same-erasure union (List[Int] | List[String]) with TypeTests provided at the call site"
+    ) {
+      import ClassesFixtures.testEnumParseDiagnostic
+      import examples.unions.typetests.given
+
+      testEnumParseDiagnostic[examples.unions.ListIntOrListString] <==>
+        "parsed with children: scala.collection.immutable.List[scala.Int], scala.collection.immutable.List[java.lang.String]"
+    }
   }
 }

--- a/hearth-tests/src/test/scala-3/hearth/typed/ClassesScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/ClassesScala3Spec.scala
@@ -99,12 +99,57 @@ final class ClassesScala3Spec extends MacroSuite {
     }
 
     test(
+      "Enum[A].{matchOn and parMatchOn} should match on the union of singleton types (Color.Red.type | Color.Blue.type)"
+    ) {
+      import ClassesFixtures.testEnumMatchOnAndParMatchOn
+
+      def code(input: examples.unions.RedOrBlue) = testEnumMatchOnAndParMatchOn(input)
+      code(examples.Color.Red) <==>
+        "sequential: subtype name: hearth.examples.Color.Red.type, expr: hearth.examples.Color.Red.type, parallel: subtype name: hearth.examples.Color.Red.type, expr: hearth.examples.Color.Red.type"
+      code(examples.Color.Blue) <==>
+        "sequential: subtype name: hearth.examples.Color.Blue.type, expr: hearth.examples.Color.Blue.type, parallel: subtype name: hearth.examples.Color.Blue.type, expr: hearth.examples.Color.Blue.type"
+    }
+
+    test(
+      "Enum[A].{matchOn and parMatchOn} should match on the mixed union of a singleton and a class (Color.Red.type | String)"
+    ) {
+      import ClassesFixtures.testEnumMatchOnAndParMatchOn
+
+      def code(input: examples.unions.RedOrString) = testEnumMatchOnAndParMatchOn(input)
+      code(examples.Color.Red) <==>
+        "sequential: subtype name: hearth.examples.Color.Red.type, expr: hearth.examples.Color.Red.type, parallel: subtype name: hearth.examples.Color.Red.type, expr: hearth.examples.Color.Red.type"
+      code("hello") <==>
+        "sequential: subtype name: java.lang.String, expr: java.lang.String, parallel: subtype name: java.lang.String, expr: java.lang.String"
+    }
+
+    test(
+      "Enum[A].{matchOn and parMatchOn} should match on the mixed union of a module singleton and a class (Marker.type | Int)"
+    ) {
+      import ClassesFixtures.testEnumMatchOnAndParMatchOn
+
+      def code(input: examples.unions.MarkerOrInt) = testEnumMatchOnAndParMatchOn(input)
+      code(examples.unions.Marker) <==>
+        "sequential: subtype name: hearth.examples.unions.Marker.type, expr: hearth.examples.unions.Marker.type, parallel: subtype name: hearth.examples.unions.Marker.type, expr: hearth.examples.unions.Marker.type"
+      code(42) <==>
+        "sequential: subtype name: scala.Int, expr: scala.Int, parallel: subtype name: scala.Int, expr: scala.Int"
+    }
+
+    test(
       "Enum[A].{matchOn and parMatchOn} should return <no enum> for non-disjoint union type (List[Int] | List[String])"
     ) {
       import ClassesFixtures.testEnumMatchOnAndParMatchOn
 
       def code(input: examples.unions.ListIntOrListString) = testEnumMatchOnAndParMatchOn(input)
       code(List(1)) <==> "<no enum>"
+    }
+
+    test(
+      "Enum[A].{matchOn and parMatchOn} should return <no enum> for union type with related runtime classes (List[Int] | Seq[String])"
+    ) {
+      import ClassesFixtures.testEnumMatchOnAndParMatchOn
+
+      def code(input: examples.unions.ListIntOrSeqString) = testEnumMatchOnAndParMatchOn(input)
+      code(List("a")) <==> "<no enum>"
     }
   }
 }

--- a/hearth-tests/src/test/scala-3/hearth/typed/DependentTypesSpec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/DependentTypesSpec.scala
@@ -49,36 +49,39 @@ final class DependentTypesSpec extends MacroSuite {
       import ClassesFixtures.testDependentEnumDiagnostic
 
       test("inner sealed trait is recognized as enum") {
-        val diag = testDependentEnumDiagnostic[InnerSealedTrait]
-        diag.contains("InnerCC") ==> true
-        diag.contains("InnerObj") ==> true
+        testDependentEnumDiagnostic[InnerSealedTrait] <==>
+          """child=InnerCC: type=hearth.typed.DependentTypesSpec.InnerSealedTrait.InnerCC, pretty=hearth.typed.DependentTypesSpec.InnerSealedTrait.InnerCC, isVal=false, isObject=false, isCaseClass=true, isCaseObject=false, isCaseVal=false, hasSingleton=false, singletonPrint=<none>
+            |child=InnerObj: type=hearth.typed.DependentTypesSpec.InnerSealedTrait.InnerObj.type, pretty=hearth.typed.DependentTypesSpec.InnerSealedTrait.InnerObj.type, isVal=false, isObject=true, isCaseClass=false, isCaseObject=true, isCaseVal=false, hasSingleton=true, singletonPrint=typed.DependentTypesSpec.InnerSealedTrait.InnerObj""".stripMargin
       }
 
       test("inner enum is recognized as enum") {
-        val diag = testDependentEnumDiagnostic[InnerEnum]
-        diag.contains("Bar") ==> true
-        diag.contains("Baz") ==> true
-        diag.contains("Qux") ==> true
+        testDependentEnumDiagnostic[InnerEnum] <==>
+          """child=Bar: type=hearth.typed.DependentTypesSpec.InnerEnum.Bar, pretty=hearth.typed.DependentTypesSpec.InnerEnum.Bar, isVal=false, isObject=false, isCaseClass=true, isCaseObject=false, isCaseVal=false, hasSingleton=false, singletonPrint=<none>
+            |child=Baz: type=hearth.typed.DependentTypesSpec.InnerEnum.Baz, pretty=hearth.typed.DependentTypesSpec.InnerEnum.Baz, isVal=false, isObject=false, isCaseClass=true, isCaseObject=false, isCaseVal=false, hasSingleton=false, singletonPrint=<none>
+            |child=Qux: type=hearth.typed.DependentTypesSpec.InnerEnum.Qux.type, pretty=hearth.typed.DependentTypesSpec.InnerEnum.Qux.type, isVal=true, isObject=false, isCaseClass=false, isCaseObject=false, isCaseVal=true, hasSingleton=true, singletonPrint=typed.DependentTypesSpec.InnerEnum.Qux""".stripMargin
       }
 
       test("inner enum with type param is recognized as enum") {
-        val diag = testDependentEnumDiagnostic[InnerEnumWithTypeParam[Int]]
-        diag.contains("Wrapped") ==> true
-        diag.contains("Empty") ==> true
+        testDependentEnumDiagnostic[InnerEnumWithTypeParam[Int]] <==>
+          """child=Wrapped: type=hearth.typed.DependentTypesSpec.InnerEnumWithTypeParam.Wrapped[scala.Int], pretty=hearth.typed.DependentTypesSpec.InnerEnumWithTypeParam.Wrapped[scala.Int], isVal=false, isObject=false, isCaseClass=true, isCaseObject=false, isCaseVal=false, hasSingleton=false, singletonPrint=<none>
+            |child=Empty: type=hearth.typed.DependentTypesSpec.InnerEnumWithTypeParam.Empty.type, pretty=hearth.typed.DependentTypesSpec.InnerEnumWithTypeParam.Empty.type, isVal=true, isObject=false, isCaseClass=false, isCaseObject=false, isCaseVal=true, hasSingleton=true, singletonPrint=typed.DependentTypesSpec.InnerEnumWithTypeParam.Empty""".stripMargin
       }
     }
 
     group("Diagnostic: inner enum TypeRepr details") {
       import ClassesFixtures.testDependentEnumTypeReprDiagnostic
 
+      // The report embeds raw compiler output (`TypeRepr.show`, `flags.show`, summoned Mirror trees), which
+      // differs between Scala 3 minor versions — this spec is also compiled under the NEWEST_SCALA_TESTS
+      // (Scala 3.8.4) matrix — so we pin only the structure: one `child=` block per case, in declaration order.
       test("should report TypeRepr details for inner enum") {
         val report: String = testDependentEnumTypeReprDiagnostic[InnerEnum]
-        report.nonEmpty ==> true
+        report.linesIterator.filter(_.startsWith("child=")).mkString("\n") <==> "child=Bar:\nchild=Baz:\nchild=Qux:"
       }
 
       test("should report TypeRepr details for inner sealed trait") {
         val report: String = testDependentEnumTypeReprDiagnostic[InnerSealedTrait]
-        report.nonEmpty ==> true
+        report.linesIterator.filter(_.startsWith("child=")).mkString("\n") <==> "child=InnerCC:\nchild=InnerObj:"
       }
     }
 
@@ -87,12 +90,14 @@ final class DependentTypesSpec extends MacroSuite {
 
       test("should match on inner sealed trait case class") {
         def code(input: InnerSealedTrait) = testEnumMatchOnAndParMatchOn(input)
-        code(InnerSealedTrait.InnerCC(1)).contains("InnerCC") ==> true
+        code(InnerSealedTrait.InnerCC(1)) <==>
+          "sequential: subtype name: hearth.typed.DependentTypesSpec.InnerSealedTrait.InnerCC, expr: InnerCC, parallel: subtype name: hearth.typed.DependentTypesSpec.InnerSealedTrait.InnerCC, expr: InnerCC"
       }
 
       test("should match on inner sealed trait case object") {
         def code(input: InnerSealedTrait) = testEnumMatchOnAndParMatchOn(input)
-        code(InnerSealedTrait.InnerObj).contains("InnerObj") ==> true
+        code(InnerSealedTrait.InnerObj) <==>
+          "sequential: subtype name: hearth.typed.DependentTypesSpec.InnerSealedTrait.InnerObj.type, expr: InnerObj, parallel: subtype name: hearth.typed.DependentTypesSpec.InnerSealedTrait.InnerObj.type, expr: InnerObj"
       }
     }
 
@@ -101,17 +106,20 @@ final class DependentTypesSpec extends MacroSuite {
 
       test("should match on inner enum case class (Bar)") {
         def code(input: InnerEnum) = testEnumMatchOnAndParMatchOn(input)
-        code(InnerEnum.Bar(42)).contains("Bar") ==> true
+        code(InnerEnum.Bar(42)) <==>
+          "sequential: subtype name: hearth.typed.DependentTypesSpec.InnerEnum.Bar, expr: Bar, parallel: subtype name: hearth.typed.DependentTypesSpec.InnerEnum.Bar, expr: Bar"
       }
 
       test("should match on inner enum case class (Baz)") {
         def code(input: InnerEnum) = testEnumMatchOnAndParMatchOn(input)
-        code(InnerEnum.Baz("hello")).contains("Baz") ==> true
+        code(InnerEnum.Baz("hello")) <==>
+          "sequential: subtype name: hearth.typed.DependentTypesSpec.InnerEnum.Baz, expr: Baz, parallel: subtype name: hearth.typed.DependentTypesSpec.InnerEnum.Baz, expr: Baz"
       }
 
       test("should match on inner enum parameterless case (Qux) without ClassCastException") {
         def code(input: InnerEnum) = testEnumMatchOnAndParMatchOn(input)
-        code(InnerEnum.Qux).contains("Qux") ==> true
+        code(InnerEnum.Qux) <==>
+          "sequential: subtype name: hearth.typed.DependentTypesSpec.InnerEnum.Qux.type, expr: Qux, parallel: subtype name: hearth.typed.DependentTypesSpec.InnerEnum.Qux.type, expr: Qux"
       }
     }
 
@@ -120,12 +128,14 @@ final class DependentTypesSpec extends MacroSuite {
 
       test("should match on inner enum with type param (Wrapped)") {
         def code(input: InnerEnumWithTypeParam[Int]) = testEnumMatchOnAndParMatchOn(input)
-        code(InnerEnumWithTypeParam.Wrapped(42)).contains("Wrapped") ==> true
+        code(InnerEnumWithTypeParam.Wrapped(42)) <==>
+          "sequential: subtype name: hearth.typed.DependentTypesSpec.InnerEnumWithTypeParam.Wrapped[scala.Int], expr: Wrapped, parallel: subtype name: hearth.typed.DependentTypesSpec.InnerEnumWithTypeParam.Wrapped[scala.Int], expr: Wrapped"
       }
 
       test("should match on inner enum with type param (Empty) without ClassCastException") {
         def code(input: InnerEnumWithTypeParam[Int]) = testEnumMatchOnAndParMatchOn(input)
-        code(InnerEnumWithTypeParam.Empty).contains("Empty") ==> true
+        code(InnerEnumWithTypeParam.Empty) <==>
+          "sequential: subtype name: hearth.typed.DependentTypesSpec.InnerEnumWithTypeParam.Empty.type, expr: Empty, parallel: subtype name: hearth.typed.DependentTypesSpec.InnerEnumWithTypeParam.Empty.type, expr: Empty"
       }
     }
 
@@ -133,13 +143,19 @@ final class DependentTypesSpec extends MacroSuite {
       import ExprsFixtures.testMatchCaseTypeMatch
 
       test("should type-match on inner sealed trait case class") {
-        val result: Data = testMatchCaseTypeMatch[InnerSealedTrait](InnerSealedTrait.InnerCC(1))
-        result.toString.contains("InnerCC") ==> true
+        testMatchCaseTypeMatch[InnerSealedTrait](InnerSealedTrait.InnerCC(1)) <==> Data.map(
+          "name" -> Data("InnerCC"),
+          "type" -> Data("hearth.typed.DependentTypesSpec.InnerSealedTrait.InnerCC"),
+          "matchCase" -> Data("innercc")
+        )
       }
 
       test("should type-match on inner sealed trait case object") {
-        val result: Data = testMatchCaseTypeMatch[InnerSealedTrait](InnerSealedTrait.InnerObj)
-        result.toString.contains("InnerObj") ==> true
+        testMatchCaseTypeMatch[InnerSealedTrait](InnerSealedTrait.InnerObj) <==> Data.map(
+          "name" -> Data("InnerObj"),
+          "type" -> Data("hearth.typed.DependentTypesSpec.InnerSealedTrait.InnerObj.type"),
+          "matchCase" -> Data("innerobj")
+        )
       }
     }
 
@@ -147,13 +163,19 @@ final class DependentTypesSpec extends MacroSuite {
       import ExprsFixtures.testMatchCaseTypeMatch
 
       test("should type-match on inner enum case class") {
-        val result: Data = testMatchCaseTypeMatch[InnerEnum](InnerEnum.Bar(42))
-        result.toString.contains("Bar") ==> true
+        testMatchCaseTypeMatch[InnerEnum](InnerEnum.Bar(42)) <==> Data.map(
+          "name" -> Data("Bar"),
+          "type" -> Data("hearth.typed.DependentTypesSpec.InnerEnum.Bar"),
+          "matchCase" -> Data("bar")
+        )
       }
 
       test("should type-match on inner enum parameterless case") {
-        val result: Data = testMatchCaseTypeMatch[InnerEnum](InnerEnum.Qux)
-        result.toString.contains("Qux") ==> true
+        testMatchCaseTypeMatch[InnerEnum](InnerEnum.Qux) <==> Data.map(
+          "name" -> Data("Qux"),
+          "type" -> Data("hearth.typed.DependentTypesSpec.InnerEnum.Qux.type"),
+          "matchCase" -> Data("qux")
+        )
       }
     }
 
@@ -161,13 +183,19 @@ final class DependentTypesSpec extends MacroSuite {
       import ExprsFixtures.testMatchCaseTypeMatch
 
       test("should type-match on inner enum with type param (Wrapped)") {
-        val result: Data = testMatchCaseTypeMatch[InnerEnumWithTypeParam[Int]](InnerEnumWithTypeParam.Wrapped(42))
-        result.toString.contains("Wrapped") ==> true
+        testMatchCaseTypeMatch[InnerEnumWithTypeParam[Int]](InnerEnumWithTypeParam.Wrapped(42)) <==> Data.map(
+          "name" -> Data("Wrapped"),
+          "type" -> Data("hearth.typed.DependentTypesSpec.InnerEnumWithTypeParam.Wrapped[scala.Int]"),
+          "matchCase" -> Data("wrapped")
+        )
       }
 
       test("should type-match on inner enum with type param (Empty)") {
-        val result: Data = testMatchCaseTypeMatch[InnerEnumWithTypeParam[Int]](InnerEnumWithTypeParam.Empty)
-        result.toString.contains("Empty") ==> true
+        testMatchCaseTypeMatch[InnerEnumWithTypeParam[Int]](InnerEnumWithTypeParam.Empty) <==> Data.map(
+          "name" -> Data("Empty"),
+          "type" -> Data("hearth.typed.DependentTypesSpec.InnerEnumWithTypeParam.Empty.type"),
+          "matchCase" -> Data("empty")
+        )
       }
     }
 

--- a/hearth-tests/src/test/scala-3/hearth/typed/MethodsScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/MethodsScala3Spec.scala
@@ -207,7 +207,9 @@ final class MethodsScala3Spec extends MacroSuite {
           testParameterProperties[examples.methods.WithGivens]("methodWithUsingParam") <==> Data.map(
             "x" -> Data.map(
               "isImplicit" -> Data(true),
-              "hasDefault" -> Data(false)
+              "hasDefault" -> Data(false),
+              "isByName" -> Data(false),
+              "isVararg" -> Data(false)
             )
           )
         }

--- a/hearth-tests/src/test/scala-3/hearth/typed/TypesScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/TypesScala3Spec.scala
@@ -535,11 +535,45 @@ final class TypesScala3Spec extends MacroSuite {
           )
         }
 
-        test("for Color.Red.type | Color.Blue.type (same erasure — both erase to Color)") {
+        test("for Color.Red.type | Color.Blue.type (singletons matched by value, exempt from class disjointness)") {
           testUnionMembers[examples.unions.RedOrBlue] <==> Data.map(
             "Type.isUnionType" -> Data(true),
-            "Type.directChildren" -> Data("<no direct children>"),
-            "Type.exhaustiveChildren" -> Data("<no exhaustive children>")
+            "Type.directChildren" -> Data.map(
+              "hearth.examples.Color.Red.type" -> Data("hearth.examples.Color.Red.type"),
+              "hearth.examples.Color.Blue.type" -> Data("hearth.examples.Color.Blue.type")
+            ),
+            "Type.exhaustiveChildren" -> Data.map(
+              "hearth.examples.Color.Red.type" -> Data("hearth.examples.Color.Red.type"),
+              "hearth.examples.Color.Blue.type" -> Data("hearth.examples.Color.Blue.type")
+            )
+          )
+        }
+
+        test("for Color.Red.type | String (mixed: singleton + class-tested member)") {
+          testUnionMembers[examples.unions.RedOrString] <==> Data.map(
+            "Type.isUnionType" -> Data(true),
+            "Type.directChildren" -> Data.map(
+              "hearth.examples.Color.Red.type" -> Data("hearth.examples.Color.Red.type"),
+              "java.lang.String" -> Data("java.lang.String")
+            ),
+            "Type.exhaustiveChildren" -> Data.map(
+              "hearth.examples.Color.Red.type" -> Data("hearth.examples.Color.Red.type"),
+              "java.lang.String" -> Data("java.lang.String")
+            )
+          )
+        }
+
+        test("for Marker.type | Int (mixed: module singleton + class-tested member)") {
+          testUnionMembers[examples.unions.MarkerOrInt] <==> Data.map(
+            "Type.isUnionType" -> Data(true),
+            "Type.directChildren" -> Data.map(
+              "hearth.examples.unions.Marker.type" -> Data("hearth.examples.unions.Marker.type"),
+              "scala.Int" -> Data("scala.Int")
+            ),
+            "Type.exhaustiveChildren" -> Data.map(
+              "hearth.examples.unions.Marker.type" -> Data("hearth.examples.unions.Marker.type"),
+              "scala.Int" -> Data("scala.Int")
+            )
           )
         }
 
@@ -569,6 +603,22 @@ final class TypesScala3Spec extends MacroSuite {
 
         test("for List[Int] | List[String] (same erasure)") {
           testUnionMembers[examples.unions.ListIntOrListString] <==> Data.map(
+            "Type.isUnionType" -> Data(true),
+            "Type.directChildren" -> Data("<no direct children>"),
+            "Type.exhaustiveChildren" -> Data("<no exhaustive children>")
+          )
+        }
+
+        test("for List[Int] | Seq[String] (related runtime classes — List <: Seq)") {
+          testUnionMembers[examples.unions.ListIntOrSeqString] <==> Data.map(
+            "Type.isUnionType" -> Data(true),
+            "Type.directChildren" -> Data("<no direct children>"),
+            "Type.exhaustiveChildren" -> Data("<no exhaustive children>")
+          )
+        }
+
+        test("for Int | java.lang.Integer (same runtime class after boxing)") {
+          testUnionMembers[examples.unions.IntOrJavaInteger] <==> Data.map(
             "Type.isUnionType" -> Data(true),
             "Type.directChildren" -> Data("<no direct children>"),
             "Type.exhaustiveChildren" -> Data("<no exhaustive children>")

--- a/hearth-tests/src/test/scala-3/hearth/typed/TypesScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/TypesScala3Spec.scala
@@ -687,6 +687,29 @@ final class TypesScala3Spec extends MacroSuite {
             )
           )
         }
+
+        test("for List[Int] | List[String] (same erasure) WITH user-provided TypeTests in scope - accepted") {
+          import TypesFixtures.testChildrenNames
+          import examples.unions.typetests.given
+
+          testChildrenNames[examples.unions.ListIntOrListString] <==> Data.map(
+            "scala.collection.immutable.List[scala.Int]" -> Data("List"),
+            "scala.collection.immutable.List[java.lang.String]" -> Data("List")
+          )
+        }
+
+        test(
+          "for Color.Red.type | List[Int] | List[String] (mixed singleton + same-erasure members) WITH user-provided TypeTests in scope - accepted"
+        ) {
+          import TypesFixtures.testChildrenNames
+          import examples.unions.typetests.given
+
+          testChildrenNames[examples.unions.RedOrListIntOrListString] <==> Data.map(
+            "hearth.examples.Color.Red.type" -> Data("Red"),
+            "scala.collection.immutable.List[scala.Int]" -> Data("List"),
+            "scala.collection.immutable.List[java.lang.String]" -> Data("List")
+          )
+        }
       }
 
       group("methods: Type.{opaqueUnderlyingType} expected behavior") {

--- a/hearth-tests/src/test/scala-3/hearth/typed/TypesScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/TypesScala3Spec.scala
@@ -649,15 +649,23 @@ final class TypesScala3Spec extends MacroSuite {
           )
         }
 
-        test("for OpaqueId | String (opaque, conservative None)") {
+        test("for OpaqueId | String (opaque with disjoint underlying class - accepted)") {
+          // OpaqueId's underlying type (Long) is resolved via opaqueUnderlyingType, and Long vs String
+          // runtime classes are disjoint, so the union is accepted.
           testUnionMembers[examples.unions.OpaqueIdOrString] <==> Data.map(
             "Type.isUnionType" -> Data(true),
-            "Type.directChildren" -> Data("<no direct children>"),
-            "Type.exhaustiveChildren" -> Data("<no exhaustive children>")
+            "Type.directChildren" -> Data.map(
+              "hearth.examples.unions.OpaqueId" -> Data("hearth.examples.unions.OpaqueId"),
+              "java.lang.String" -> Data("java.lang.String")
+            ),
+            "Type.exhaustiveChildren" -> Data.map(
+              "hearth.examples.unions.OpaqueId" -> Data("hearth.examples.unions.OpaqueId"),
+              "java.lang.String" -> Data("java.lang.String")
+            )
           )
         }
 
-        test("for OpaqueId | Long (opaque + underlying type)") {
+        test("for OpaqueId | Long (opaque + its own underlying type - related classes, refused)") {
           testUnionMembers[examples.unions.OpaqueIdOrLong] <==> Data.map(
             "Type.isUnionType" -> Data(true),
             "Type.directChildren" -> Data("<no direct children>"),
@@ -665,11 +673,68 @@ final class TypesScala3Spec extends MacroSuite {
           )
         }
 
-        test("for OpaqueId | OpaqueName (two opaques)") {
+        test("for OpaqueId | OpaqueName (two opaques with disjoint underlying classes - accepted)") {
+          // OpaqueId(= Long) and OpaqueName(= String) resolve to disjoint runtime classes.
           testUnionMembers[examples.unions.OpaqueIdOrOpaqueName] <==> Data.map(
             "Type.isUnionType" -> Data(true),
-            "Type.directChildren" -> Data("<no direct children>"),
-            "Type.exhaustiveChildren" -> Data("<no exhaustive children>")
+            "Type.directChildren" -> Data.map(
+              "hearth.examples.unions.OpaqueId" -> Data("hearth.examples.unions.OpaqueId"),
+              "hearth.examples.unions.OpaqueName" -> Data("hearth.examples.unions.OpaqueName")
+            ),
+            "Type.exhaustiveChildren" -> Data.map(
+              "hearth.examples.unions.OpaqueId" -> Data("hearth.examples.unions.OpaqueId"),
+              "hearth.examples.unions.OpaqueName" -> Data("hearth.examples.unions.OpaqueName")
+            )
+          )
+        }
+      }
+
+      group("methods: Type.{opaqueUnderlyingType} expected behavior") {
+        import TypesFixtures.testOpaqueUnderlyingType
+
+        test("for simple opaque types") {
+          testOpaqueUnderlyingType[examples.opaqueid.OpaqueId] <==> Data.map(
+            "Type.isOpaqueType" -> Data(true),
+            "Type.opaqueUnderlyingType" -> Data("scala.Long")
+          )
+        }
+
+        test("for bounded opaque types (resolves the RHS, not the bound)") {
+          testOpaqueUnderlyingType[examples.opaqueunderlying.Bounded] <==> Data.map(
+            "Type.isOpaqueType" -> Data(true),
+            "Type.opaqueUnderlyingType" -> Data("scala.Int")
+          )
+        }
+
+        test("for nested opaque chains (resolves the innermost underlying type)") {
+          testOpaqueUnderlyingType[examples.opaqueunderlying.Outer] <==> Data.map(
+            "Type.isOpaqueType" -> Data(true),
+            "Type.opaqueUnderlyingType" -> Data("scala.Int")
+          )
+        }
+
+        test("for applied parameterized opaque types (type arguments are preserved)") {
+          testOpaqueUnderlyingType[examples.opaqueunderlying.Wrapper[Int]] <==> Data.map(
+            "Type.isOpaqueType" -> Data(true),
+            "Type.opaqueUnderlyingType" -> Data("scala.collection.immutable.List[scala.Int]")
+          )
+        }
+
+        test("for plain aliases to opaque types") {
+          testOpaqueUnderlyingType[examples.opaqueunderlying.AliasToOpaque] <==> Data.map(
+            "Type.isOpaqueType" -> Data(true),
+            "Type.opaqueUnderlyingType" -> Data("scala.Long")
+          )
+        }
+
+        test("for non-opaque types") {
+          testOpaqueUnderlyingType[String] <==> Data.map(
+            "Type.isOpaqueType" -> Data(false),
+            "Type.opaqueUnderlyingType" -> Data("<no underlying type>")
+          )
+          testOpaqueUnderlyingType[examples.classes.ExampleCaseClass] <==> Data.map(
+            "Type.isOpaqueType" -> Data(false),
+            "Type.opaqueUnderlyingType" -> Data("<no underlying type>")
           )
         }
       }

--- a/hearth-tests/src/test/scala/hearth/EnvironmentSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/EnvironmentSpec.scala
@@ -93,6 +93,34 @@ final class EnvironmentSpec extends MacroSuite {
       }
     }
 
+    group("methods: Environment.reportInfo(msg, position), expected behavior") {
+      import EnvironmentFixtures.testReportInfoAtPosition
+
+      test("should report info at the given position and continue the expansion") {
+        // Apparently, there is no way to check if there were some info/warn messages,
+        // so we only verify that reporting at a Method's position succeeds and the expansion continues.
+        testReportInfoAtPosition[examples.methods.NoCompanionClass] <==> Data.map(
+          "infoReported" -> Data(true)
+        )
+      }
+    }
+
+    group("methods: Environment.reportError(msg, position), expected behavior") {
+
+      test("should report error at the given position") {
+        compileErrors("EnvironmentFixtures.testReportErrorAtPosition").check("Error at position message")
+      }
+    }
+
+    group("methods: Environment.reportErrorAndAbort(msg, position), expected behavior") {
+
+      test("should report error at the given position and abort") {
+        compileErrors("EnvironmentFixtures.testReportErrorAndAbortAtPosition").check(
+          "Error and abort at position message"
+        )
+      }
+    }
+
     group("methods: Environment.loadMacroExtensions, expected behavior") {
       import EnvironmentFixtures.testLoadingExtensions
 

--- a/hearth-tests/src/test/scala/hearth/crossquotes/CrossTypeSelfRefSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/crossquotes/CrossTypeSelfRefSpec.scala
@@ -1,0 +1,32 @@
+package hearth
+package crossquotes
+
+import hearth.data.Data
+
+/** Macro implementation is in [[hearth.cq.CrossQuotesMacros]] (Scala 2) and [[hearth.cq.CrossQuotesPlugin]] (Scala 3).
+  *
+  * Fixtures are in [[CrossTypeSelfRefFixturesImpl]].
+  *
+  * Regression tests for hearth#285 — `implicit val ConfigT: Type[Configuration] = Type.of[Configuration]` must not
+  * resolve the generated implicit search to the very value being defined.
+  */
+final class CrossTypeSelfRefSpec extends MacroSuite {
+
+  group("Cross-Quotes macro/plugin: self-referential implicit Type vals (hearth#285)") {
+
+    test("implicit val A: Type[A] = Type.of[A] should materialize directly, not resolve to itself") {
+      CrossTypeSelfRefFixtures.testSelfReferentialImplicitType <==> Data.map(
+        "classLevelVal" -> Data("hearth.examples.classes.ExampleClass"),
+        "methodLocalVal" -> Data("hearth.examples.classes.ExampleTrait"),
+        "secondLocalVal" -> Data("hearth.examples.classes.ExampleClassWithTypeParam[scala.Int]"),
+        "implicitStillUsable" -> Data("scala.Option[hearth.examples.classes.ExampleTrait]")
+      )
+    }
+
+    test("implicit val F: Type.Ctor1[F] = Type.Ctor1.of[F] should materialize directly, not resolve to itself") {
+      CrossTypeSelfRefFixtures.testSelfReferentialImplicitCtor <==> Data.map(
+        "appliedCtor" -> Data("scala.Option[scala.Int]")
+      )
+    }
+  }
+}

--- a/hearth-tests/src/test/scala/hearth/typed/AnonymousInstanceSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/AnonymousInstanceSpec.scala
@@ -39,6 +39,28 @@ final class AnonymousInstanceSpec extends MacroSuite {
             )
           )
         }
+
+        test("rejects type not accessible at the call site") {
+          AnonymousInstanceFixtures.testAnonymousInstanceParseInaccessible <==> Data.map(
+            "result" -> Data("incompatible"),
+            "reason" -> Data(
+              "Type hearth.examples.anonymous_instances.PackagePrivateTrait is not accessible at the call site"
+            )
+          )
+        }
+
+        test("rejects more than one class parent") {
+          AnonymousInstanceFixtures.testAnonymousInstanceParseWithMixins[
+            examples.anonymous_instances.AbstractClassNoArgs,
+            examples.anonymous_instances.AbstractClassWithArgs
+          ] <==> Data.map(
+            "result" -> Data("incompatible"),
+            "reason" -> Data(
+              "At most one class parent allowed, got: hearth.examples.anonymous_instances.AbstractClassNoArgs, " +
+                "hearth.examples.anonymous_instances.AbstractClassWithArgs"
+            )
+          )
+        }
       }
 
       group("parse: method classification for single parent") {
@@ -278,6 +300,43 @@ final class AnonymousInstanceSpec extends MacroSuite {
         test("rejects sealed trait") {
           testAnonymousInstanceConstruct[examples.anonymous_instances.SealedTrait] <==>
             "incompatible: Cannot create anonymous instance of sealed type hearth.examples.anonymous_instances.SealedTrait"
+        }
+      }
+
+      group("construct: error reporting") {
+        import AnonymousInstanceFixtures.{
+          testAnonymousInstanceConstructNoOverrides,
+          testAnonymousInstanceConstructNoOverridesWithMixins,
+          testAnonymousInstanceConstructOverridingFinal
+        }
+
+        test("reports missing required override") {
+          testAnonymousInstanceConstructNoOverrides[examples.anonymous_instances.SimpleTrait] <==>
+            "errors: Missing required override: value (hearth.examples.anonymous_instances.SimpleTrait: def value: scala.Int)"
+        }
+
+        test("aggregates multiple missing required overrides") {
+          testAnonymousInstanceConstructNoOverridesWithMixins[
+            examples.anonymous_instances.MixinA,
+            examples.anonymous_instances.MixinB
+          ] <==>
+            ("errors: Missing required override: fromA (hearth.examples.anonymous_instances.MixinA: def fromA: java.lang.String); " +
+              "Missing required override: fromB (hearth.examples.anonymous_instances.MixinA: def fromB: scala.Int)")
+        }
+
+        test("reports overriding a final method") {
+          testAnonymousInstanceConstructOverridingFinal[examples.anonymous_instances.TraitWithFinalMethod](
+            "finalMethod"
+          ) <==>
+            "errors: Cannot override final method: finalMethod (hearth.examples.anonymous_instances.TraitWithFinalMethod: final def finalMethod: scala.Int)"
+        }
+
+        test("reports unresolved diamond conflict") {
+          testAnonymousInstanceConstructNoOverridesWithMixins[
+            examples.anonymous_instances.DiamondLeft,
+            examples.anonymous_instances.DiamondRight
+          ] <==>
+            "errors: Diamond conflict for method 'method' — conflicting implementations from: hearth.examples.anonymous_instances.DiamondLeft"
         }
       }
 

--- a/hearth-tests/src/test/scala/hearth/typed/AnonymousInstanceSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/AnonymousInstanceSpec.scala
@@ -292,6 +292,31 @@ final class AnonymousInstanceSpec extends MacroSuite {
           ] <==> "success"
         }
 
+        // Regression for commit 7c82fc9 (Scala 2: premature c.typecheck of the generated `new` tree broke
+        // anonymous instances in call-site-local scopes).
+        test("anonymous instance of a trait defined locally at the call site") {
+          trait LocalTrait {
+            def value: Int
+          }
+          testAnonymousInstanceConstruct[LocalTrait] <==> "success"
+        }
+
+        // Regression for commit 7c82fc9 (Scala 2: premature c.typecheck of the generated `new` tree broke
+        // anonymous instances whose override bodies reference call-site-scoped expressions).
+        test("override body can splice an expression captured from the call site") {
+          val captured = List("captured", "value").mkString("-") // a local val, not a literal
+          AnonymousInstanceFixtures.testAnonymousInstanceCapturedOverride(captured) <==> "captured-value!"
+        }
+
+        test("override body can reference a lambda parameter of an enclosing Expr.quote (cats-tagless pattern)") {
+          AnonymousInstanceFixtures.testAnonymousInstanceOverrideReferencingQuoteParam.apply("quoted") <==> "quoted!"
+        }
+
+        test("override body can use the override's own parameters together with captured expressions") {
+          val captured = List("ctx").mkString
+          AnonymousInstanceFixtures.testAnonymousInstanceOverrideUsingParams(captured) <==> "ctx! echo"
+        }
+
         test("rejects final class") {
           testAnonymousInstanceConstruct[examples.anonymous_instances.FinalClass] <==>
             "incompatible: Cannot create anonymous instance of final type hearth.examples.anonymous_instances.FinalClass"

--- a/hearth-tests/src/test/scala/hearth/typed/AnonymousInstanceSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/AnonymousInstanceSpec.scala
@@ -56,6 +56,18 @@ final class AnonymousInstanceSpec extends MacroSuite {
           )
         }
 
+        test("trait with vararg abstract method") {
+          testAnonymousInstanceParse[examples.anonymous_instances.TraitWithVarargMethod] <==> Data.map(
+            "result" -> Data("compatible"),
+            "classParent" -> Data("<none>"),
+            "traitParents" -> Data("hearth.examples.anonymous_instances.TraitWithVarargMethod"),
+            "mustOverride" -> Data("sum"),
+            "mayOverride" -> Data(""),
+            "cannotOverride" -> Data(""),
+            "diamondConflicts" -> Data("")
+          )
+        }
+
         test("trait with concrete and abstract methods") {
           testAnonymousInstanceParse[examples.anonymous_instances.TraitWithConcreteMethod] <==> Data.map(
             "result" -> Data("compatible"),
@@ -238,6 +250,10 @@ final class AnonymousInstanceSpec extends MacroSuite {
 
         test("abstract class with default constructor args") {
           testAnonymousInstanceConstruct[examples.anonymous_instances.AbstractClassWithDefaults] <==> "success"
+        }
+
+        test("trait with vararg abstract method") {
+          testAnonymousInstanceConstruct[examples.anonymous_instances.TraitWithVarargMethod] <==> "success"
         }
 
         test("class parent with trait mixin") {

--- a/hearth-tests/src/test/scala/hearth/typed/ClassesSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ClassesSpec.scala
@@ -264,6 +264,26 @@ final class ClassesSpec extends MacroSuite {
       testCaseClassConstructRoundTrip[examples.classes.ExampleCaseClass] <==> "a=42"
     }
 
+    test("CaseClass with vararg field: parse, construct via vararg-aware ApplyValues, Seq-typed accessor") {
+      import ClassesFixtures.testVarargCaseClassConstruct
+
+      // The vararg constructor parameter is normalized to scala.collection.immutable.Seq[A] (isVararg=true),
+      // construct receives one Expr[Seq[A]] argument and re-splices it as `seq*`, and the case-field accessor
+      // exposes a plain Seq[A]. Runtime equality verifies the constructed instance.
+      testVarargCaseClassConstruct(hearth.examples.classes.ExampleCaseClassWithVarargs(1, 2, 3)) <==> Data.map(
+        "primaryConstructor" -> Data("(xs: scala.collection.immutable.Seq[scala.Int] (vararg))"),
+        "caseFields" -> Data("(xs: scala.collection.immutable.Seq[scala.Int])"),
+        "constructedEqualsExpected" -> Data(true)
+      )
+    }
+
+    test("CaseClass[A].caseFieldValuesAt should extract the Seq-typed field of a vararg case class") {
+      import ClassesFixtures.testCaseClassCaseFieldValuesAt
+
+      testCaseClassCaseFieldValuesAt(hearth.examples.classes.ExampleCaseClassWithVarargs(1, 2, 3)) <==>
+        "(xs: hearth.examples.classes.ExampleCaseClassWithVarargs.apply(1, 2, 3).xs)"
+    }
+
     test("SingletonValue round-trip: evaluate singleton expression at runtime") {
       import ClassesFixtures.testSingletonRoundTrip
 

--- a/hearth-tests/src/test/scala/hearth/typed/ClassesSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ClassesSpec.scala
@@ -228,6 +228,29 @@ final class ClassesSpec extends MacroSuite {
         "(a: hearth.examples.classes.ExampleCaseClass.apply(0).a)"
     }
 
+    // Regression for commit 68e1781: caseFieldValuesAt(instance, visibility) filters case fields by
+    // accessibility. The `private[hearth]` field b IS accessible at this call site (inside hearth),
+    // so AtCallSite keeps it, while the default Everywhere visibility (b is not public) skips it.
+    test("CaseClass[A].caseFieldValuesAt should filter fields by the requested visibility") {
+      import ClassesFixtures.{testCaseClassCaseFieldValuesAt, testCaseClassCaseFieldValuesAtCallSite}
+
+      // Pinned cross-platform divergence: on Scala 2 the case accessor of a private[hearth] val is the
+      // synthetic b$access$1, which scalac makes fully public — so it is reported even under Everywhere.
+      // On Scala 3 the accessor b keeps its restricted visibility, so Everywhere filters it out while
+      // AtCallSite (expanding inside the hearth package) keeps it.
+      val b = if (LanguageVersion.byHearth.isScala2_13) "b$access$1" else "b"
+
+      testCaseClassCaseFieldValuesAtCallSite(hearth.examples.classes.ExampleCaseClassWithPrivateField(0, "b")) <==>
+        s"(a: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").a, $b: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").$b)"
+
+      testCaseClassCaseFieldValuesAt(hearth.examples.classes.ExampleCaseClassWithPrivateField(0, "b")) <==> (
+        if (LanguageVersion.byHearth.isScala2_13)
+          "(a: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").a, b$access$1: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").b$access$1)"
+        else
+          "(a: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").a)"
+      )
+    }
+
     test("CaseClass[A] should detect default values on constructor parameters") {
       import ClassesFixtures.testCaseClassDefaultValues
 
@@ -246,6 +269,20 @@ final class ClassesSpec extends MacroSuite {
 
       testSingletonRoundTrip[examples.enums.ExampleSealedTrait.ExampleSealedTraitObject.type] <==>
         "ExampleSealedTraitObject"
+    }
+
+    // Regression for commit 68e1781 (splice isolation): handlers build their results from nested
+    // Expr.quote calls that splice the matched expression and an Inlined macro argument.
+    test("Enum[A].parMatchOn with handler results built from nested Expr.quote") {
+      import ClassesFixtures.testEnumParMatchOnNestedQuote
+
+      val suffix = List(" (handled)").mkString // a local val, so on Scala 3 it arrives as an Inlined argument
+
+      def code(input: hearth.examples.enums.ExampleSealedTrait) = testEnumParMatchOnNestedQuote(input, suffix)
+      code(hearth.examples.enums.ExampleSealedTrait.ExampleSealedTraitClass(1)) <==>
+        "ExampleSealedTraitClass(1) (handled)"
+      code(hearth.examples.enums.ExampleSealedTrait.ExampleSealedTraitObject) <==>
+        "ExampleSealedTraitObject (handled)"
     }
 
     test("Enum[A].{matchOn and parMatchOn} should match on the sealed trait") {

--- a/hearth-tests/src/test/scala/hearth/typed/ClassesSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ClassesSpec.scala
@@ -229,26 +229,33 @@ final class ClassesSpec extends MacroSuite {
     }
 
     // Regression for commit 68e1781: caseFieldValuesAt(instance, visibility) filters case fields by
-    // accessibility. The `private[hearth]` field b IS accessible at this call site (inside hearth),
-    // so AtCallSite keeps it, while the default Everywhere visibility (b is not public) skips it.
+    // accessibility. By default (Unrestricted) ALL case fields are returned (pre-68e1781 behavior);
+    // the `private[hearth]` field b IS accessible at this call site (inside hearth), so AtCallSite
+    // keeps it, while explicit Everywhere (b is not public) skips it on both platforms.
     test("CaseClass[A].caseFieldValuesAt should filter fields by the requested visibility") {
-      import ClassesFixtures.{testCaseClassCaseFieldValuesAt, testCaseClassCaseFieldValuesAtCallSite}
+      import ClassesFixtures.{
+        testCaseClassCaseFieldValuesAt,
+        testCaseClassCaseFieldValuesAtCallSite,
+        testCaseClassCaseFieldValuesAtEverywhere
+      }
 
-      // Pinned cross-platform divergence: on Scala 2 the case accessor of a private[hearth] val is the
-      // synthetic b$access$1, which scalac makes fully public — so it is reported even under Everywhere.
-      // On Scala 3 the accessor b keeps its restricted visibility, so Everywhere filters it out while
-      // AtCallSite (expanding inside the hearth package) keeps it.
-      val b = if (LanguageVersion.byHearth.isScala2_13) "b$access$1" else "b"
+      // On Scala 2 the non-public case field b is read through the public synthetic accessor b$access$1, on
+      // Scala 3 through the restricted accessor b. The map key is normalized to the declared name b, and the
+      // visibility filtering follows the declared field's visibility on both platforms - only the printed
+      // accessor call differs.
+      val bCall = if (LanguageVersion.byHearth.isScala2_13) "b$access$1" else "b"
 
+      // Default: every case field, regardless of visibility.
+      testCaseClassCaseFieldValuesAt(hearth.examples.classes.ExampleCaseClassWithPrivateField(0, "b")) <==>
+        s"(a: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").a, b: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").$bCall)"
+
+      // AtCallSite: b is private[hearth] and we expand inside hearth, so it is kept.
       testCaseClassCaseFieldValuesAtCallSite(hearth.examples.classes.ExampleCaseClassWithPrivateField(0, "b")) <==>
-        s"(a: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").a, $b: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").$b)"
+        s"(a: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").a, b: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").$bCall)"
 
-      testCaseClassCaseFieldValuesAt(hearth.examples.classes.ExampleCaseClassWithPrivateField(0, "b")) <==> (
-        if (LanguageVersion.byHearth.isScala2_13)
-          "(a: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").a, b$access$1: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").b$access$1)"
-        else
-          "(a: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").a)"
-      )
+      // Everywhere: b is not public, so it is dropped on both platforms.
+      testCaseClassCaseFieldValuesAtEverywhere(hearth.examples.classes.ExampleCaseClassWithPrivateField(0, "b")) <==>
+        "(a: hearth.examples.classes.ExampleCaseClassWithPrivateField.apply(0, \"b\").a)"
     }
 
     test("CaseClass[A] should detect default values on constructor parameters") {

--- a/hearth-tests/src/test/scala/hearth/typed/DestructuredExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/DestructuredExprsSpec.scala
@@ -90,6 +90,128 @@ final class DestructuredExprsSpec extends MacroSuite {
       }
     }
 
+    group("parseDetailed: vararg call sites") {
+      import DestructuredExprsFixtures.testParseDetailed
+
+      // The vararg slot is represented as ONE argument in AppliedValues (matching Method.ApplyValues, which expects
+      // a single Expr[Seq[A]] for a vararg parameter): individual elements become a Varargs node (elements
+      // recoverable), a spread sequence (`seq*`) becomes the destructured sequence expression itself.
+
+      test("vararg call with individual elements becomes one Varargs slot") {
+        testParseDetailed((w: examples.methods.WithVarargs) => w.varargMethod(1, 2, 3)) <==> Data.map(
+          "nodeType" -> Data("Lambda"),
+          "params" -> Data.list(
+            Data.map("name" -> Data("w"), "type" -> Data("hearth.examples.methods.WithVarargs"))
+          ),
+          "body" -> Data.map(
+            "nodeType" -> Data("MethodCall"),
+            "methodName" -> Data("varargMethod"),
+            "returnType" -> Data("scala.Int"),
+            "applied" -> Data.list(
+              Data.map(
+                "kind" -> Data("Instance"),
+                "value" -> Data.map("nodeType" -> Data("ParamRef"), "paramName" -> Data("w"))
+              ),
+              Data.map(
+                "kind" -> Data("Values"),
+                "args" -> Data.list(
+                  Data.map(
+                    "nodeType" -> Data("Varargs"),
+                    "type" -> Data("scala.collection.immutable.Seq[scala.Int]"),
+                    "elements" -> Data.list(
+                      Data.map("nodeType" -> Data("Literal"), "value" -> Data("1")),
+                      Data.map("nodeType" -> Data("Literal"), "value" -> Data("2")),
+                      Data.map("nodeType" -> Data("Literal"), "value" -> Data("3"))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      }
+
+      test("vararg call with no elements becomes an empty Varargs slot") {
+        testParseDetailed((w: examples.methods.WithVarargs) => w.varargMethod()) <==> Data.map(
+          "nodeType" -> Data("Lambda"),
+          "params" -> Data.list(
+            Data.map("name" -> Data("w"), "type" -> Data("hearth.examples.methods.WithVarargs"))
+          ),
+          "body" -> Data.map(
+            "nodeType" -> Data("MethodCall"),
+            "methodName" -> Data("varargMethod"),
+            "returnType" -> Data("scala.Int"),
+            "applied" -> Data.list(
+              Data.map(
+                "kind" -> Data("Instance"),
+                "value" -> Data.map("nodeType" -> Data("ParamRef"), "paramName" -> Data("w"))
+              ),
+              Data.map(
+                "kind" -> Data("Values"),
+                "args" -> Data.list(
+                  Data.map(
+                    "nodeType" -> Data("Varargs"),
+                    "type" -> Data("scala.collection.immutable.Seq[scala.Int]"),
+                    "elements" -> Data.list()
+                  )
+                )
+              )
+            )
+          )
+        )
+      }
+
+      test("vararg call with spread sequence becomes the sequence expression itself") {
+        testParseDetailed((w: examples.methods.WithVarargs, xs: Seq[Int]) => w.varargMethod(xs*)) <==> Data.map(
+          "nodeType" -> Data("Lambda"),
+          "params" -> Data.list(
+            Data.map("name" -> Data("w"), "type" -> Data("hearth.examples.methods.WithVarargs")),
+            Data.map("name" -> Data("xs"), "type" -> Data("scala.collection.immutable.Seq[scala.Int]"))
+          ),
+          "body" -> Data.map(
+            "nodeType" -> Data("MethodCall"),
+            "methodName" -> Data("varargMethod"),
+            "returnType" -> Data("scala.Int"),
+            "applied" -> Data.list(
+              Data.map(
+                "kind" -> Data("Instance"),
+                "value" -> Data.map("nodeType" -> Data("ParamRef"), "paramName" -> Data("w"))
+              ),
+              Data.map(
+                "kind" -> Data("Values"),
+                "args" -> Data.list(
+                  Data.map("nodeType" -> Data("ParamRef"), "paramName" -> Data("xs"))
+                )
+              )
+            )
+          )
+        )
+      }
+
+      test("vararg constructor call with individual elements becomes one Varargs slot") {
+        testParseDetailed(new examples.methods.WithVarargsCtor("a", "b")) <==> Data.map(
+          "nodeType" -> Data("MethodCall"),
+          "methodName" -> Data("<init>"),
+          "returnType" -> Data("hearth.examples.methods.WithVarargsCtor"),
+          "applied" -> Data.list(
+            Data.map(
+              "kind" -> Data("Values"),
+              "args" -> Data.list(
+                Data.map(
+                  "nodeType" -> Data("Varargs"),
+                  "type" -> Data("scala.collection.immutable.Seq[java.lang.String]"),
+                  "elements" -> Data.list(
+                    Data.map("nodeType" -> Data("Literal"), "value" -> Data("\"a\"")),
+                    Data.map("nodeType" -> Data("Literal"), "value" -> Data("\"b\""))
+                  )
+                )
+              )
+            )
+          )
+        )
+      }
+    }
+
     group("outermost MethodCall: DSL patterns with implicit evidence") {
       import DestructuredExprsFixtures.testOutermostMethodCall
       import examples.parsed_exprs.dsl.*

--- a/hearth-tests/src/test/scala/hearth/typed/ExprCodecSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprCodecSpec.scala
@@ -41,6 +41,18 @@ final class ExprCodecSpec extends MacroSuite {
           )
         )
       }
+
+      test("vararg case class") {
+        // fromExpr semi-evaluates the vararg apply call, toExpr re-lifts the (normalized) Seq[Int] field through
+        // the built-in SeqExprCodec and re-splices it as `seq: _*` via the vararg-aware construct path.
+        testExprCodecRoundTrip(VarargNumbers(1, 2, 3)) <==> Data.map(
+          "decoded" -> Data("VarargNumbers(List(1, 2, 3))"),
+          "reLifted" -> caseClassReLifted(
+            s2 = "new hearth.examples.expr_codecs.VarargNumbers((scala.collection.immutable.Seq(1, 2, 3): _*))",
+            s3 = "new hearth.examples.expr_codecs.VarargNumbers(scala.Seq.apply[scala.Int](1, 2, 3): _*)"
+          )
+        )
+      }
     }
 
     group("sealed traits") {

--- a/hearth-tests/src/test/scala/hearth/typed/ExprCodecSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprCodecSpec.scala
@@ -105,4 +105,70 @@ final class ExprCodecSpec extends MacroSuite {
       }
     }
   }
+
+  group("Expr.semiQuote direct usage") {
+
+    test("quotes primitives and String via built-in codecs") {
+      ExprCodecFixtures.testSemiQuotePrimitives <==> Data.map(
+        "int" -> Data("42"),
+        "string" -> Data("\"quoted\""),
+        "boolean" -> Data("true"),
+        "double" -> Data("3.14")
+      )
+    }
+
+    test("quotes case classes (recursively)") {
+      ExprCodecFixtures.testSemiQuoteCaseClass <==> Data.map(
+        "simple" -> caseClassReLifted(
+          s2 = "new hearth.examples.expr_codecs.ServerConfig((\"localhost\": scala.Predef.String), (8080: scala.Int))",
+          s3 = "new hearth.examples.expr_codecs.ServerConfig(\"localhost\", 8080)"
+        ),
+        "nested" -> caseClassReLifted(
+          s2 =
+            "new hearth.examples.expr_codecs.AppConfig(new hearth.examples.expr_codecs.ServerConfig((\"db.local\": scala.Predef.String), (5432: scala.Int)), (true: scala.Boolean))",
+          s3 =
+            "new hearth.examples.expr_codecs.AppConfig(new hearth.examples.expr_codecs.ServerConfig(\"db.local\", 5432), true)"
+        )
+      )
+    }
+
+    test("quotes children of a sealed hierarchy (upcast to the parent)") {
+      ExprCodecFixtures.testSemiQuoteSealedChild <==> Data.map(
+        "caseClassChild" -> caseClassReLifted(
+          s2 =
+            "(new hearth.examples.expr_codecs.Shape.Circle((3.14: scala.Double)): hearth.examples.expr_codecs.Shape)",
+          s3 = "new hearth.examples.expr_codecs.Shape.Circle(3.14)"
+        ),
+        "caseObjectChild" -> singletonReLifted(
+          s2fqn = "(hearth.examples.expr_codecs.Shape.Origin: hearth.examples.expr_codecs.Shape)",
+          s3short = "expr_codecs.Shape.Origin"
+        )
+      )
+    }
+
+    test("quotes a standalone case object") {
+      ExprCodecFixtures.testSemiQuoteSingleton <==> Data.map(
+        "caseObject" -> singletonReLifted(
+          s2fqn = "hearth.examples.expr_codecs.Sentinel",
+          s3short = "expr_codecs.Sentinel"
+        )
+      )
+    }
+
+    test("QuoteOverride customizes quoting for a chosen type (also inside case classes)") {
+      ExprCodecFixtures.testSemiQuoteWithOverride <==> Data.map(
+        "direct" -> Data("\"HELLO\""),
+        "nested" -> caseClassReLifted(
+          s2 = "new hearth.examples.expr_codecs.ServerConfig((\"LOCALHOST\": scala.Predef.String), (8080: scala.Int))",
+          s3 = "new hearth.examples.expr_codecs.ServerConfig(\"LOCALHOST\", 8080)"
+        )
+      )
+    }
+
+    test("returns Left with a message for a type that cannot be quoted") {
+      ExprCodecFixtures.testSemiQuoteFailure <==> Data.map(
+        "notQuotable" -> Data("<failed: Cannot semi-quote value of type hearth.examples.expr_codecs.NotQuotable>")
+      )
+    }
+  }
 }

--- a/hearth-tests/src/test/scala/hearth/typed/ExprCodecSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprCodecSpec.scala
@@ -118,6 +118,20 @@ final class ExprCodecSpec extends MacroSuite {
     }
   }
 
+  group("built-in parameterized codecs") {
+
+    test("Expr.typeOf reports the concrete instantiated type for exprs produced by built-in codecs") {
+      // Regression: on Scala 2 ExprCodec.make captured the codec's own free type parameter A in the WeakTypeTag,
+      // so Expr.typeOf reported `A` instead of e.g. Seq[Int], breaking downstream upcast calls.
+      ExprCodecFixtures.testBuiltInCodecExprTypes <==> Data.map(
+        "Seq[Int]" -> Data("ok"),
+        "List[Int]" -> Data("ok"),
+        "Option[Int]" -> Data("ok"),
+        "Map[String, Int]" -> Data("ok")
+      )
+    }
+  }
+
   group("Expr.semiQuote direct usage") {
 
     test("quotes primitives and String via built-in codecs") {

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -96,15 +96,12 @@ final class ExprsSpec extends MacroSuite {
           implicit val pref: examples.expr_codecs.Preference[examples.expr_codecs.ServerConfig] =
             examples.expr_codecs.Preference[examples.expr_codecs.ServerConfig]
 
-          val result = testSummonViaUntypedRoundtrip[examples.expr_codecs.ServerConfig]
-          val map = result.asMap.get
-          assert(map("direct").asBoolean.get == true, s"direct should succeed, got: $result")
-          assert(map("fromTyped").asBoolean.get == true, s"fromTyped roundtrip should succeed, got: $result")
-          if (LanguageVersion.byHearth.isScala3)
-            assert(
-              map("fromClass").asBoolean.get == true,
-              s"fromClass roundtrip should succeed on Scala 3, got: $result"
-            )
+          testSummonViaUntypedRoundtrip[examples.expr_codecs.ServerConfig] <==> Data.map(
+            "direct" -> Data(true),
+            "fromTyped" -> Data(true),
+            "fromClass" -> Data(true),
+            "summonByType" -> Data(true)
+          )
         }
       }
 
@@ -116,6 +113,30 @@ final class ExprsSpec extends MacroSuite {
             "status" -> Data("success"),
             "value" -> Data("42"),
             "class" -> Data("java.lang.Integer")
+          )
+        }
+
+        // Regression for commits 481f734 and 1472324: asInstanceOf/isInstanceOf are compiler intrinsics, not
+        // real JVM methods — semiEval must not try to invoke them reflectively (this is the cross-platform
+        // counterpart of the Scala 3-only tests in ExprsScala3Spec; the Scala 2 code path had no coverage).
+        test("should evaluate asInstanceOf as an intrinsic (pass value through)") {
+          testSemiEval(("hello": Any).asInstanceOf[String].length) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("5"),
+            "class" -> Data("java.lang.Integer")
+          )
+        }
+
+        test("should evaluate isInstanceOf via runtime class check") {
+          testSemiEval(("hello": Any).isInstanceOf[String]) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("true"),
+            "class" -> Data("java.lang.Boolean")
+          )
+          testSemiEval((42: Any).isInstanceOf[String]) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("false"),
+            "class" -> Data("java.lang.Boolean")
           )
         }
 
@@ -398,6 +419,20 @@ final class ExprsSpec extends MacroSuite {
           "type" -> Data("hearth.examples.enums.ExampleSealedTrait.ExampleSealedTraitObject.type"),
           "matchCase" -> Data("examplesealedtraitobject")
         )
+      }
+
+      test("matchOn with case bodies built from nested Expr.quote with splices (regression for 68e1781)") {
+        import ExprsFixtures.testMatchOnWithNestedQuote
+
+        val suffix = List(" (handled)").mkString // a local val, so on Scala 3 it arrives as an Inlined argument
+
+        def expand(example: examples.enums.ExampleSealedTrait): String =
+          testMatchOnWithNestedQuote(example, suffix)
+
+        expand(examples.enums.ExampleSealedTrait.ExampleSealedTraitClass(1)) <==>
+          "ExampleSealedTraitClass: ExampleSealedTraitClass(1) (handled)"
+        expand(examples.enums.ExampleSealedTrait.ExampleSealedTraitObject) <==>
+          "ExampleSealedTraitObject: ExampleSealedTraitObject (handled)"
       }
 
       test("method MatchCase.eqValue should allow pattern-matching by value equality") {

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -337,6 +337,34 @@ final class ExprsSpec extends MacroSuite {
             "class" -> Data("java.lang.String")
           )
         }
+
+        test("should fail with Left for a reference to a runtime-only local value") {
+          @scala.annotation.nowarn // the val is only used inside the macro-inspected tree
+          def run = {
+            val runtimeValue = "only known at runtime"
+            testSemiEval(runtimeValue) <==> Data.map(
+              "status" -> Data("failure"),
+              "errors" -> Data.list(Data("Cannot semi-evaluate expression: runtimeValue"))
+            )
+          }
+          run
+        }
+
+        test("should aggregate multiple independent errors in a NonEmptyVector") {
+          @scala.annotation.nowarn // the vals are only used inside the macro-inspected tree
+          def run = {
+            val first = "first runtime value"
+            val second = "second runtime value"
+            testSemiEval(List(first, second)) <==> Data.map(
+              "status" -> Data("failure"),
+              "errors" -> Data.list(
+                Data("Cannot semi-evaluate expression: first"),
+                Data("Cannot semi-evaluate expression: second")
+              )
+            )
+          }
+          run
+        }
       }
 
     }

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -2224,6 +2224,169 @@ final class MethodsSpec extends MacroSuite {
     }
   }
 
+  group("methods: annotationsOfType and constructorArguments") {
+    import MethodsFixtures.{testAnnotationsOfType, testAnnotationValueDecoded}
+
+    test("filters type and method annotations by type, decoding constructor args (present and absent cases)") {
+      testAnnotationsOfType[examples.methods.NoCompanionClass]("methodWithAnnotation") <==> Data.map(
+        "type" -> Data.map(
+          "hasExampleAnnotation" -> Data(false),
+          "hasExampleAnnotation2" -> Data(true),
+          "exampleAnnotation2Args" -> Data.list(Data.list(Data("1"))),
+          "parentAnnotations" -> Data(0),
+          "childAnnotations" -> Data(0)
+        ),
+        "method" -> Data.map(
+          "hasExampleAnnotation" -> Data(true),
+          "hasExampleAnnotation2" -> Data(false),
+          "exampleAnnotation2Args" -> Data.list(),
+          "parentAnnotations" -> Data(0),
+          "childAnnotations" -> Data(0),
+          "parameters" -> Data.list(
+            Data.map(
+              "name" -> Data("arg"),
+              "hasExampleAnnotation" -> Data(false),
+              "exampleAnnotation2Args" -> Data.list(),
+              "parentAnnotations" -> Data(0),
+              "childAnnotations" -> Data(0)
+            )
+          )
+        ),
+        "constructor" -> Data.list()
+      )
+    }
+
+    test("filters method parameter annotations by type") {
+      testAnnotationsOfType[examples.methods.NoCompanionClass]("methodWithAnnotatedParam") <==> Data.map(
+        "type" -> Data.map(
+          "hasExampleAnnotation" -> Data(false),
+          "hasExampleAnnotation2" -> Data(true),
+          "exampleAnnotation2Args" -> Data.list(Data.list(Data("1"))),
+          "parentAnnotations" -> Data(0),
+          "childAnnotations" -> Data(0)
+        ),
+        "method" -> Data.map(
+          "hasExampleAnnotation" -> Data(false),
+          "hasExampleAnnotation2" -> Data(false),
+          "exampleAnnotation2Args" -> Data.list(),
+          "parentAnnotations" -> Data(0),
+          "childAnnotations" -> Data(0),
+          "parameters" -> Data.list(
+            Data.map(
+              "name" -> Data("arg"),
+              "hasExampleAnnotation" -> Data(true),
+              "exampleAnnotation2Args" -> Data.list(),
+              "parentAnnotations" -> Data(0),
+              "childAnnotations" -> Data(0)
+            )
+          )
+        ),
+        "constructor" -> Data.list()
+      )
+    }
+
+    test("filters case class constructor parameter annotations by type, decoding constructor args") {
+      testAnnotationsOfType[examples.methods.WithAnnotatedParams]("") <==> Data.map(
+        "type" -> Data.map(
+          "hasExampleAnnotation" -> Data(false),
+          "hasExampleAnnotation2" -> Data(false),
+          "exampleAnnotation2Args" -> Data.list(),
+          "parentAnnotations" -> Data(0),
+          "childAnnotations" -> Data(0)
+        ),
+        "method" -> Data("<no method requested>"),
+        "constructor" -> Data.list(
+          Data.map(
+            "name" -> Data("a"),
+            "hasExampleAnnotation" -> Data(true),
+            "exampleAnnotation2Args" -> Data.list(),
+            "parentAnnotations" -> Data(0),
+            "childAnnotations" -> Data(0)
+          ),
+          Data.map(
+            "name" -> Data("b"),
+            "hasExampleAnnotation" -> Data(false),
+            "exampleAnnotation2Args" -> Data.list(Data.list(Data("1"))),
+            "parentAnnotations" -> Data(0),
+            "childAnnotations" -> Data(0)
+          ),
+          Data.map(
+            "name" -> Data("c"),
+            "hasExampleAnnotation" -> Data(false),
+            "exampleAnnotation2Args" -> Data.list(),
+            "parentAnnotations" -> Data(0),
+            "childAnnotations" -> Data(0)
+          )
+        )
+      )
+    }
+
+    test("<:< filtering matches annotation subtypes by their base type (type, method and parameter)") {
+      testAnnotationsOfType[examples.methods.WithChildAnnotation]("annotatedMethod") <==> Data.map(
+        "type" -> Data.map(
+          "hasExampleAnnotation" -> Data(false),
+          "hasExampleAnnotation2" -> Data(false),
+          "exampleAnnotation2Args" -> Data.list(),
+          "parentAnnotations" -> Data(1),
+          "childAnnotations" -> Data(1)
+        ),
+        "method" -> Data.map(
+          "hasExampleAnnotation" -> Data(false),
+          "hasExampleAnnotation2" -> Data(false),
+          "exampleAnnotation2Args" -> Data.list(),
+          "parentAnnotations" -> Data(1),
+          "childAnnotations" -> Data(1),
+          "parameters" -> Data.list(
+            Data.map(
+              "name" -> Data("arg"),
+              "hasExampleAnnotation" -> Data(false),
+              "exampleAnnotation2Args" -> Data.list(),
+              "parentAnnotations" -> Data(1),
+              "childAnnotations" -> Data(1)
+            )
+          )
+        ),
+        "constructor" -> Data.list()
+      )
+    }
+
+    test("<:< filtering does not match a base annotation when its subtype is requested") {
+      testAnnotationsOfType[examples.methods.WithChildAnnotation]("annotatedMethod2") <==> Data.map(
+        "type" -> Data.map(
+          "hasExampleAnnotation" -> Data(false),
+          "hasExampleAnnotation2" -> Data(false),
+          "exampleAnnotation2Args" -> Data.list(),
+          "parentAnnotations" -> Data(1),
+          "childAnnotations" -> Data(1)
+        ),
+        "method" -> Data.map(
+          "hasExampleAnnotation" -> Data(false),
+          "hasExampleAnnotation2" -> Data(true),
+          "exampleAnnotation2Args" -> Data.list(Data.list(Data("42"))),
+          "parentAnnotations" -> Data(1),
+          "childAnnotations" -> Data(0),
+          "parameters" -> Data.list(
+            Data.map(
+              "name" -> Data("arg"),
+              "hasExampleAnnotation" -> Data(false),
+              "exampleAnnotation2Args" -> Data.list(),
+              "parentAnnotations" -> Data(0),
+              "childAnnotations" -> Data(0)
+            )
+          )
+        ),
+        "constructor" -> Data.list()
+      )
+    }
+
+    test("typed annotation expression from annotationsOfType decodes to values at macro time") {
+      testAnnotationValueDecoded[examples.methods.NoCompanionClass] <==> Data.map(
+        "wholeAnnotation" -> Data("1"),
+        "firstArgument" -> Data("1")
+      )
+    }
+  }
+
   group("methods: fold on abstract trait method") {
     import MethodsFixtures.testCallInstanceViaFold
 

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -1610,6 +1610,282 @@ final class MethodsSpec extends MacroSuite {
         }
       }
 
+      // Regression for commit 68e1781: a `var` constructor parameter produces a getter and a setter (name_=);
+      // only the getter may be flagged as a constructor argument / case field — the setter must not be.
+      group("regression: setters are not constructor arguments nor case fields") {
+        import MethodsFixtures.testMethodProperties
+
+        test("plain class with var constructor parameter: getter is the constructor argument") {
+          testMethodProperties[examples.methods.WithVarCtorParam]("name") <==> Data.map(
+            "name" -> Data.map(
+              "invocation" -> Data("OnInstance"),
+              "hasTypeParameters" -> Data(false),
+              "position" -> methodsPosition(111, 33),
+              "annotations" -> Data.list(),
+              "isConstructor" -> Data(false),
+              "isVal" -> Data(false),
+              "isVar" -> Data(true),
+              "isLazy" -> Data(false),
+              "isDef" -> Data(false),
+              "isFinal" -> Data(false),
+              "isAbstract" -> Data(false),
+              "isOverride" -> Data(false),
+              "isImplicit" -> Data(false),
+              "isDeclared" -> Data(true),
+              "isSynthetic" -> Data(false),
+              "isInherited" -> Data(false),
+              "isAvailable(Everywhere)" -> Data(true),
+              "isAvailable(AtCallSite)" -> Data(true),
+              "arity" -> Data(0),
+              "isNullary" -> Data(true),
+              "isUnary" -> Data(false),
+              "isBinary" -> Data(false),
+              "isConstructorArgument" -> Data(true),
+              "isCaseField" -> Data(false),
+              "isScalaGetter" -> Data(true),
+              "isScalaSetter" -> Data(false),
+              "isScalaAccessor" -> Data(true),
+              "isJavaGetter" -> Data(false),
+              "isJavaSetter" -> Data(false),
+              "isJavaAccessor" -> Data(false),
+              "isAccessor" -> Data(true),
+              "scalaAccessorName" -> Data("name"),
+              "javaAccessorName" -> Data("<no java accessor name>"),
+              "accessorName" -> Data("name")
+            )
+          )
+        }
+
+        test("plain class with var constructor parameter: setter is not a constructor argument") {
+          testMethodProperties[examples.methods.WithVarCtorParam]("name_=") <==> Data.map(
+            "name_=(String)" -> Data.map(
+              "invocation" -> Data("OnInstance"),
+              "hasTypeParameters" -> Data(false),
+              "position" -> methodsPosition(111, 33),
+              "annotations" -> Data.list(),
+              "isConstructor" -> Data(false),
+              "isVal" -> Data(false),
+              "isVar" -> Data(true),
+              "isLazy" -> Data(false),
+              "isDef" -> Data(true),
+              "isFinal" -> Data(false),
+              "isAbstract" -> Data(false),
+              "isOverride" -> Data(false),
+              "isImplicit" -> Data(false),
+              "isDeclared" -> Data(true),
+              "isSynthetic" -> Data(false),
+              "isInherited" -> Data(false),
+              "isAvailable(Everywhere)" -> Data(true),
+              "isAvailable(AtCallSite)" -> Data(true),
+              "arity" -> Data(1),
+              "isNullary" -> Data(false),
+              "isUnary" -> Data(true),
+              "isBinary" -> Data(false),
+              "isConstructorArgument" -> Data(false),
+              "isCaseField" -> Data(false),
+              "isScalaGetter" -> Data(false),
+              "isScalaSetter" -> Data(true),
+              "isScalaAccessor" -> Data(true),
+              "isJavaGetter" -> Data(false),
+              "isJavaSetter" -> Data(false),
+              "isJavaAccessor" -> Data(false),
+              "isAccessor" -> Data(true),
+              "scalaAccessorName" -> Data("name"),
+              "javaAccessorName" -> Data("<no java accessor name>"),
+              "accessorName" -> Data("name")
+            )
+          )
+        }
+
+        test("case class with var constructor parameter: getter is a case field") {
+          testMethodProperties[examples.methods.CaseClassWithVarCtorParam]("name") <==> Data.map(
+            "name" -> Data.map(
+              "invocation" -> Data("OnInstance"),
+              "hasTypeParameters" -> Data(false),
+              "position" -> methodsPosition(113, 32),
+              "annotations" -> Data.list(),
+              "isConstructor" -> Data(false),
+              "isVal" -> Data(false),
+              "isVar" -> Data(true),
+              "isLazy" -> Data(false),
+              "isDef" -> Data(false),
+              "isFinal" -> Data(false),
+              "isAbstract" -> Data(false),
+              "isOverride" -> Data(false),
+              "isImplicit" -> Data(false),
+              "isDeclared" -> Data(true),
+              "isSynthetic" -> Data(false),
+              "isInherited" -> Data(false),
+              "isAvailable(Everywhere)" -> Data(true),
+              "isAvailable(AtCallSite)" -> Data(true),
+              "arity" -> Data(0),
+              "isNullary" -> Data(true),
+              "isUnary" -> Data(false),
+              "isBinary" -> Data(false),
+              "isConstructorArgument" -> Data(true),
+              "isCaseField" -> Data(true),
+              "isScalaGetter" -> Data(true),
+              "isScalaSetter" -> Data(false),
+              "isScalaAccessor" -> Data(true),
+              "isJavaGetter" -> Data(false),
+              "isJavaSetter" -> Data(false),
+              "isJavaAccessor" -> Data(false),
+              "isAccessor" -> Data(true),
+              "scalaAccessorName" -> Data("name"),
+              "javaAccessorName" -> Data("<no java accessor name>"),
+              "accessorName" -> Data("name")
+            )
+          )
+        }
+
+        test("case class with var constructor parameter: setter is not a case field") {
+          testMethodProperties[examples.methods.CaseClassWithVarCtorParam]("name_=") <==> Data.map(
+            "name_=(String)" -> Data.map(
+              "invocation" -> Data("OnInstance"),
+              "hasTypeParameters" -> Data(false),
+              "position" -> methodsPosition(113, 32),
+              "annotations" -> Data.list(),
+              "isConstructor" -> Data(false),
+              "isVal" -> Data(false),
+              "isVar" -> Data(true),
+              "isLazy" -> Data(false),
+              "isDef" -> Data(true),
+              "isFinal" -> Data(false),
+              "isAbstract" -> Data(false),
+              "isOverride" -> Data(false),
+              "isImplicit" -> Data(false),
+              "isDeclared" -> Data(true),
+              "isSynthetic" -> Data(false),
+              "isInherited" -> Data(false),
+              "isAvailable(Everywhere)" -> Data(true),
+              "isAvailable(AtCallSite)" -> Data(true),
+              "arity" -> Data(1),
+              "isNullary" -> Data(false),
+              "isUnary" -> Data(true),
+              "isBinary" -> Data(false),
+              "isConstructorArgument" -> Data(false),
+              "isCaseField" -> Data(false),
+              "isScalaGetter" -> Data(false),
+              "isScalaSetter" -> Data(true),
+              "isScalaAccessor" -> Data(true),
+              "isJavaGetter" -> Data(false),
+              "isJavaSetter" -> Data(false),
+              "isJavaAccessor" -> Data(false),
+              "isAccessor" -> Data(true),
+              "scalaAccessorName" -> Data("name"),
+              "javaAccessorName" -> Data("<no java accessor name>"),
+              "accessorName" -> Data("name")
+            )
+          )
+        }
+      }
+
+      // Regression for commit 68e1781: visibility declared on a var (private[examples]) must propagate
+      // from the getter/val to the synthesized setter (counter_=), on both platforms.
+      group("regression: setter inherits the visibility of its var") {
+        import MethodsFixtures.{testMethodProperties, testMethodVisibility}
+
+        // The original motivation for the fix: scala.collection.immutable.:: declares
+        // `private[scala] var next` — for the precompiled stdlib class on Scala 3 the synthesized
+        // setter symbol does not carry the visibility flags itself, so they must be looked up on the field.
+        test("private[scala] var next of scala.collection.immutable.:: restricts the setter too") {
+          testMethodVisibility[scala.collection.immutable.::[Int]]("next") <==> Data.map(
+            "next" -> Data.map(
+              "isAvailable(Everywhere)" -> Data(false),
+              "isAvailable(AtCallSite)" -> Data(false)
+            )
+          )
+          testMethodVisibility[scala.collection.immutable.::[Int]]("next_=") <==> Data.map(
+            "next_=" -> Data.map(
+              "isAvailable(Everywhere)" -> Data(false),
+              "isAvailable(AtCallSite)" -> Data(false)
+            )
+          )
+        }
+
+        test("restricted var getter is not available outside its scope") {
+          testMethodProperties[examples.methods.WithRestrictedVar]("counter") <==> Data.map(
+            "counter" -> Data.map(
+              "invocation" -> Data("OnInstance"),
+              "hasTypeParameters" -> Data(false),
+              "position" -> methodsPosition(116, 24),
+              "annotations" -> Data.list(),
+              "isConstructor" -> Data(false),
+              "isVal" -> Data(false),
+              "isVar" -> Data(true),
+              "isLazy" -> Data(false),
+              "isDef" -> Data(false),
+              "isFinal" -> Data(false),
+              "isAbstract" -> Data(false),
+              "isOverride" -> Data(false),
+              "isImplicit" -> Data(false),
+              "isDeclared" -> Data(true),
+              "isSynthetic" -> Data(false),
+              "isInherited" -> Data(false),
+              "isAvailable(Everywhere)" -> Data(false),
+              "isAvailable(AtCallSite)" -> Data(false),
+              "arity" -> Data(0),
+              "isNullary" -> Data(true),
+              "isUnary" -> Data(false),
+              "isBinary" -> Data(false),
+              "isConstructorArgument" -> Data(false),
+              "isCaseField" -> Data(false),
+              "isScalaGetter" -> Data(true),
+              "isScalaSetter" -> Data(false),
+              "isScalaAccessor" -> Data(true),
+              "isJavaGetter" -> Data(false),
+              "isJavaSetter" -> Data(false),
+              "isJavaAccessor" -> Data(false),
+              "isAccessor" -> Data(true),
+              "scalaAccessorName" -> Data("counter"),
+              "javaAccessorName" -> Data("<no java accessor name>"),
+              "accessorName" -> Data("counter")
+            )
+          )
+        }
+
+        test("restricted var setter is not available outside its scope either") {
+          testMethodProperties[examples.methods.WithRestrictedVar]("counter_=") <==> Data.map(
+            "counter_=(Int)" -> Data.map(
+              "invocation" -> Data("OnInstance"),
+              "hasTypeParameters" -> Data(false),
+              "position" -> methodsPosition(116, 24),
+              "annotations" -> Data.list(),
+              "isConstructor" -> Data(false),
+              "isVal" -> Data(false),
+              "isVar" -> Data(true),
+              "isLazy" -> Data(false),
+              "isDef" -> Data(true),
+              "isFinal" -> Data(false),
+              "isAbstract" -> Data(false),
+              "isOverride" -> Data(false),
+              "isImplicit" -> Data(false),
+              "isDeclared" -> Data(true),
+              "isSynthetic" -> Data(false),
+              "isInherited" -> Data(false),
+              "isAvailable(Everywhere)" -> Data(false),
+              "isAvailable(AtCallSite)" -> Data(false),
+              "arity" -> Data(1),
+              "isNullary" -> Data(false),
+              "isUnary" -> Data(true),
+              "isBinary" -> Data(false),
+              "isConstructorArgument" -> Data(false),
+              "isCaseField" -> Data(false),
+              "isScalaGetter" -> Data(false),
+              "isScalaSetter" -> Data(true),
+              "isScalaAccessor" -> Data(true),
+              "isJavaGetter" -> Data(false),
+              "isJavaSetter" -> Data(false),
+              "isJavaAccessor" -> Data(false),
+              "isAccessor" -> Data(true),
+              "scalaAccessorName" -> Data("counter"),
+              "javaAccessorName" -> Data("<no java accessor name>"),
+              "accessorName" -> Data("counter")
+            )
+          )
+        }
+      }
+
       group("calling methods, return Expr with a called method result") {
         import MethodsFixtures.testCallNoInstanceIntMethod
         import MethodsFixtures.testCallInstanceIntMethod

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -2102,6 +2102,41 @@ final class MethodsSpec extends MacroSuite {
       }
     }
 
+    group("method calling via foldF") {
+
+      test("nullary — nullaryNoParamList returns 42") {
+        MethodsFixtures.testCallInstanceViaFoldF(new examples.methods.NullaryMethods)("nullaryNoParamList")() <==>
+          Data("42")
+      }
+
+      test("singleParamList(1, test) returns true") {
+        MethodsFixtures.testCallInstanceViaFoldF(new examples.methods.MultiParamListMethods)("singleParamList")(
+          1
+        ) <==> Data("true")
+      }
+
+      test("multiParamList(1)(test) returns true") {
+        MethodsFixtures.testCallInstanceViaFoldF(new examples.methods.MultiParamListMethods)("multiParamList")(
+          1
+        ) <==> Data("true")
+      }
+
+      test("missing required Int argument short-circuits the whole foldF to None") {
+        MethodsFixtures.testCallInstanceViaFoldF(new examples.methods.MultiParamListMethods)(
+          "singleParamList"
+        )() <==> Data("<not applicable>")
+      }
+
+      test("wrong application — providing no arguments at all fails with a requirement error") {
+        MethodsFixtures.testCallInstanceViaFoldMissingArgs(new examples.methods.MultiParamListMethods)(
+          "singleParamList"
+        ) <==> Data(
+          "REQUIREMENT FAILED: Expected that hearth.examples.methods.MultiParamListMethods's singleParamList parameter `arg1` would be provided or have a default value.\n" +
+            "Ensure that all arguments are provided or have a default value."
+        )
+      }
+    }
+
     group("prettyPrint (ANSI coloring)") {
 
       test("prettyPrint stripped of ANSI equals plainPrint — nullary") {

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -1504,7 +1504,9 @@ final class MethodsSpec extends MacroSuite {
           testParameterProperties[examples.methods.WithImplicits]("methodWithImplicitParam") <==> Data.map(
             "x" -> Data.map(
               "isImplicit" -> Data(true),
-              "hasDefault" -> Data(false)
+              "hasDefault" -> Data(false),
+              "isByName" -> Data(false),
+              "isVararg" -> Data(false)
             )
           )
         }
@@ -1513,7 +1515,9 @@ final class MethodsSpec extends MacroSuite {
           testParameterProperties[examples.methods.WithImplicits]("implicitConversion") <==> Data.map(
             "x" -> Data.map(
               "isImplicit" -> Data(false),
-              "hasDefault" -> Data(false)
+              "hasDefault" -> Data(false),
+              "isByName" -> Data(false),
+              "isVararg" -> Data(false)
             )
           )
         }
@@ -1522,8 +1526,86 @@ final class MethodsSpec extends MacroSuite {
           testParameterProperties[examples.methods.NoCompanionClass]("method") <==> Data.map(
             "arg" -> Data.map(
               "isImplicit" -> Data(false),
-              "hasDefault" -> Data(false)
+              "hasDefault" -> Data(false),
+              "isByName" -> Data(false),
+              "isVararg" -> Data(false)
             )
+          )
+        }
+      }
+
+      group("isVararg: vararg (repeated) parameter detection and calls") {
+        import MethodsFixtures.{testCallVarargIntMethod, testConstructVarargCtor, testParameterProperties}
+
+        test("parameter-level isVararg for vararg method parameter") {
+          testParameterProperties[examples.methods.WithVarargs]("varargMethod") <==> Data.map(
+            "xs" -> Data.map(
+              "isImplicit" -> Data(false),
+              "hasDefault" -> Data(false),
+              "isByName" -> Data(false),
+              "isVararg" -> Data(true)
+            )
+          )
+        }
+
+        test("parameter-level isVararg is false for normal parameter") {
+          testParameterProperties[examples.methods.WithVarargs]("normalMethod") <==> Data.map(
+            "x" -> Data.map(
+              "isImplicit" -> Data(false),
+              "hasDefault" -> Data(false),
+              "isByName" -> Data(false),
+              "isVararg" -> Data(false)
+            )
+          )
+        }
+
+        test("parameter-level isVararg is false for by-name parameter") {
+          testParameterProperties[examples.methods.WithVarargs]("byNameMethod") <==> Data.map(
+            "x" -> Data.map(
+              "isImplicit" -> Data(false),
+              "hasDefault" -> Data(false),
+              "isByName" -> Data(true),
+              "isVararg" -> Data(false)
+            )
+          )
+        }
+
+        test("parameter-level isVararg for vararg constructor parameter") {
+          MethodsFixtures.testConstructorsExtraction[examples.methods.WithVarargsCtor] <==> Data.map(
+            "primaryConstructor" -> Data("(xs: scala.collection.immutable.Seq[java.lang.String])"),
+            "defaultConstructor" -> Data("<no default constructor>"),
+            "constructors" -> Data.list(
+              Data("(xs: scala.collection.immutable.Seq[java.lang.String])")
+            )
+          )
+        }
+
+        test("vararg method rendered as A* in plainPrint") {
+          val data = MethodsFixtures.testMethodPrettyPrint[examples.methods.WithVarargs]("varargMethod")
+          val map = data.asList.get.head.asMap.get
+          val plain = map("plainPrint").asString.get
+          val stripped = map("prettyPrintStripped").asString.get
+          assert(plain.contains("(xs: scala.Int*)"), s"plainPrint should render vararg as scala.Int*, got: $plain")
+          assert(stripped == plain, s"stripped: $stripped\nplain:    $plain")
+        }
+
+        test("calling a vararg method with multiple values via Method API") {
+          testCallVarargIntMethod[examples.methods.WithVarargs](new examples.methods.WithVarargs)("varargMethod")(
+            1,
+            2,
+            3
+          ) ==> 6
+        }
+
+        test("calling a vararg method with no values via Method API") {
+          testCallVarargIntMethod[examples.methods.WithVarargs](new examples.methods.WithVarargs)(
+            "varargMethod"
+          )() ==> 0
+        }
+
+        test("constructing a class with vararg constructor via Method API") {
+          testConstructVarargCtor[examples.methods.WithVarargsCtor]("a", "b", "c") <==> Data(
+            "WithVarargsCtor(a,b,c)"
           )
         }
       }

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -2536,7 +2536,7 @@ final class MethodsSpec extends MacroSuite {
   }
 
   group("methods: annotationsOfType and constructorArguments") {
-    import MethodsFixtures.{testAnnotationsOfType, testAnnotationValueDecoded}
+    import MethodsFixtures.{testAnnotationsOfType, testAnnotationValueDecoded, testFieldNameReproducer}
 
     test("filters type and method annotations by type, decoding constructor args (present and absent cases)") {
       testAnnotationsOfType[examples.methods.NoCompanionClass]("methodWithAnnotation") <==> Data.map(
@@ -2694,6 +2694,23 @@ final class MethodsSpec extends MacroSuite {
       testAnnotationValueDecoded[examples.methods.NoCompanionClass] <==> Data.map(
         "wholeAnnotation" -> Data("1"),
         "firstArgument" -> Data("1")
+      )
+    }
+
+    test(
+      "issue #283 reproducer: @fieldName(\"first_name\") on case class ctor param decodes String/Boolean/Double literals"
+    ) {
+      testFieldNameReproducer[examples.methods.Person] <==> Data.list(
+        Data.map(
+          "name" -> Data("firstName"),
+          "fieldNames" -> Data.list(Data("first_name")),
+          "fieldFlags" -> Data.list()
+        ),
+        Data.map(
+          "name" -> Data("age"),
+          "fieldNames" -> Data.list(Data("age")),
+          "fieldFlags" -> Data.list(Data.list(Data("true"), Data("1.5")))
+        )
       )
     }
   }

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -2698,6 +2698,34 @@ final class MethodsSpec extends MacroSuite {
     }
   }
 
+  group("methods: splicing annotation exprs into macro output") {
+    import MethodsFixtures.testSplicedAnnotationValue
+
+    test("type annotation expr spliced into generated code evaluates at runtime") {
+      testSplicedAnnotationValue[examples.methods.NoCompanionClass]("") <==> Data.map(
+        "typeValue" -> Data(1),
+        "methodValue" -> Data(-1),
+        "parameterValue" -> Data(-1)
+      )
+    }
+
+    test("method annotation expr spliced into generated code evaluates at runtime") {
+      testSplicedAnnotationValue[examples.methods.WithChildAnnotation]("annotatedMethod2") <==> Data.map(
+        "typeValue" -> Data(-1),
+        "methodValue" -> Data(42),
+        "parameterValue" -> Data(-1)
+      )
+    }
+
+    test("constructor parameter annotation expr spliced into generated code evaluates at runtime") {
+      testSplicedAnnotationValue[examples.methods.WithAnnotatedParams]("") <==> Data.map(
+        "typeValue" -> Data(-1),
+        "methodValue" -> Data(-1),
+        "parameterValue" -> Data(1)
+      )
+    }
+  }
+
   group("methods: fold on abstract trait method") {
     import MethodsFixtures.testCallInstanceViaFold
 

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -2094,6 +2094,54 @@ final class MethodsSpec extends MacroSuite {
     }
   }
 
+  group("methods: parameter annotations") {
+    import MethodsFixtures.{testConstructorParameterAnnotations, testParameterAnnotations}
+
+    test("method parameter annotations are typed and destructurable") {
+      testParameterAnnotations[examples.methods.NoCompanionClass]("methodWithAnnotatedParam") <==> Data.list(
+        Data.map(
+          "name" -> Data("arg"),
+          "annotations" -> Data.list(
+            Data.map(
+              "isExampleAnnotation" -> Data(true),
+              "isExampleAnnotation2" -> Data(false),
+              "destructuredArgs" -> Data("")
+            )
+          )
+        )
+      )
+    }
+
+    test("case class constructor parameter annotations are typed and destructurable") {
+      testConstructorParameterAnnotations[examples.methods.WithAnnotatedParams] <==> Data.list(
+        Data.map(
+          "name" -> Data("a"),
+          "annotations" -> Data.list(
+            Data.map(
+              "isExampleAnnotation" -> Data(true),
+              "isExampleAnnotation2" -> Data(false),
+              "destructuredArgs" -> Data("")
+            )
+          )
+        ),
+        Data.map(
+          "name" -> Data("b"),
+          "annotations" -> Data.list(
+            Data.map(
+              "isExampleAnnotation" -> Data(false),
+              "isExampleAnnotation2" -> Data(true),
+              "destructuredArgs" -> Data("1")
+            )
+          )
+        ),
+        Data.map(
+          "name" -> Data("c"),
+          "annotations" -> Data.list()
+        )
+      )
+    }
+  }
+
   group("methods: fold on abstract trait method") {
     import MethodsFixtures.testCallInstanceViaFold
 

--- a/hearth-tests/src/test/scala/hearth/typed/TypesSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/TypesSpec.scala
@@ -1757,6 +1757,125 @@ final class TypesSpec extends MacroSuite {
           )
         }
       }
+
+      group("methods: Type.{typeArguments, decompose1, decompose2}, Ctor.sameTypeConstructorAs, expected behavior") {
+        import TypesFixtures.{
+          testTypeArguments,
+          testDecompose1,
+          testDecompose2,
+          testMiniFunctorDerivation,
+          testDecomposeSummonName,
+          testCtorK1FromDiscoveredParts
+        }
+
+        test("typeArguments returns type arguments of applied types and Nil otherwise") {
+          testTypeArguments[List[Int]] <==> Data.map(
+            "Type.typeArguments" -> Data.list(Data("scala.Int"))
+          )
+          testTypeArguments[Map[String, Int]] <==> Data.map(
+            "Type.typeArguments" -> Data.list(Data("java.lang.String"), Data("scala.Int"))
+          )
+          testTypeArguments[Int] <==> Data.map(
+            "Type.typeArguments" -> Data.list()
+          )
+        }
+
+        test("decompose1 on an applied unary type returns a re-applicable Ctor1 and the type argument") {
+          testDecompose1[List[Int]] <==> Data.map(
+            "decomposed" -> Data(true),
+            "arg" -> Data("scala.Int"),
+            "reappliedToString" -> Data("scala.collection.immutable.List[java.lang.String]"),
+            "sameCtorAsList" -> Data(true),
+            "sameCtorAsOption" -> Data(false),
+            "sameCtorAsSelf" -> Data(true)
+          )
+          testDecompose1[Option[String]] <==> Data.map(
+            "decomposed" -> Data(true),
+            "arg" -> Data("java.lang.String"),
+            "reappliedToString" -> Data("scala.Option[java.lang.String]"),
+            "sameCtorAsList" -> Data(false),
+            "sameCtorAsOption" -> Data(true),
+            "sameCtorAsSelf" -> Data(true)
+          )
+        }
+
+        test("decompose1 on a non-applied type or a non-unary applied type returns None") {
+          testDecompose1[Int] <==> Data.map("decomposed" -> Data(false))
+          testDecompose1[String] <==> Data.map("decomposed" -> Data(false))
+          testDecompose1[Map[String, Int]] <==> Data.map("decomposed" -> Data(false))
+        }
+
+        test("decompose2 on an applied binary type returns a re-applicable Ctor2 and the type arguments") {
+          testDecompose2[Map[String, Int]] <==> Data.map(
+            "decomposed" -> Data(true),
+            "arg1" -> Data("java.lang.String"),
+            "arg2" -> Data("scala.Int"),
+            "reappliedToStringInt" -> Data("scala.collection.immutable.Map[java.lang.String, scala.Int]"),
+            "sameCtorAsMap" -> Data(true),
+            "sameCtorAsEither" -> Data(false)
+          )
+          testDecompose2[Either[Int, String]] <==> Data.map(
+            "decomposed" -> Data(true),
+            "arg1" -> Data("scala.Int"),
+            "arg2" -> Data("java.lang.String"),
+            "reappliedToStringInt" -> Data("scala.util.Either[java.lang.String, scala.Int]"),
+            "sameCtorAsMap" -> Data(false),
+            "sameCtorAsEither" -> Data(true)
+          )
+          testDecompose2[List[Int]] <==> Data.map("decomposed" -> Data(false))
+          testDecompose2[Int] <==> Data.map("decomposed" -> Data(false))
+        }
+
+        test("decompose1/decompose2 dealias before decomposing") {
+          @scala.annotation.unused
+          type StringMap[V] = Map[String, V]
+          testDecompose1[StringMap[Int]] <==> Data.map("decomposed" -> Data(false))
+          testDecompose2[StringMap[Int]] <==> Data.map(
+            "decomposed" -> Data(true),
+            "arg1" -> Data("java.lang.String"),
+            "arg2" -> Data("scala.Int"),
+            "reappliedToStringInt" -> Data("scala.collection.immutable.Map[java.lang.String, scala.Int]"),
+            "sameCtorAsMap" -> Data(true),
+            "sameCtorAsEither" -> Data(false)
+          )
+        }
+
+        test("mini-Functor derivation: discover each field's constructor, compare, re-apply, summon type class") {
+          testMiniFunctorDerivation[examples.kinds.Box[Int]] <==> Data.map(
+            "items" -> Data.map(
+              "arg" -> Data("scala.Int"),
+              "reappliedToString" -> Data("scala.collection.immutable.List[java.lang.String]"),
+              "isList" -> Data(true),
+              "isOption" -> Data(false),
+              "myTCInstanceFound" -> Data(true)
+            ),
+            "maybe" -> Data.map(
+              "arg" -> Data("scala.Int"),
+              "reappliedToString" -> Data("scala.Option[java.lang.String]"),
+              "isList" -> Data(false),
+              "isOption" -> Data(true),
+              "myTCInstanceFound" -> Data(true)
+            )
+          )
+        }
+
+        test("summoning a type-class instance for a discovered constructor finds the RIGHT instance") {
+          testDecomposeSummonName[List[Int]] <==> "MyTC[List]"
+          testDecomposeSummonName[Option[String]] <==> "MyTC[Option]"
+          testDecomposeSummonName[Vector[Int]] <==> "<no instance found>"
+          testDecomposeSummonName[Int] <==> "<not an applied type>"
+        }
+
+        test(
+          "CtorK1 applied to a discovered Ctor1, where the CtorK1 itself was discovered from an untyped constructor"
+        ) {
+          testCtorK1FromDiscoveredParts[List[Int]] <==> Data.map(
+            "appliedSameCtorAsAlg" -> Data(true),
+            "memberCtorMatches" -> Data(true)
+          )
+          testCtorK1FromDiscoveredParts[Int] <==> Data.map("error" -> Data("not an applied type"))
+        }
+      }
     }
 
     group("type TypeCodec") {

--- a/hearth-tests/src/test/scala/hearth/typed/TypesSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/TypesSpec.scala
@@ -91,6 +91,24 @@ final class TypesSpec extends MacroSuite {
           )
         }
 
+        // Pins the current behavior for wildcard (Scala 3) / existential (Scala 2) type arguments.
+        test("for wildcard type arguments (pinned current behavior)") {
+          testNamesPrinters[List[?]] <==> Data.map(
+            "Type.shortName" -> Data("List"),
+            "Type.fqcn" -> Data("scala.collection.immutable.List"),
+            // Scala 3 keeps the wildcard as explicit type bounds, while on Scala 2 the wildcard passed as
+            // a type argument is absorbed into its upper bound (Any) by the time the macro sees it.
+            "Type.plainPrint" -> Data(
+              if (LanguageVersion.byHearth.isScala3) "scala.collection.immutable.List[_ >: scala.Nothing <: scala.Any]"
+              else "scala.collection.immutable.List[scala.Any]"
+            ),
+            "Type.prettyPrint" -> Data(
+              if (LanguageVersion.byHearth.isScala3) "scala.collection.immutable.List[_ >: scala.Nothing <: scala.Any]"
+              else "scala.collection.immutable.List[scala.Any]"
+            )
+          )
+        }
+
         test("for top-level classes (non-sealed)") {
           List(
             testNamesPrinters[examples.classes.ExampleTrait] -> (("ExampleTrait", "")),
@@ -877,6 +895,39 @@ final class TypesSpec extends MacroSuite {
               "Type.isAvailable(AtCallSite)" -> Data(true)
             )
           }
+        }
+
+        // Pins the current behavior of predicates for wildcard (Scala 3) / existential (Scala 2) type arguments.
+        test("for wildcard type arguments (pinned current behavior)") {
+          testFlags[List[?]] <==> Data.map(
+            "Type.isPrimitive" -> Data(false),
+            "Type.isArray" -> Data(false),
+            "Type.isIArray" -> Data(false),
+            "Type.isJvmBuiltIn" -> Data(false),
+            "Type.isAbstract" -> Data(true),
+            "Type.isFinal" -> Data(false),
+            "Type.isClass" -> Data(true),
+            "Type.isTypeSystemSpecial" -> Data(false),
+            "Type.isOpaqueType" -> Data(false),
+            "Type.isTuple" -> Data(false),
+            "Type.isNamedTuple" -> Data(false),
+            "Type.isUnionType" -> Data(false),
+            "Type.notJvmBuiltInClass" -> Data(true),
+            "Type.isPlainOldJavaObject" -> Data(false),
+            "Type.isJavaBean" -> Data(false),
+            "Type.isSealed" -> Data(true),
+            "Type.isJavaEnum" -> Data(false),
+            "Type.isJavaEnumValue" -> Data(false),
+            "Type.isEnumeration" -> Data(false),
+            "Type.isCase" -> Data(false),
+            "Type.isObject" -> Data(false),
+            "Type.isVal" -> Data(false),
+            "Type.isCaseClass" -> Data(false),
+            "Type.isCaseObject" -> Data(false),
+            "Type.isCaseVal" -> Data(false),
+            "Type.isAvailable(Everywhere)" -> Data(true),
+            "Type.isAvailable(AtCallSite)" -> Data(true)
+          )
         }
 
         test("for built-in types") {

--- a/hearth-tests/src/test/scala/hearth/typed/TypesSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/TypesSpec.scala
@@ -1257,6 +1257,22 @@ final class TypesSpec extends MacroSuite {
         }
       }
 
+      group("methods: Type.{opaqueUnderlyingType} expected behavior") {
+        import TypesFixtures.testOpaqueUnderlyingType
+
+        // Scala 3-only opaque types are tested in TypesScala3Spec; on Scala 2 the API always returns None.
+        test("for non-opaque types") {
+          testOpaqueUnderlyingType[String] <==> Data.map(
+            "Type.isOpaqueType" -> Data(false),
+            "Type.opaqueUnderlyingType" -> Data("<no underlying type>")
+          )
+          testOpaqueUnderlyingType[examples.classes.ExampleCaseClass] <==> Data.map(
+            "Type.isOpaqueType" -> Data(false),
+            "Type.opaqueUnderlyingType" -> Data("<no underlying type>")
+          )
+        }
+      }
+
       group("methods: <:<, =:=, expected behavior") {
         import TypesFixtures.testComparisons
 

--- a/hearth-tests/src/test/scalajvm/hearth/typed/MethodsJvmSpec.scala
+++ b/hearth-tests/src/test/scalajvm/hearth/typed/MethodsJvmSpec.scala
@@ -766,6 +766,36 @@ final class MethodsJvmSpec extends MacroSuite {
           )
         }
       }
+
+      group("isVararg: Java varargs (int... xs) detection and calls") {
+        import MethodsFixtures.{testCallVarargIntMethod, testParameterProperties}
+
+        test("parameter-level isVararg for Java vararg parameter") {
+          // Java parameter names are not preserved (javac without -parameters), so each platform synthesizes one.
+          val paramName = if (LanguageVersion.byHearth.isScala2_13) "x$1" else "x$0"
+
+          testParameterProperties[examples.classes.ExampleJavaVarargs]("sum") <==> Data.map(
+            paramName -> Data.map(
+              "isImplicit" -> Data(false),
+              "hasDefault" -> Data(false),
+              "isByName" -> Data(false),
+              "isVararg" -> Data(true)
+            )
+          )
+        }
+
+        test("calling a Java vararg method with multiple values via Method API") {
+          testCallVarargIntMethod[examples.classes.ExampleJavaVarargs](
+            new examples.classes.ExampleJavaVarargs
+          )("sum")(1, 2, 3) ==> 6
+        }
+
+        test("calling a Java vararg method with no values via Method API") {
+          testCallVarargIntMethod[examples.classes.ExampleJavaVarargs](
+            new examples.classes.ExampleJavaVarargs
+          )("sum")() ==> 0
+        }
+      }
     }
   }
 }

--- a/hearth/src/main/scala-2/hearth/EnvironmentsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/EnvironmentsScala2.scala
@@ -43,9 +43,13 @@ trait EnvironmentsScala2 extends Environments { this: MacroCommonsScala2 =>
     override lazy val XMacroSettings: List[String] = c.settings
 
     override def reportInfo(msg: String): Unit = c.echo(c.enclosingPosition, msg)
+    override def reportInfo(msg: String, position: Position): Unit = c.echo(position, msg)
     override def reportWarn(msg: String): Unit = c.warning(c.enclosingPosition, msg)
+    override def reportWarn(msg: String, position: Position): Unit = c.warning(position, msg)
     override def reportError(msg: String): Unit = c.error(c.enclosingPosition, msg)
+    override def reportError(msg: String, position: Position): Unit = c.error(position, msg)
     override def reportErrorAndAbort(msg: String): Nothing = c.abort(c.enclosingPosition, msg)
+    override def reportErrorAndAbort(msg: String, position: Position): Nothing = c.abort(position, msg)
   }
 
   /** Do not use this module, it exists only to be used by Scala 2 Cross-Quotes macros and Scala 3 Cross-Quotes compiler

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -1251,6 +1251,14 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
       EqValue(name, matched.as_??, expr.as_??, matched)
     }
 
+    override def typeTestMatch[A: Type, B: Type](freshName: FreshName): MatchCase[Expr[B]] =
+      // $COVERAGE-OFF$ Scala 3-only API, should never be reached on Scala 2
+      assertionFailed(
+        "MatchCase.typeTestMatch is only supported on Scala 3 (scala.reflect.TypeTest does not exist on Scala 2.13). " +
+          "Guard calls with Type.isUnionType / Type.unionMemberRequiresTypeTest, which are always false on Scala 2."
+      )
+    // $COVERAGE-ON$
+
     override def matchOn[A: Type, B: Type](toMatch: Expr[A])(cases: NonEmptyVector[MatchCase[Expr[B]]]): Expr[B] = {
       val caseTrees = cases.toVector.map {
         case TypeMatch(name, expr, result) =>

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -23,7 +23,8 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
 
       final class ExprCodecImpl[A](typeCodec: Option[TypeCodec[A]])(implicit
           val to: Liftable[A],
-          val from: Unliftable[A]
+          val from: Unliftable[A],
+          tag: WeakTypeTag[A]
       ) extends ExprCodec[A] {
 
         override def toExpr(value: A): Expr[A] = typeCodec match {
@@ -31,7 +32,9 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
             val aType = codec.toType(value).as_??
             import aType.Underlying as B
             c.Expr[B](to.apply(value)).asInstanceOf[Expr[A]]
-          case _ => c.Expr[A](to.apply(value))
+          // Quasiquote-built trees are untyped, so Expr.typeOf falls back to the WeakTypeTag - it has to capture
+          // the concrete instantiated type (passed by make/withTypeCodec), not ExprCodecImpl's own type parameter A.
+          case _ => c.Expr[A](to.apply(value))(tag)
         }
 
         override def fromExpr(expr: Expr[A]): Option[A] = from.unapply(expr.tree)
@@ -39,10 +42,10 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
 
       implicit final class ExprCodecCompanionOps(private val self: ExprCodec.type) {
 
-        def make[A: Liftable: Unliftable]: ExprCodec[A] =
+        def make[A: Liftable: Unliftable: Type]: ExprCodec[A] =
           new ExprCodecImpl[A](None)
 
-        def withTypeCodec[A: Liftable: Unliftable: TypeCodec]: ExprCodec[A] =
+        def withTypeCodec[A: Liftable: Unliftable: TypeCodec: Type]: ExprCodec[A] =
           new ExprCodecImpl[A](Some(TypeCodec[A]))
       }
 

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -3659,12 +3659,13 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
         val ctor =
           if (coreSym != null && coreSym != NoSymbol) ctors.find(_.symbol == coreSym).orElse(ctors.headOption)
           else ctors.headOption
-        ctor.map { method =>
+        ctor.map { untypedCtor =>
+          val method = untypedCtor.asTyped[Any](using UntypedType.toTyped[Any](ctorTpe))
           val applied = List.newBuilder[DestructuredExpr.MethodCall.Applied]
-          dstrBuildAppliedSteps(steps, lambdaParams, applied)
+          dstrBuildAppliedSteps(steps, lambdaParams, applied, dstrParameterClauses(method))
           new DestructuredExpr.MethodCall(
             dstrTpeOf(tree),
-            method.asTyped[Any](using UntypedType.toTyped[Any](ctorTpe)),
+            method,
             applied.result(),
             () => tree
           )
@@ -3689,7 +3690,7 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
           dstrResolveMethod(qualTpe, coreSym).map { method =>
             val applied = List.newBuilder[DestructuredExpr.MethodCall.Applied]
             applied += new DestructuredExpr.MethodCall.AppliedInstance(dstrImpl(qualifier, lambdaParams))
-            dstrBuildAppliedSteps(steps, lambdaParams, applied)
+            dstrBuildAppliedSteps(steps, lambdaParams, applied, dstrParameterClauses(method))
             new DestructuredExpr.MethodCall(dstrTpeOf(tree), method, applied.result(), () => tree)
           }
 
@@ -3699,7 +3700,7 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
             val moduleTpe = ownerSym.asModule.moduleClass.asType.toType
             dstrResolveMethod(moduleTpe, coreSym).map { method =>
               val applied = List.newBuilder[DestructuredExpr.MethodCall.Applied]
-              dstrBuildAppliedSteps(steps, lambdaParams, applied)
+              dstrBuildAppliedSteps(steps, lambdaParams, applied, dstrParameterClauses(method))
               new DestructuredExpr.MethodCall(dstrTpeOf(tree), method, applied.result(), () => tree)
             }
           } else None
@@ -3725,14 +3726,53 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
       lambdaParams: Map[Symbol, DestructuredExpr.Lambda.Param],
       applied: scala.collection.mutable.Builder[DestructuredExpr.MethodCall.Applied, List[
         DestructuredExpr.MethodCall.Applied
-      ]]
-  ): Unit =
+      ]],
+      parameterClauses: List[List[Parameter]]
+  ): Unit = {
+    var valueClauseIdx = 0
     steps.foreach {
       case DstrTypeStep(targs) =>
         applied += new DestructuredExpr.MethodCall.AppliedTypes(targs.map(dstrTpeOf))
       case DstrValueStep(args) =>
-        applied += new DestructuredExpr.MethodCall.AppliedValues(args.map(dstrImpl(_, lambdaParams)))
+        val clause = parameterClauses.lift(valueClauseIdx)
+        valueClauseIdx += 1
+        applied += new DestructuredExpr.MethodCall.AppliedValues(dstrValueArgs(args, clause, lambdaParams))
     }
+  }
+
+  /** Destructures one value-argument clause, handling vararg (repeated) parameters.
+    *
+    * On Scala 2 there is no tree-level marker on individual vararg elements (`m(1, 2, 3)` is just an `Apply` with 3
+    * args), so the resolved [[Method]]'s parameter clause is consulted: when the last parameter `isVararg` the trailing
+    * arguments are grouped into one [[DestructuredExpr.Varargs]] slot - mirroring how [[Method.ApplyValues]] expects a
+    * single `Expr[Seq[A]]` argument for the vararg parameter. A spread sequence (`m(seq: _*)`, i.e.
+    * `Typed(seq, Ident(WILDCARD_STAR))`) is left to [[dstrImpl]], whose `Typed` case unwraps it to the sequence
+    * expression itself - matching what Scala 3 produces for `m(seq*)`.
+    */
+  private def dstrValueArgs(
+      args: List[Tree],
+      clause: Option[List[Parameter]],
+      lambdaParams: Map[Symbol, DestructuredExpr.Lambda.Param]
+  ): List[DestructuredExpr] = clause match {
+    case Some(params) if params.lastOption.exists(_.isVararg) && !dstrIsSpreadCall(args, params.size) =>
+      val (regular, repeated) = args.splitAt(params.size - 1)
+      regular.map(dstrImpl(_, lambdaParams)) :+ new DestructuredExpr.Varargs(
+        params.last.tpe,
+        repeated.map(dstrImpl(_, lambdaParams)),
+        () => q"_root_.scala.collection.immutable.Seq(..$repeated)"
+      )
+    case _ =>
+      args.map(dstrImpl(_, lambdaParams))
+  }
+
+  private def dstrIsSpreadCall(args: List[Tree], clauseSize: Int): Boolean =
+    args.lengthCompare(clauseSize) == 0 && (args.lastOption match {
+      case Some(Typed(_, Ident(typeNames.WILDCARD_STAR))) => true
+      case _                                              => false
+    })
+
+  private def dstrParameterClauses(method: Method): List[List[Parameter]] =
+    method.totalParameters.map(_.values.toList)
 
   private def dstrResolveMethod(qualTpe: c.Type, methodSym: Symbol): Option[Method] = {
     val instanceTpe: UntypedType = qualTpe.widen

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
@@ -516,7 +516,8 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
             case ExistentialType(_, underlying) => underlying
             case other                          => other
           }
-          Some(sig.finalResultType.dealias.as_??)
+          // E.g. the case-field accessor of a vararg parameter would otherwise return `scala.<repeated>[A]`.
+          Some(normalizeRepeatedParamType(sig.finalResultType.dealias).as_??)
         }
 
       val buildExpr: (Option[UntypedExpr], UntypedTypeArguments, UntypedArguments) => Either[String, UntypedExpr] =

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
@@ -21,6 +21,10 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
       symbol.annotations.map(_.tree.tpe)
 
     override def isByName: Boolean = symbol.isByNameParam
+    override def isVararg: Boolean = {
+      val tpeSymbol = symbol.typeSignature.typeSymbol
+      tpeSymbol == definitions.RepeatedParamClass || tpeSymbol == definitions.JavaRepeatedParamClass
+    }
     override def isImplicit: Boolean = symbol.isImplicit
     override def hasDefault: Boolean = symbol.asTerm.isParamWithDefault
   }
@@ -31,6 +35,22 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
       if (symbol.isTerm) Right(new UntypedParameter(method, symbol.asTerm, index))
       else Left(s"Expected param Symbol, got $symbol")
   }
+
+  /** Normalizes the raw repeated-parameter marker type `A*` (`scala.<repeated>[A]` / `scala.<repeated...>[A]`) to
+    * `scala.collection.immutable.Seq[A]`, so that [[Parameter.tpe]] is a real, usable type, consistent between Scala 2
+    * and Scala 3. Non-repeated types are returned unchanged.
+    */
+  private def normalizeRepeatedParamType(tpe: c.universe.Type): c.universe.Type = {
+    val tpeSymbol = tpe.typeSymbol
+    if (
+      (tpeSymbol == definitions.RepeatedParamClass || tpeSymbol == definitions.JavaRepeatedParamClass) &&
+      tpe.typeArgs.sizeIs == 1
+    )
+      appliedType(c.typeOf[scala.collection.immutable.Seq[Any]].typeConstructor, tpe.typeArgs)
+    else tpe
+  }
+
+  override protected def adaptVarargArgument(expr: UntypedExpr): UntypedExpr = q"$expr: _*"
 
   object UntypedParameters extends UntypedParametersModule {
 
@@ -68,7 +88,11 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
       untyped.map { params =>
         params.flatMap { case (paramName, untyped) =>
           typesByParamName.get(paramName).map { tpe =>
-            val param = new Parameter(asUntyped = untyped, untypedInstanceType = instanceTpe, tpe = tpe.as_??)
+            val param = new Parameter(
+              asUntyped = untyped,
+              untypedInstanceType = instanceTpe,
+              tpe = normalizeRepeatedParamType(tpe).as_??
+            )
             paramName -> param
           }
         }
@@ -293,6 +317,9 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
           case _                               => false
         }
         def printType(t: c.universe.Type): String = t.dealias match {
+          case TypeRef(_, sym, List(arg))
+              if sym == definitions.RepeatedParamClass || sym == definitions.JavaRepeatedParamClass =>
+            s"${printType(arg)}*"
           case TypeRef(_, sym, Nil) if isTP(sym)                                                    => symbolName(sym)
           case TypeRef(_, sym, Nil) if sym.isType && sym.owner.isClass && !sym.owner.isPackageClass =>
             s"${sym.owner.fullName}#${symbolName(sym)}"

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
@@ -80,7 +80,22 @@ trait UntypedTypesScala2 extends UntypedTypes { this: MacroCommonsScala2 =>
 
       def symbolName(symbol: Symbol): String = symbol.name.decodedName.toString
 
-      def symbolAvailable(symbol: Symbol, scope: Accessible): Boolean = {
+      private val syntheticCaseAccessorName = "(.+)\\$access\\$\\d+".r
+
+      def symbolAvailable(symbol0: Symbol, scope: Accessible): Boolean = {
+        // For a non-public case field `b`, Scala 2 marks the public synthetic accessor `b$access$1` as the case
+        // accessor, while the user-declared member keeps its declared visibility (Scala 3 has no such synthetic
+        // accessor and keeps the restricted `b` as the case accessor). To keep visibility filtering consistent
+        // between the platforms, we answer for the underlying user-declared member instead of the synthetic accessor.
+        val symbol = symbolName(symbol0) match {
+          case syntheticCaseAccessorName(fieldName) if symbol0.isMethod && symbol0.asMethod.isCaseAccessor =>
+            symbol0.owner.typeSignature.member(TermName(fieldName)) match {
+              case NoSymbol   => symbol0
+              case underlying => underlying
+            }
+          case _ => symbol0
+        }
+
         val owner = symbol.owner
         val enclosing = c.internal.enclosingOwner
 
@@ -105,6 +120,7 @@ trait UntypedTypesScala2 extends UntypedTypes { this: MacroCommonsScala2 =>
           case Everywhere => isPublic
           case AtCallSite =>
             isPublic || isPrivateButInTheSameClass || isProtectedButInTheSameClass || isPrivateWithinButInTheRightPlace
+          case Unrestricted => true
         }
       }
 

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
@@ -152,6 +152,9 @@ trait UntypedTypesScala2 extends UntypedTypes { this: MacroCommonsScala2 =>
 
     override def isOpaqueType(instanceTpe: UntypedType): Boolean = false
 
+    // Scala 2 has no opaque types, so there is never an underlying type to resolve.
+    override def opaqueUnderlyingType(instanceTpe: UntypedType): Option[UntypedType] = None
+
     override def isTuple(instanceTpe: UntypedType): Boolean = {
       val A = instanceTpe.typeSymbol
       A != NoSymbol && {

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
@@ -480,11 +480,20 @@ trait UntypedTypesScala2 extends UntypedTypes { this: MacroCommonsScala2 =>
       } else None
     }
 
+    override def dealias(untyped: UntypedType): UntypedType =
+      untyped.dealias
+
+    override def typeConstructor(untyped: UntypedType): UntypedType =
+      untyped.dealias.typeConstructor
+
     override def typeArguments(untyped: UntypedType): List[UntypedType] =
       untyped.typeArgs
 
     override def applyTypeArgs(untyped: UntypedType, args: List[UntypedType]): UntypedType =
       appliedType(untyped.typeConstructor, args)
+
+    override def sameTypeConstructorAs(a: UntypedType, b: UntypedType): Boolean =
+      a.dealias.typeConstructor.typeSymbol == b.dealias.typeConstructor.typeSymbol
 
     override def annotations(untyped: UntypedType): List[UntypedExpr] =
       untyped.typeSymbol.annotations.map(ann => c.untypecheck(ann.tree))

--- a/hearth/src/main/scala-3/hearth/EnvironmentsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/EnvironmentsScala3.scala
@@ -28,7 +28,7 @@ trait EnvironmentsScala3 extends Environments { this: MacroCommonsScala3 =>
 
     override def reportInfo(msg: String): Unit = report.info(msg, currentPosition)
     override def reportInfo(msg: String, position: Position): Unit = report.info(msg, position)
-    override def reportWarn(msg: String): Unit = report.info(msg, currentPosition)
+    override def reportWarn(msg: String): Unit = report.warning(msg, currentPosition)
     override def reportWarn(msg: String, position: Position): Unit = report.warning(msg, position)
     override def reportError(msg: String): Unit = report.error(msg, currentPosition)
     override def reportError(msg: String, position: Position): Unit = report.error(msg, position)

--- a/hearth/src/main/scala-3/hearth/EnvironmentsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/EnvironmentsScala3.scala
@@ -27,9 +27,13 @@ trait EnvironmentsScala3 extends Environments { this: MacroCommonsScala3 =>
     }
 
     override def reportInfo(msg: String): Unit = report.info(msg, currentPosition)
+    override def reportInfo(msg: String, position: Position): Unit = report.info(msg, position)
     override def reportWarn(msg: String): Unit = report.info(msg, currentPosition)
+    override def reportWarn(msg: String, position: Position): Unit = report.warning(msg, position)
     override def reportError(msg: String): Unit = report.error(msg, currentPosition)
+    override def reportError(msg: String, position: Position): Unit = report.error(msg, position)
     override def reportErrorAndAbort(msg: String): Nothing = report.errorAndAbort(msg, currentPosition)
+    override def reportErrorAndAbort(msg: String, position: Position): Nothing = report.errorAndAbort(msg, position)
   }
 
   object CrossQuotes extends CrossQuotesModule {

--- a/hearth/src/main/scala-3/hearth/std/extensions/IsValueTypeProviderForOpaque.scala
+++ b/hearth/src/main/scala-3/hearth/std/extensions/IsValueTypeProviderForOpaque.scala
@@ -25,36 +25,40 @@ final class IsValueTypeProviderForOpaque extends StandardMacroExtension { loader
       /** Get the underlying type of an opaque type.
         *
         * Strategy:
-        *   1. Try `simplified` which reduces TypeRefs to their underlying type when in scope
-        *   2. Outside the opaque type's scope
+        *   1. Try `UntypedType.opaqueUnderlyingType` (compiler-supported `TypeRef.translucentSuperType`) - it sees the
+        *      real RHS even from outside the defining scope, correct through bounds, nested opaque chains, and applied
+        *      parameterized opaques
+        *   2. Fall back to the smart-constructor heuristic when the compiler-supported lookup cannot determine the
+        *      underlying type:
+        *      - try `simplified` which reduces TypeRefs to their underlying type when in scope
         *      - try to infer from PlainValue ctor (the one that returns A directly, not Either[?, A])
         *      - fall back to the underlying type of the opaque type
-        *
-        * Note: We cannot use `sym.tree` from outside the opaque type's scope because it only shows TypeBounds, not the
-        * actual underlying type.
         */
       def underlyingTypeReprImpl(repr: TypeRepr)(using ctx: MacroCommons & StdExtensions): TypeRepr = {
         val tpe = repr.dealias
         val sym = tpe.typeSymbol
         if sym.flags.is(Flags.Opaque) then {
-          // Strategy 1: simplified reduces TypeRefs to their underlying type when in scope.
-          val simplifiedTpe = tpe.simplified
-          if simplifiedTpe.typeSymbol != sym then simplifiedTpe
-          else {
-            // Strategy 2: Infer from PlainValue smart constructor.
-            // A PlainValue ctor has signature (Input => Output) where Output is the opaque type.
-            // The Input type is the underlying type.
-            CtorLikes
-              .unapply(tpe.asTyped[Any])
-              .map { nel =>
-                def preferPlain = nel.toList.collectFirst {
-                  case existential if existential.value.isInstanceOf[CtorLikeOf.PlainValue[?, ?]] =>
-                    existential.Underlying.asUntyped
+          // Strategy 1: translucentSuperType-based lookup (works from outside the defining scope).
+          UntypedType.opaqueUnderlyingType(tpe).getOrElse {
+            // Strategy 2a: simplified reduces TypeRefs to their underlying type when in scope.
+            val simplifiedTpe = tpe.simplified
+            if simplifiedTpe.typeSymbol != sym then simplifiedTpe
+            else {
+              // Strategy 2b: Infer from PlainValue smart constructor.
+              // A PlainValue ctor has signature (Input => Output) where Output is the opaque type.
+              // The Input type is the underlying type.
+              CtorLikes
+                .unapply(tpe.asTyped[Any])
+                .map { nel =>
+                  def preferPlain = nel.toList.collectFirst {
+                    case existential if existential.value.isInstanceOf[CtorLikeOf.PlainValue[?, ?]] =>
+                      existential.Underlying.asUntyped
+                  }
+                  def fallback = nel.head.Underlying.asUntyped
+                  preferPlain getOrElse fallback
                 }
-                def fallback = nel.head.Underlying.asUntyped
-                preferPlain getOrElse fallback
-              }
-              .getOrElse(tpe)
+                .getOrElse(tpe)
+            }
           }
         } else sym.typeRef
       }

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -1403,6 +1403,8 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
     final private case class TypeMatch[A](name: Symbol, expr: Expr_??, result: A) extends MatchCase[A]
     final private case class EqValue[A](name: Symbol, matchedExpr: Expr_??, valueExpr: Expr_??, result: A)
         extends MatchCase[A]
+    final private case class TypeTestMatch[A](name: Symbol, typeTest: Term, expr: Expr_??, result: A)
+        extends MatchCase[A]
 
     override def typeMatch[A: Type](freshName: FreshName): MatchCase[Expr[A]] = {
       val name = freshTerm.bind[A](freshName, Flags.EmptyFlags)
@@ -1414,6 +1416,21 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
       val name = freshTerm.bind[A](freshName, Flags.EmptyFlags)
       val matched: Expr[A] = Ref(name).asExprOf[A]
       EqValue(name, matched.as_??, expr.as_??, matched)
+    }
+
+    private lazy val typeTestSymbol = Symbol.requiredClass("scala.reflect.TypeTest")
+
+    override def typeTestMatch[A: Type, B: Type](freshName: FreshName): MatchCase[Expr[B]] = {
+      val typeTest = Implicits.search(typeTestSymbol.typeRef.appliedTo(List(TypeRepr.of[A], TypeRepr.of[B]))) match {
+        case success: ImplicitSearchSuccess => success.tree
+        case _                              =>
+          assertionFailed(
+            s"MatchCase.typeTestMatch: no implicit scala.reflect.TypeTest[${Type.plainPrint[A]}, ${Type.plainPrint[B]}] found at the macro expansion point"
+          )
+      }
+      val name = freshTerm.bind[B](freshName, Flags.EmptyFlags)
+      val expr: Expr[B] = Ref(name).asExprOf[B]
+      TypeTestMatch(name, typeTest, expr.as_??, expr)
     }
 
     @scala.annotation.tailrec
@@ -1450,6 +1467,25 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             CaseDef(Bind(name, Ref(sym)), None, body)
             // case arg : Enum.Value => ...
             else CaseDef(Bind(name, Typed(Wildcard(), TypeTree.of[Matched])), None, body)
+
+          case TypeTestMatch(name, typeTest, expr, result) =>
+            import expr.value as toSuppress
+
+            // val body = '{ val _ = $toSuppress; $result }
+            val body = Block(
+              List(Expr.suppressUnused(toSuppress).asTerm),
+              stripInlined(result.asTerm)
+            )
+
+            // case tt(name @ _) => ... - the TypeTest instance is the extractor, its unapply is total
+            // over the scrutinee and returns Some only for values of the narrowed type. This is the same
+            // tree shape the compiler itself produces when it inserts a contextual TypeTest for an
+            // uncheckable `case name: Matched =>`.
+            CaseDef(
+              Unapply(Select.unique(typeTest, "unapply"), Nil, List(Bind(name, Wildcard()))),
+              None,
+              body
+            )
 
           case EqValue(name, matchedExpr, valueExpr, result) =>
             import matchedExpr.value as toSuppress
@@ -1498,6 +1534,11 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             case Left(value)  => Left(EqValue(name, matchedExpr, valueExpr, value))
             case Right(value) => Right(EqValue(name, matchedExpr, valueExpr, value))
           }
+        case TypeTestMatch(name, typeTest, expr, result) =>
+          f(result) match {
+            case Left(value)  => Left(TypeTestMatch(name, typeTest, expr, value))
+            case Right(value) => Right(TypeTestMatch(name, typeTest, expr, value))
+          }
       }
 
     override val traverse: fp.Traverse[MatchCase] = new fp.Traverse[MatchCase] {
@@ -1506,41 +1547,48 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         fa match {
           case TypeMatch(name, expr, a)                 => f(a).map(b => TypeMatch(name, expr, b))
           case EqValue(name, matchedExpr, valueExpr, a) => f(a).map(b => EqValue(name, matchedExpr, valueExpr, b))
+          case TypeTestMatch(name, typeTest, expr, a)   => f(a).map(b => TypeTestMatch(name, typeTest, expr, b))
         }
 
       override def parTraverse[G[_]: fp.Parallel, A, B](fa: MatchCase[A])(f: A => G[B]): G[MatchCase[B]] =
         fa match {
           case TypeMatch(name, expr, a)                 => f(a).map(b => TypeMatch(name, expr, b))
           case EqValue(name, matchedExpr, valueExpr, a) => f(a).map(b => EqValue(name, matchedExpr, valueExpr, b))
+          case TypeTestMatch(name, typeTest, expr, a)   => f(a).map(b => TypeTestMatch(name, typeTest, expr, b))
         }
     }
 
     override val directStyle: fp.DirectStyle[MatchCase] = new fp.DirectStyle[MatchCase] {
       private val saved =
-        scala.collection.mutable.Map.empty[Any, (quotes.reflect.Symbol, Expr_??, Option[Expr_??])]
+        scala.collection.mutable.Map
+          .empty[Any, (quotes.reflect.Symbol, Expr_??, Option[Expr_??], Option[quotes.reflect.Term])]
 
       override protected def scopedUnsafe[A](owner: fp.DirectStyle.ScopeOwner[MatchCase])(thunk: => A): MatchCase[A] = {
         val result = fp.effect.DirectStyleExecutor(thunk)
-        val (name, expr, valueExprOpt) = saved
+        val (name, expr, valueExprOpt, typeTestOpt) = saved
           .remove(owner)
           // $COVERAGE-OFF$
           .getOrElse(
             hearthRequirementFailed("MatchCase.directStyle: runSafe was not called inside scoped")
           )
         // $COVERAGE-ON$
-        valueExprOpt match {
-          case Some(valueExpr) => EqValue(name, expr, valueExpr, result)
-          case None            => TypeMatch(name, expr, result)
+        (valueExprOpt, typeTestOpt) match {
+          case (Some(valueExpr), _)   => EqValue(name, expr, valueExpr, result)
+          case (None, Some(typeTest)) => TypeTestMatch(name, typeTest, expr, result)
+          case (None, None)           => TypeMatch(name, expr, result)
         }
       }
 
       override protected def runUnsafe[A](owner: fp.DirectStyle.ScopeOwner[MatchCase])(value: => MatchCase[A]): A =
         fp.effect.DirectStyleExecutor(value) match {
           case TypeMatch(name, expr, result) =>
-            saved(owner) = (name, expr, None)
+            saved(owner) = (name, expr, None, None)
             result.asInstanceOf[A]
           case EqValue(name, matchedExpr, valueExpr, result) =>
-            saved(owner) = (name, matchedExpr, Some(valueExpr))
+            saved(owner) = (name, matchedExpr, Some(valueExpr), None)
+            result.asInstanceOf[A]
+          case TypeTestMatch(name, typeTest, expr, result) =>
+            saved(owner) = (name, expr, None, Some(typeTest))
             result.asInstanceOf[A]
         }
     }

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -6119,7 +6119,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 val applied = List.newBuilder[DestructuredExpr.MethodCall.Applied]
                 applied += new DestructuredExpr.MethodCall.AppliedInstance(dstrImpl(receiverTerm, lambdaParams))
                 if restArgs.nonEmpty then applied += new DestructuredExpr.MethodCall.AppliedValues(
-                  restArgs.map(a => dstrImpl(a, lambdaParams))
+                  restArgs.map(a => dstrArg(a, lambdaParams))
                 )
                 dstrBuildAppliedSteps(restSteps, lambdaParams, applied)
                 new DestructuredExpr.MethodCall(dstrTpeOf(term), method, applied.result(), () => term)
@@ -6130,7 +6130,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                   val applied = List.newBuilder[DestructuredExpr.MethodCall.Applied]
                   applied += new DestructuredExpr.MethodCall.AppliedInstance(dstrImpl(receiverTerm, lambdaParams))
                   if restArgs.nonEmpty then applied += new DestructuredExpr.MethodCall.AppliedValues(
-                    restArgs.map(a => dstrImpl(a, lambdaParams))
+                    restArgs.map(a => dstrArg(a, lambdaParams))
                   )
                   dstrBuildAppliedSteps(restSteps, lambdaParams, applied)
                   new DestructuredExpr.MethodCall(dstrTpeOf(term), method, applied.result(), () => term)
@@ -6151,7 +6151,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                   typeStep.targs.map(t => UntypedType.as_??(t.asInstanceOf[TypeTree].tpe))
                 )
                 if restArgs.nonEmpty then applied += new DestructuredExpr.MethodCall.AppliedValues(
-                  restArgs.map(a => dstrImpl(a, lambdaParams))
+                  restArgs.map(a => dstrArg(a, lambdaParams))
                 )
                 dstrBuildAppliedSteps(restSteps, lambdaParams, applied)
                 new DestructuredExpr.MethodCall(dstrTpeOf(term), method, applied.result(), () => term)
@@ -6205,9 +6205,59 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         )
       case DstrValueStep(args) =>
         applied += new DestructuredExpr.MethodCall.AppliedValues(
-          args.map(a => dstrImpl(a, lambdaParams))
+          args.map(a => dstrArg(a, lambdaParams))
         )
     }
+  }
+
+  /** Destructures a single value argument, handling vararg (repeated) argument trees.
+    *
+    * Individual elements (`m(1, 2, 3)`) arrive as `Typed(Repeated(elems, _), _)` (or a bare `Repeated`) and become one
+    * [[DestructuredExpr.Varargs]] slot. A spread sequence (`m(seq*)`) arrives as `Typed(seq, <repeated tpt>)` and is
+    * unwrapped to the destructured sequence expression itself - matching what Scala 2 produces for `m(seq: _*)`.
+    */
+  private def dstrArg(argAny: Any, lambdaParams: Map[Any, DestructuredExpr.Lambda.Param]): DestructuredExpr = {
+    import quotes.reflect.*
+    argAny.asInstanceOf[Term] match {
+      case Repeated(elems, elemTpt)                         => dstrVarargs(elems, elemTpt, lambdaParams)
+      case Typed(Repeated(elems, elemTpt), _)               => dstrVarargs(elems, elemTpt, lambdaParams)
+      case Typed(inner, tpt) if dstrIsRepeatedParamTpt(tpt) => dstrImpl(inner, lambdaParams)
+      case other                                            => dstrImpl(other, lambdaParams)
+    }
+  }
+
+  private def dstrIsRepeatedParamTpt(tptAny: Any): Boolean = {
+    import quotes.reflect.*
+    tptAny.asInstanceOf[TypeTree].tpe match {
+      case AppliedType(tycon, _)   => tycon.typeSymbol == defn.RepeatedParamClass
+      case AnnotatedType(_, annot) => annot.tpe.typeSymbol == defn.RepeatedAnnot
+      case _                       => false
+    }
+  }
+
+  private def dstrVarargs(
+      elemsAny: List[Any],
+      elemTptAny: Any,
+      lambdaParams: Map[Any, DestructuredExpr.Lambda.Param]
+  ): DestructuredExpr = {
+    import quotes.reflect.*
+    val elems = elemsAny.map(_.asInstanceOf[Term])
+    val elemTpe = elemTptAny.asInstanceOf[TypeTree].tpe.widen
+    val seqTpe = TypeRepr.of[scala.collection.immutable.Seq[Any]] match {
+      case AppliedType(tycon, _) => tycon.appliedTo(elemTpe)
+      case other                 => other
+    }
+    new DestructuredExpr.Varargs(
+      UntypedType.as_??(seqTpe),
+      elems.map(e => dstrImpl(e, lambdaParams)),
+      () =>
+        Select.overloaded(
+          Ref(Symbol.requiredModule("scala.collection.immutable.Seq")),
+          "apply",
+          List(elemTpe),
+          elems
+        )
+    )
   }
 
   private def dstrResolveMethod(qualTpeAny: Any, methodSymAny: Any): Option[Method] = {

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -8,7 +8,7 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
 
   import quotes.*, quotes.reflect.*
 
-  import UntypedType.platformSpecific.{positionOf, symbolAvailable}
+  import UntypedType.platformSpecific.{positionOf, repositionAnnotation, symbolAvailable}
 
   // Repeated (vararg) parameters appear in two shapes on Scala 3:
   //   - `scala.<repeated>[A]` (an `AppliedType` of `defn.RepeatedParamClass`) in method signatures,
@@ -53,7 +53,7 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
     override def name: String = symbol.name
     override def position: Option[Position] = positionOf(symbol)
 
-    override def annotations: List[UntypedExpr] = symbol.annotations
+    override def annotations: List[UntypedExpr] = symbol.annotations.map(repositionAnnotation)
     override def annotationTypes: List[UntypedType] = symbol.annotations.map(_.tpe)
 
     // By-name-ness is not visible on the parameter symbol itself (its termRef widens the ByNameType away),
@@ -378,7 +378,7 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
     override lazy val name: String = symbol.name
     override def position: Option[Position] = positionOf(symbol)
 
-    override def annotations: List[UntypedExpr] = symbol.annotations
+    override def annotations: List[UntypedExpr] = symbol.annotations.map(repositionAnnotation)
     override def annotationTypes: List[UntypedType] = symbol.annotations.map(_.tpe)
 
     override def isConstructor: Boolean = symbol.isClassConstructor

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -10,6 +10,43 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
 
   import UntypedType.platformSpecific.{positionOf, symbolAvailable}
 
+  // Repeated (vararg) parameters appear in two shapes on Scala 3:
+  //   - `scala.<repeated>[A]` (an `AppliedType` of `defn.RepeatedParamClass`) in method signatures,
+  //   - `Seq[A] @scala.annotation.internal.Repeated` (an `AnnotatedType`) when widening the parameter's term ref.
+  private lazy val repeatedAnnotationSymbol: Symbol = Symbol.requiredClass("scala.annotation.internal.Repeated")
+  private lazy val immutableSeqTypeConstructor: TypeRepr = TypeRepr.of[scala.collection.immutable.Seq[Any]] match {
+    case AppliedType(tycon, _) => tycon
+    // $COVERAGE-OFF$ Should never happen - Seq[Any] is always an AppliedType
+    case other => other
+    // $COVERAGE-ON$
+  }
+
+  private def isRepeatedParamType(tpe: TypeRepr): Boolean = tpe match {
+    case AppliedType(tycon, _) => tycon.typeSymbol == defn.RepeatedParamClass
+    case AnnotatedType(_, ann) => ann.tpe.typeSymbol == repeatedAnnotationSymbol
+    case _                     => false
+  }
+
+  /** Normalizes the raw repeated-parameter marker type (`scala.<repeated>[A]` or `Seq[A] @Repeated`) to
+    * `scala.collection.immutable.Seq[A]`, so that [[Parameter.tpe]] is a real, usable type, consistent between Scala 2
+    * and Scala 3. Non-repeated types are returned unchanged.
+    */
+  private def normalizeRepeatedParamType(tpe: TypeRepr): TypeRepr = tpe match {
+    case AppliedType(tycon, List(elem)) if tycon.typeSymbol == defn.RepeatedParamClass =>
+      immutableSeqTypeConstructor.appliedTo(elem)
+    case AnnotatedType(underlying, ann) if ann.tpe.typeSymbol == repeatedAnnotationSymbol => underlying
+    case other                                                                            => other
+  }
+
+  override protected def adaptVarargArgument(expr: UntypedExpr): UntypedExpr = {
+    val argTpe = expr.tpe.widenTermRefByName.dealias
+    val elementType = argTpe.baseType(immutableSeqTypeConstructor.typeSymbol) match {
+      case AppliedType(_, List(elem)) => elem
+      case _                          => argTpe.typeArgs.headOption.getOrElse(TypeRepr.of[Any])
+    }
+    Typed(expr, Inferred(defn.RepeatedParamClass.typeRef.appliedTo(elementType)))
+  }
+
   class UntypedParameter private[UntypedMethodsScala3] (val method: UntypedMethod, val symbol: Symbol, val index: Int)
       extends UntypedParameterMethods {
 
@@ -19,10 +56,22 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
     override def annotations: List[UntypedExpr] = symbol.annotations
     override def annotationTypes: List[UntypedType] = symbol.annotations.map(_.tpe)
 
-    override def isByName: Boolean = symbol.typeRef.simplified match {
-      case ByNameType(_) => true
-      case _             => false
+    // By-name-ness is not visible on the parameter symbol itself (its termRef widens the ByNameType away),
+    // so we look the parameter up in the owning method's signature, where it appears as `ByNameType`.
+    override def isByName: Boolean = {
+      def loop(tpe: TypeRepr): Boolean = tpe match {
+        case MethodType(names, types, returnType) =>
+          names.zip(types).collectFirst { case (n, t) if n == symbol.name => t } match {
+            case Some(ByNameType(_)) => true
+            case Some(_)             => false
+            case None                => loop(returnType)
+          }
+        case PolyType(_, _, returnType) => loop(returnType)
+        case _                          => false
+      }
+      loop(safeMemberType(method.symbol.owner.typeRef, method.symbol))
     }
+    override def isVararg: Boolean = isRepeatedParamType(symbol.termRef.widenTermRefByName)
     override def isImplicit: Boolean = symbol.flags.is(Flags.Implicit) || symbol.flags.is(Flags.Given)
     override def hasDefault: Boolean = symbol.flags.is(Flags.HasDefault)
   }
@@ -106,7 +155,11 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
       untyped.map { params =>
         params.flatMap { case (paramName, untyped) =>
           typesByParamName.get(paramName).map { tpe =>
-            val param = Parameter(asUntyped = untyped, untypedInstanceType = instanceTpe, tpe = tpe.as_??)
+            val param = Parameter(
+              asUntyped = untyped,
+              untypedInstanceType = instanceTpe,
+              tpe = normalizeRepeatedParamType(tpe).as_??
+            )
             paramName -> param
           }
         }
@@ -368,7 +421,13 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
         if isConstructor && instanceTpe.typeArgs.nonEmpty then rawMemberType.appliedTo(instanceTpe.typeArgs)
         else rawMemberType
       def typePrint(t: TypeRepr): String = {
-        val raw = t.plainPrint
+        val raw = t match {
+          case AppliedType(tycon, List(elem)) if tycon.typeSymbol == defn.RepeatedParamClass =>
+            s"${elem.plainPrint}*"
+          case AnnotatedType(underlying, ann) if ann.tpe.typeSymbol == repeatedAnnotationSymbol =>
+            underlying.typeArgs.headOption.map(elem => s"${elem.plainPrint}*").getOrElse(underlying.plainPrint)
+          case _ => t.plainPrint
+        }
         if hl.TypeDefColor.isEmpty then raw else hl.highlightTypeDef(raw)
       }
       def collectParamLists(tpe: TypeRepr): (List[List[(String, String)]], String) = tpe match {
@@ -484,6 +543,7 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
     override def annotations: List[UntypedExpr] = Nil
     override def annotationTypes: List[UntypedType] = Nil
     override def isByName: Boolean = false
+    override def isVararg: Boolean = false
     override def isImplicit: Boolean = false
     override def hasDefault: Boolean = false
   }

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -766,7 +766,8 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
             case other          => other
           }
           val memberType = safeMemberType(instanceTpe, untyped.symbol).widenByName
-          Some(finalResultType(memberType).as_??)
+          // E.g. the case-field accessor of a vararg parameter would otherwise return `scala.<repeated>[A]`.
+          Some(normalizeRepeatedParamType(finalResultType(memberType)).as_??)
         }
 
       val buildExpr: (Option[UntypedExpr], UntypedTypeArguments, UntypedArguments) => Either[String, UntypedExpr] =

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -99,6 +99,34 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
         callReflectMethod[List[TypeRepr]](tpe, "parents")
       def typeReprBaseClasses(tpe: TypeRepr): List[Symbol] =
         callReflectMethod[List[Symbol]](tpe, "baseClasses")
+
+      /** Makes an annotation tree obtained from `Symbol.annotations` spliceable into macro output.
+        *
+        * On Scala 3, annotation trees carry no source spans, so splicing them into the macro result is rejected by
+        * `-Xcheck-macros` ("position not set"). There is no public API to set a span on an existing tree, but every
+        * tree created through the public `quotes.reflect` constructors is automatically assigned the macro-expansion
+        * position. So we rebuild the annotation tree node by node: this preserves the structure (constructor call +
+        * argument trees), keeping macro-time reading (e.g. `DestructuredExpr`, `Expr.semiEval`) intact while making the
+        * tree safe to splice.
+        *
+        * Tree shapes that cannot appear in (or are irrelevant for) annotation constructor calls are returned as-is.
+        */
+      def repositionAnnotation(annotation: Term): Term = {
+        def rebuild(term: Term): Term = term match {
+          case Apply(fun, args)      => Apply(rebuild(fun), args.map(rebuild))
+          case TypeApply(fun, args)  => TypeApply(rebuild(fun), args.map(arg => Inferred(arg.tpe)))
+          case Select(qualifier, _)  => Select(rebuild(qualifier), term.symbol)
+          case New(tpt)              => New(Inferred(tpt.tpe))
+          case Literal(constant)     => Literal(constant)
+          case ident: Ident          => if ident.symbol.isTerm then Ref(ident.symbol) else ident
+          case Typed(expr, tpt)      => Typed(rebuild(expr), Inferred(tpt.tpe))
+          case NamedArg(name, arg)   => NamedArg(name, rebuild(arg))
+          case Repeated(elems, tpt)  => Repeated(elems.map(rebuild), Inferred(tpt.tpe))
+          case Inlined(_, Nil, body) => rebuild(body)
+          case other                 => other
+        }
+        rebuild(annotation)
+      }
     }
     import platformSpecific.*
 
@@ -784,7 +812,7 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
       untyped.appliedTo(args)
 
     override def annotations(untyped: UntypedType): List[UntypedExpr] =
-      untyped.typeSymbol.annotations
+      untyped.typeSymbol.annotations.map(repositionAnnotation)
     override def annotationTypes(untyped: UntypedType): List[UntypedType] =
       untyped.typeSymbol.annotations.map(_.tpe)
   }

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -594,32 +594,65 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
           }
           if hasSubtypeOverlap then None
           else {
-            // Check erasure safety: no two members should erase to the same runtime class
-            def erasure(tpe: TypeRepr): Option[TypeRepr] =
-              // Opaque types hide their underlying representation, so we can't determine
-              // their runtime erasure from outside the defining scope.
-              if isOpaqueType(tpe) then None
-              else {
-                val widened = tpe.widen.dealias
-                widened match {
-                  case AppliedType(tycon, _) => Some(tycon)
-                  case other                 =>
-                    if other.classSymbol.isDefined then Some(other)
-                    else None // unknown → can't prove safety
-                }
-              }
+            // Stable singleton members (literal types, case objects/modules, Scala 3 enum case vals)
+            // are matched BY VALUE (equality/identity test), not by a runtime class test, so they are
+            // exempt from the runtime-class disjointness requirement below. They never overlap with
+            // class-tested members either: that would require a static subtype relationship
+            // (e.g. Color.Red.type <:< Color), which was already rejected by the pre-check above.
+            def isSingletonMember(tpe: TypeRepr): Boolean = tpe match {
+              case _: ConstantType => true
+              case _               =>
+                val termSym = tpe.termSymbol
+                def isModuleRef =
+                  !tpe.typeSymbol.isNoSymbol && tpe.typeSymbol.flags.is(Flags.Module)
+                def isEnumCaseVal =
+                  !termSym.isNoSymbol && termSym.flags.is(Flags.Enum) &&
+                    (termSym.flags.is(Flags.JavaStatic) || termSym.flags.is(Flags.StableRealizable))
+                isModuleRef || isEnumCaseVal
+            }
 
-            val erasures = members.map(erasure)
-            // If any member has unknown erasure, be conservative
-            if erasures.exists(_.isEmpty) then None
+            val classMembers = members.filterNot(isSingletonMember)
+
+            // Union values are boxed at runtime, so primitives have to be normalized to their boxed
+            // representations (e.g. Int and java.lang.Integer are NOT disjoint at runtime).
+            val boxedClasses = Map[java.lang.Class[?], java.lang.Class[?]](
+              classOf[Unit] -> classOf[scala.runtime.BoxedUnit],
+              classOf[Boolean] -> classOf[java.lang.Boolean],
+              classOf[Byte] -> classOf[java.lang.Byte],
+              classOf[Short] -> classOf[java.lang.Short],
+              classOf[Int] -> classOf[java.lang.Integer],
+              classOf[Long] -> classOf[java.lang.Long],
+              classOf[Float] -> classOf[java.lang.Float],
+              classOf[Double] -> classOf[java.lang.Double],
+              classOf[Char] -> classOf[java.lang.Character]
+            )
+
+            // Compute the runtime class used by the `case x: Member` class test. Members whose runtime
+            // class cannot be determined (abstract types, type params, refinements, opaques) are refused
+            // conservatively - we cannot prove that the class tests dispatch soundly.
+            def runtimeClass(tpe: TypeRepr): Option[java.lang.Class[?]] =
+              // Opaque types hide their underlying representation, so we can't determine
+              // their runtime class from outside the defining scope.
+              if isOpaqueType(tpe) then None
+              else toClass(tpe.widen.dealias).map(clazz => boxedClasses.getOrElse(clazz, clazz))
+
+            val classes = classMembers.map(runtimeClass)
+            // If any class-tested member has an unknown runtime class, be conservative
+            if classes.exists(_.isEmpty) then None
             else {
-              val knownErasures = erasures.flatten
-              val hasDuplicateErasure = knownErasures.indices.exists { i =>
-                knownErasures.indices.exists { j =>
-                  i != j && (knownErasures(i) =:= knownErasures(j))
+              val knownClasses = classes.flatten
+              // Reject RELATED runtime classes, not just equal ones: `case x: List[Int]` would also
+              // catch a `Seq[String]` value that happens to be a List, dispatching to the wrong branch.
+              val hasRelatedRuntimeClasses = knownClasses.indices.exists { i =>
+                knownClasses.indices.exists { j =>
+                  i != j && {
+                    val a = knownClasses(i)
+                    val b = knownClasses(j)
+                    a.isAssignableFrom(b) || b.isAssignableFrom(a)
+                  }
                 }
               }
-              if hasDuplicateErasure then None
+              if hasRelatedRuntimeClasses then None
               else
                 Some(ListMap.from(members.map { tpe =>
                   UntypedType.plainPrint(tpe) -> tpe

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -75,6 +75,7 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
           case Everywhere => isPublic
           case AtCallSite =>
             isPublic || isPrivateButInTheSameClass || isProtectedButInTheSameClass || isPrivateWithinButInTheRightPlace
+          case Unrestricted => true
         }
       }
 

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -592,14 +592,57 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
             .map(subtypeSymbol => subtypeName(subtypeSymbol) -> subtypeTypeOf(instanceTpe, subtypeSymbol))
         }
       )
-      else if isUnionType(instanceTpe) then {
-        val nothingType = TypeRepr.of[Nothing]
-
-        // Flatten nested OrType tree
-        def flatten(tpe: TypeRepr): List[TypeRepr] = tpe.dealias match {
-          case OrType(left, right) => flatten(left) ++ flatten(right)
-          case other               => List(other)
+      else if isUnionType(instanceTpe) then unionMemberDispatch(instanceTpe).flatMap { dispatch =>
+        // Members that cannot be soundly discriminated by a runtime class test are acceptable only when
+        // the user provides an implicit scala.reflect.TypeTest[Union, Member] (a total runtime
+        // discriminator); otherwise the whole union is refused (see unionRefusalReason for diagnostics).
+        val allMembersDiscriminable = dispatch.forall {
+          case (member, UnionMemberDispatch.ByTypeTest) => userProvidedUnionTypeTestExists(instanceTpe, member)
+          case _                                        => true
         }
+        if allMembersDiscriminable then Some(ListMap.from(dispatch.map { case (tpe, _) =>
+          UntypedType.plainPrint(tpe) -> tpe
+        }))
+        else None
+      }
+      else None
+
+    /** How a generated pattern match would dispatch on a particular union member. */
+    sealed private trait UnionMemberDispatch extends Product with Serializable
+    private object UnionMemberDispatch {
+
+      /** Stable singletons (literal types, modules, Scala 3 enum case vals) - matched by value/identity. */
+      case object ByValue extends UnionMemberDispatch
+
+      /** Members whose runtime class is determinable and disjoint from every other member's - matched with a
+        * `case x: Member` class test.
+        */
+      final case class ByClassTest(runtimeClass: java.lang.Class[?]) extends UnionMemberDispatch
+
+      /** Members whose runtime class is undeterminable (abstract types, type params) or related to another member's
+        * (same/related erasure, e.g. `List[Int]` vs `List[String]`) - a class test would be unsound, so they require a
+        * user-provided `scala.reflect.TypeTest[Union, Member]` extractor.
+        */
+      case object ByTypeTest extends UnionMemberDispatch
+    }
+
+    /** Classifies the members of a union type by how a generated pattern match has to dispatch on them.
+      *
+      * Returns `None` when the type is not a union we could ever decompose: not an `OrType` at all, fewer than 2
+      * distinct members after dropping `Nothing` and duplicates, or members with static subtype relationships between
+      * them (where "which branch should win" has no sound answer).
+      */
+    private def unionMemberDispatch(instanceTpe: UntypedType): Option[List[(UntypedType, UnionMemberDispatch)]] = {
+      val nothingType = TypeRepr.of[Nothing]
+
+      // Flatten nested OrType tree
+      def flatten(tpe: TypeRepr): List[TypeRepr] = tpe.dealias match {
+        case OrType(left, right) => flatten(left) ++ flatten(right)
+        case other               => List(other)
+      }
+
+      if !isUnionType(instanceTpe) then None
+      else {
         val allMembers = flatten(instanceTpe.dealias)
 
         // Filter Nothing, deduplicate
@@ -635,8 +678,6 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
                 isModuleRef || isEnumCaseVal
             }
 
-            val classMembers = members.filterNot(isSingletonMember)
-
             // Union values are boxed at runtime, so primitives have to be normalized to their boxed
             // representations (e.g. Int and java.lang.Integer are NOT disjoint at runtime).
             val boxedClasses = Map[java.lang.Class[?], java.lang.Class[?]](
@@ -652,41 +693,89 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
             )
 
             // Compute the runtime class used by the `case x: Member` class test. Members whose runtime
-            // class cannot be determined (abstract types, type params, refinements) are refused
-            // conservatively - we cannot prove that the class tests dispatch soundly.
+            // class cannot be determined (abstract types, type params, refinements) cannot be proven
+            // to dispatch soundly with a class test, so they require a TypeTest.
             def runtimeClass(tpe: TypeRepr): Option[java.lang.Class[?]] = {
               // Opaque types hide their underlying representation, but `opaqueUnderlyingType` can resolve
               // it from outside the defining scope - the class test dispatches on the underlying class
-              // (e.g. `OpaqueId(= Long) | String` is accepted, while `OpaqueId | Long` is refused).
+              // (e.g. `OpaqueId(= Long) | String` is accepted, while `OpaqueId | Long` requires TypeTests).
               val classTestedTpe = opaqueUnderlyingType(tpe).getOrElse(tpe)
               toClass(classTestedTpe.widen.dealias).map(clazz => boxedClasses.getOrElse(clazz, clazz))
             }
 
-            val classes = classMembers.map(runtimeClass)
-            // If any class-tested member has an unknown runtime class, be conservative
-            if classes.exists(_.isEmpty) then None
-            else {
-              val knownClasses = classes.flatten
-              // Reject RELATED runtime classes, not just equal ones: `case x: List[Int]` would also
-              // catch a `Seq[String]` value that happens to be a List, dispatching to the wrong branch.
-              val hasRelatedRuntimeClasses = knownClasses.indices.exists { i =>
-                knownClasses.indices.exists { j =>
-                  i != j && {
-                    val a = knownClasses(i)
-                    val b = knownClasses(j)
-                    a.isAssignableFrom(b) || b.isAssignableFrom(a)
-                  }
-                }
-              }
-              if hasRelatedRuntimeClasses then None
-              else
-                Some(ListMap.from(members.map { tpe =>
-                  UntypedType.plainPrint(tpe) -> tpe
-                }))
+            val singletonFlags = members.map(isSingletonMember)
+            val classes = members.zip(singletonFlags).map { case (tpe, isSingleton) =>
+              if isSingleton then None else runtimeClass(tpe)
             }
+            // A class test is sound only when no OTHER member's runtime class is RELATED to this one:
+            // `case x: List[Int]` would also catch a `Seq[String]` value that happens to be a List,
+            // dispatching to the wrong branch. (Equal classes - e.g. List[Int] vs List[String] - are a
+            // special case of related ones.)
+            def relatedToAnotherMember(i: Int): Boolean = classes(i).exists { a =>
+              classes.indices.exists { j =>
+                j != i && classes(j).exists(b => a.isAssignableFrom(b) || b.isAssignableFrom(a))
+              }
+            }
+
+            Some(members.toList.zipWithIndex.map { case (tpe, i) =>
+              if singletonFlags(i) then tpe -> UnionMemberDispatch.ByValue
+              else
+                classes(i) match {
+                  case Some(clazz) if !relatedToAnotherMember(i) => tpe -> UnionMemberDispatch.ByClassTest(clazz)
+                  case _                                         => tpe -> UnionMemberDispatch.ByTypeTest
+                }
+            })
           }
         }
-      } else None
+      }
+    }
+
+    private lazy val typeTestSymbol = Symbol.requiredClass("scala.reflect.TypeTest")
+
+    /** Whether a USER-PROVIDED `scala.reflect.TypeTest[Union, Member]` can be summoned at the expansion point.
+      *
+      * The compiler synthesizes `TypeTest` instances on its own whenever it considers the underlying class test
+      * checkable (e.g. for `TypeTest[Int | java.lang.Integer, Int]`) - but members are classified as
+      * [[UnionMemberDispatch.ByTypeTest]] precisely because that class test is NOT a sound discriminator at runtime, so
+      * compiler-synthesized instances (inlined anonymous classes, returned as `Block` trees) are ignored; only actual
+      * givens/implicits (resolved as references to a real symbol) count.
+      */
+    private def userProvidedUnionTypeTestExists(unionTpe: UntypedType, member: UntypedType): Boolean = {
+      @scala.annotation.tailrec
+      def isUserProvided(term: Term): Boolean = term match {
+        case Inlined(_, _, inner) => isUserProvided(inner)
+        case Typed(inner, _)      => isUserProvided(inner)
+        case Block(_, _)          => false // compiler-synthesized anonymous TypeTest instance
+        case other                => !other.symbol.isNoSymbol
+      }
+      Implicits.search(typeTestSymbol.typeRef.appliedTo(List(unionTpe.dealias, member))) match {
+        case success: ImplicitSearchSuccess => isUserProvided(success.tree)
+        case _                              => false
+      }
+    }
+
+    override def unionMemberRequiresTypeTest(unionTpe: UntypedType, member: UntypedType): Boolean =
+      unionMemberDispatch(unionTpe).exists(_.exists { case (tpe, dispatch) =>
+        dispatch == UnionMemberDispatch.ByTypeTest && tpe =:= member
+      })
+
+    override def unionRefusalReason(instanceTpe: UntypedType): Option[String] =
+      unionMemberDispatch(instanceTpe).flatMap { dispatch =>
+        val missing = dispatch.collect {
+          case (member, UnionMemberDispatch.ByTypeTest) if !userProvidedUnionTypeTestExists(instanceTpe, member) =>
+            member
+        }
+        if missing.isEmpty then None
+        else
+          Some(
+            missing
+              .map { member =>
+                s"union member ${UntypedType.plainPrint(member)} is not runtime-distinguishable; " +
+                  s"provide an implicit scala.reflect.TypeTest[${UntypedType.plainPrint(instanceTpe)}, ${UntypedType.plainPrint(member)}]"
+              }
+              .mkString(", ")
+          )
+      }
 
     override def typeArguments(untyped: UntypedType): List[UntypedType] =
       untyped.typeArgs

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -123,6 +123,30 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
       !sym.isNoSymbol && sym.flags.is(Flags.Opaque)
     }
 
+    override def opaqueUnderlyingType(instanceTpe: UntypedType): Option[UntypedType] = {
+      // `TypeRef.translucentSuperType` is the compiler-supported way of looking through an opaque type:
+      // on an opaque TypeRef it returns `symbol.opaqueAlias.asSeenFrom(prefix, owner)` - the real RHS,
+      // visible from outside the defining scope, correct through bounds (`opaque type X <: Int = Int`
+      // resolves to `Int`, not the bound), nested opaque chains, and path-dependent prefixes.
+      @scala.annotation.tailrec
+      def loop(tpe: TypeRepr): TypeRepr = tpe match {
+        case tr: TypeRef if tr.isOpaqueAlias                          => loop(tr.translucentSuperType.dealias)
+        case AppliedType(tycon: TypeRef, args) if tycon.isOpaqueAlias =>
+          tycon.translucentSuperType.dealias match {
+            // For parameterized opaques (`opaque type Wrapper[A] = List[A]`) the translucent supertype of the
+            // bare constructor is a TypeLambda - re-apply the original type arguments so that `Wrapper[Int]`
+            // resolves to `List[Int]` rather than the bare `List` constructor (`appliedTo` beta-reduces).
+            case tl: TypeLambda => loop(tl.appliedTo(args).dealias)
+            // Not expected for an opaque constructor, but if the RHS is not a type lambda, stop here rather
+            // than dropping the type arguments.
+            case _ => tpe
+          }
+        case _ => tpe
+      }
+      val result = loop(instanceTpe.dealias)
+      if result =:= instanceTpe then None else Some(result)
+    }
+
     override def isTuple(instanceTpe: UntypedType): Boolean = {
       val tupleBase = fromTyped[Tuple]
       val nonEmptyBase = fromTyped[NonEmptyTuple]
@@ -628,13 +652,15 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
             )
 
             // Compute the runtime class used by the `case x: Member` class test. Members whose runtime
-            // class cannot be determined (abstract types, type params, refinements, opaques) are refused
+            // class cannot be determined (abstract types, type params, refinements) are refused
             // conservatively - we cannot prove that the class tests dispatch soundly.
-            def runtimeClass(tpe: TypeRepr): Option[java.lang.Class[?]] =
-              // Opaque types hide their underlying representation, so we can't determine
-              // their runtime class from outside the defining scope.
-              if isOpaqueType(tpe) then None
-              else toClass(tpe.widen.dealias).map(clazz => boxedClasses.getOrElse(clazz, clazz))
+            def runtimeClass(tpe: TypeRepr): Option[java.lang.Class[?]] = {
+              // Opaque types hide their underlying representation, but `opaqueUnderlyingType` can resolve
+              // it from outside the defining scope - the class test dispatches on the underlying class
+              // (e.g. `OpaqueId(= Long) | String` is accepted, while `OpaqueId | Long` is refused).
+              val classTestedTpe = opaqueUnderlyingType(tpe).getOrElse(tpe)
+              toClass(classTestedTpe.widen.dealias).map(clazz => boxedClasses.getOrElse(clazz, clazz))
+            }
 
             val classes = classMembers.map(runtimeClass)
             // If any class-tested member has an unknown runtime class, be conservative

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -806,11 +806,23 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
           )
       }
 
+    override def dealias(untyped: UntypedType): UntypedType =
+      untyped.dealias
+
+    override def typeConstructor(untyped: UntypedType): UntypedType =
+      untyped.dealias match {
+        case AppliedType(tycon, _) => tycon
+        case other                 => other
+      }
+
     override def typeArguments(untyped: UntypedType): List[UntypedType] =
       untyped.typeArgs
 
     override def applyTypeArgs(untyped: UntypedType, args: List[UntypedType]): UntypedType =
       untyped.appliedTo(args)
+
+    override def sameTypeConstructorAs(a: UntypedType, b: UntypedType): Boolean =
+      typeConstructor(a).typeSymbol == typeConstructor(b).typeSymbol
 
     override def annotations(untyped: UntypedType): List[UntypedExpr] =
       untyped.typeSymbol.annotations.map(repositionAnnotation)

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -643,14 +643,14 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
       /** Stable singletons (literal types, modules, Scala 3 enum case vals) - matched by value/identity. */
       case object ByValue extends UnionMemberDispatch
 
-      /** Members whose runtime class is determinable and disjoint from every other member's - matched with a
+      /** Members whose erased class is determinable and disjoint from every other member's - matched with a
         * `case x: Member` class test.
         */
-      final case class ByClassTest(runtimeClass: java.lang.Class[?]) extends UnionMemberDispatch
+      case object ByClassTest extends UnionMemberDispatch
 
-      /** Members whose runtime class is undeterminable (abstract types, type params) or related to another member's
-        * (same/related erasure, e.g. `List[Int]` vs `List[String]`) - a class test would be unsound, so they require a
-        * user-provided `scala.reflect.TypeTest[Union, Member]` extractor.
+      /** Members whose erased class is undeterminable (abstract types, type params, refinements) or related to another
+        * member's (same/related erasure, e.g. `List[Int]` vs `List[String]`) - a class test would be unsound, so they
+        * require a user-provided `scala.reflect.TypeTest[Union, Member]` extractor.
         */
       case object ByTypeTest extends UnionMemberDispatch
     }
@@ -691,8 +691,8 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
           if hasSubtypeOverlap then None
           else {
             // Stable singleton members (literal types, case objects/modules, Scala 3 enum case vals)
-            // are matched BY VALUE (equality/identity test), not by a runtime class test, so they are
-            // exempt from the runtime-class disjointness requirement below. They never overlap with
+            // are matched BY VALUE (equality/identity test), not by a class test, so they are
+            // exempt from the erased-class disjointness requirement below. They never overlap with
             // class-tested members either: that would require a static subtype relationship
             // (e.g. Color.Red.type <:< Color), which was already rejected by the pre-check above.
             def isSingletonMember(tpe: TypeRepr): Boolean = tpe match {
@@ -707,57 +707,68 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
                 isModuleRef || isEnumCaseVal
             }
 
-            // Union values are boxed at runtime, so primitives have to be normalized to their boxed
-            // representations (e.g. Int and java.lang.Integer are NOT disjoint at runtime).
-            val boxedClasses = Map[java.lang.Class[?], java.lang.Class[?]](
-              classOf[Unit] -> classOf[scala.runtime.BoxedUnit],
-              classOf[Boolean] -> classOf[java.lang.Boolean],
-              classOf[Byte] -> classOf[java.lang.Byte],
-              classOf[Short] -> classOf[java.lang.Short],
-              classOf[Int] -> classOf[java.lang.Integer],
-              classOf[Long] -> classOf[java.lang.Long],
-              classOf[Float] -> classOf[java.lang.Float],
-              classOf[Double] -> classOf[java.lang.Double],
-              classOf[Char] -> classOf[java.lang.Character]
-            )
-
-            // Compute the runtime class used by the `case x: Member` class test. Members whose runtime
-            // class cannot be determined (abstract types, type params, refinements) cannot be proven
-            // to dispatch soundly with a class test, so they require a TypeTest.
-            def runtimeClass(tpe: TypeRepr): Option[java.lang.Class[?]] = {
+            // Compute the ERASED CLASS SYMBOL used by the `case x: Member` class test, working at the
+            // COMPILER-SYMBOL level (not via `java.lang.Class.forName`) so the check also works for types
+            // defined in the SAME compilation run as the macro expansion, whose classfiles do not exist yet.
+            //
+            // Members whose erased class cannot be determined (abstract types, type params, refinements) cannot
+            // be proven to dispatch soundly with a class test, so they require a TypeTest. Union values are boxed
+            // at runtime, so primitive value-class symbols are normalized to their boxed counterparts (e.g. `Int`
+            // and `java.lang.Integer` are NOT disjoint at runtime).
+            def erasedClassSymbol(tpe: TypeRepr): Option[Symbol] = {
               // Opaque types hide their underlying representation, but `opaqueUnderlyingType` can resolve
               // it from outside the defining scope - the class test dispatches on the underlying class
               // (e.g. `OpaqueId(= Long) | String` is accepted, while `OpaqueId | Long` requires TypeTests).
               val classTestedTpe = opaqueUnderlyingType(tpe).getOrElse(tpe)
-              toClass(classTestedTpe.widen.dealias).map(clazz => boxedClasses.getOrElse(clazz, clazz))
+              // `classSymbol` returns the class symbol of the erased type - for an `AppliedType` this is the
+              // tycon's class symbol (e.g. `List[Int]` -> `scala.collection.immutable.List`).
+              classTestedTpe.widen.dealias.classSymbol.map(sym => boxedClassSymbols.getOrElse(sym, sym))
             }
 
             val singletonFlags = members.map(isSingletonMember)
-            val classes = members.zip(singletonFlags).map { case (tpe, isSingleton) =>
-              if isSingleton then None else runtimeClass(tpe)
+            val classSymbols = members.zip(singletonFlags).map { case (tpe, isSingleton) =>
+              if isSingleton then None else erasedClassSymbol(tpe)
             }
-            // A class test is sound only when no OTHER member's runtime class is RELATED to this one:
+            // A class test is sound only when no OTHER member's erased class is RELATED to this one:
             // `case x: List[Int]` would also catch a `Seq[String]` value that happens to be a List,
             // dispatching to the wrong branch. (Equal classes - e.g. List[Int] vs List[String] - are a
-            // special case of related ones.)
-            def relatedToAnotherMember(i: Int): Boolean = classes(i).exists { a =>
-              classes.indices.exists { j =>
-                j != i && classes(j).exists(b => a.isAssignableFrom(b) || b.isAssignableFrom(a))
+            // special case of related ones.) Relatedness is checked at the class level: A and B are related
+            // iff A's erased class derives from B's OR vice versa, tested through their class symbols' typeRefs
+            // (`TypeRepr.derivesFrom(cls)` is the compiler-symbol-level subclass check).
+            def relatedToAnotherMember(i: Int): Boolean = classSymbols(i).exists { a =>
+              classSymbols.indices.exists { j =>
+                j != i && classSymbols(j).exists(b => a.typeRef.derivesFrom(b) || b.typeRef.derivesFrom(a))
               }
             }
 
             Some(members.toList.zipWithIndex.map { case (tpe, i) =>
               if singletonFlags(i) then tpe -> UnionMemberDispatch.ByValue
               else
-                classes(i) match {
-                  case Some(clazz) if !relatedToAnotherMember(i) => tpe -> UnionMemberDispatch.ByClassTest(clazz)
-                  case _                                         => tpe -> UnionMemberDispatch.ByTypeTest
+                classSymbols(i) match {
+                  case Some(_) if !relatedToAnotherMember(i) => tpe -> UnionMemberDispatch.ByClassTest
+                  case _                                     => tpe -> UnionMemberDispatch.ByTypeTest
                 }
             })
           }
         }
       }
     }
+
+    /** Union values are boxed at runtime, so primitive class symbols have to be normalized to their boxed counterparts
+      * before the disjointness comparison (e.g. `Int` and `java.lang.Integer` are NOT disjoint at runtime). Built once:
+      * keyed by the primitive value class symbol, valued by the boxed class symbol.
+      */
+    private lazy val boxedClassSymbols: Map[Symbol, Symbol] = Map(
+      TypeRepr.of[Unit].classSymbol.get -> Symbol.requiredClass("scala.runtime.BoxedUnit"),
+      TypeRepr.of[Boolean].classSymbol.get -> Symbol.requiredClass("java.lang.Boolean"),
+      TypeRepr.of[Byte].classSymbol.get -> Symbol.requiredClass("java.lang.Byte"),
+      TypeRepr.of[Short].classSymbol.get -> Symbol.requiredClass("java.lang.Short"),
+      TypeRepr.of[Int].classSymbol.get -> Symbol.requiredClass("java.lang.Integer"),
+      TypeRepr.of[Long].classSymbol.get -> Symbol.requiredClass("java.lang.Long"),
+      TypeRepr.of[Float].classSymbol.get -> Symbol.requiredClass("java.lang.Float"),
+      TypeRepr.of[Double].classSymbol.get -> Symbol.requiredClass("java.lang.Double"),
+      TypeRepr.of[Char].classSymbol.get -> Symbol.requiredClass("java.lang.Character")
+    )
 
     private lazy val typeTestSymbol = Symbol.requiredClass("scala.reflect.TypeTest")
 

--- a/hearth/src/main/scala/hearth/Environments.scala
+++ b/hearth/src/main/scala/hearth/Environments.scala
@@ -76,9 +76,40 @@ trait Environments extends EnvironmentCrossQuotesSupport { env =>
     final def typedSettings: Either[String, data.Data] = data.Data.parseList(XMacroSettings)
 
     def reportInfo(msg: String): Unit
+
+    /** Reports an info message at the given [[Position]] instead of the macro expansion point, e.g. to point at the
+      * specific field/parameter that a derivation step refers to.
+      *
+      * @since 0.4.0
+      */
+    def reportInfo(msg: String, position: Position): Unit
+
     def reportWarn(msg: String): Unit
+
+    /** Reports a warning at the given [[Position]] instead of the macro expansion point, e.g. to point at the specific
+      * field/parameter that a derivation step refers to.
+      *
+      * @since 0.4.0
+      */
+    def reportWarn(msg: String, position: Position): Unit
+
     def reportError(msg: String): Unit
+
+    /** Reports an error at the given [[Position]] instead of the macro expansion point, e.g. to point at the specific
+      * field/parameter that made a derivation step fail.
+      *
+      * @since 0.4.0
+      */
+    def reportError(msg: String, position: Position): Unit
+
     def reportErrorAndAbort(msg: String): Nothing
+
+    /** Reports an error at the given [[Position]] instead of the macro expansion point and aborts the expansion, e.g.
+      * to point at the specific field/parameter that made a derivation step fail.
+      *
+      * @since 0.4.0
+      */
+    def reportErrorAndAbort(msg: String, position: Position): Nothing
 
     /** Pass position like "File.scala:12" or "File.scala:12:34", and it will check if current expansion matches it.
       *

--- a/hearth/src/main/scala/hearth/Environments.scala
+++ b/hearth/src/main/scala/hearth/Environments.scala
@@ -149,7 +149,7 @@ trait Environments extends EnvironmentCrossQuotesSupport { env =>
       * It would pretty print the last known state of MIO for debugging and consider
       * `-Xmacro-settings:hearth.mioTerminationShouldUseReportError=true|false` option (false by default), which could
       * be used to tell the macro whether it should use:
-      *   - [[Environment.reportErrorAndAbort]] to terminate the macro expansion and show the error message using the
+      *   - `Environment.reportErrorAndAbort` to terminate the macro expansion and show the error message using the
       *     reporter, which would terminate only the current macro,
       *   - or just print the error message to `stderr` and throw the exception to terminate the whole compilation
       *     process (on Scala 3, on Scala 3 each looped macro has to be terminated individually).

--- a/hearth/src/main/scala/hearth/typed/Classes.scala
+++ b/hearth/src/main/scala/hearth/typed/Classes.scala
@@ -273,9 +273,19 @@ trait Classes { this: MacroCommons =>
         }
       }
 
+    /** Returns the values of all case fields of the given instance.
+      *
+      * By default ([[Unrestricted]]) ALL case fields are returned, regardless of their visibility. Pass [[AtCallSite]]
+      * to keep only the fields accessible at the macro expansion point, or [[Everywhere]] to keep only the fields
+      * accessible from any scope (public).
+      *
+      * On Scala 2 a non-public case field `b` is read through the public synthetic accessor `b$access$1` that scalac
+      * generates for it; the returned map is keyed by the declared field name (`b`) on both platforms, and visibility
+      * filtering follows the declared field's visibility on both platforms as well.
+      */
     def caseFieldValuesAt(
         instance: Expr[A],
-        visibility: Accessible = Everywhere
+        visibility: Accessible = Unrestricted
     ): ListMap[String, Expr_??] = ListMap.from(caseFields.filter(_.isAvailable(visibility)).map { field =>
       (field match {
         case oi: Method.OnInstance if field.isNullary =>
@@ -284,7 +294,7 @@ trait Classes { this: MacroCommons =>
             case r: Method.Result[?] =>
               import r.Returned
               r.build() match {
-                case Right(value) => field.name -> value.as_??
+                case Right(value) => CaseClass.declaredCaseFieldName(field.name) -> value.as_??
                 case Left(error)  =>
                   throw new AssertionError(
                     s"Failed to get the value of the field ${field.name} of ${tpe.prettyPrint}: $error"
@@ -310,6 +320,16 @@ trait Classes { this: MacroCommons =>
     }
   }
   object CaseClass {
+
+    /** On Scala 2 the case accessor of a non-public case field `b` is the public synthetic `b$access$N` method.
+      * Normalizes such names back to the declared field name, so that e.g. [[CaseClass.caseFieldValuesAt]] is keyed
+      * identically on Scala 2 and Scala 3.
+      */
+    private[Classes] val syntheticCaseAccessorName = "(.+)\\$access\\$\\d+".r
+    private[Classes] def declaredCaseFieldName(name: String): String = name match {
+      case syntheticCaseAccessorName(fieldName) => fieldName
+      case _                                    => name
+    }
 
     def unapply[A](tpe: Type[A]): Option[CaseClass[A]] =
       if (tpe.isCaseClass) tpe.primaryConstructor.map(new CaseClass(tpe, _))

--- a/hearth/src/main/scala/hearth/typed/Classes.scala
+++ b/hearth/src/main/scala/hearth/typed/Classes.scala
@@ -371,25 +371,50 @@ trait Classes { this: MacroCommons =>
 
     lazy val exhaustiveChildren: Option[NonEmptyMap[String, ??<:[A]]] = tpe.exhaustiveChildren
 
+    /** Children in the order their match cases have to be emitted.
+      *
+      * For sealed hierarchies/enumerations the declaration order is kept (cases are disjoint, order is irrelevant). For
+      * union types the order matters: value/identity matches (precise) are emitted first, then TypeTest extractor cases
+      * (total, user-provided discriminators for members a class test cannot tell apart), and runtime class tests last -
+      * a class-tested value can only reach its case after every TypeTest-discriminated member had the chance to consume
+      * it, so overlapping erasures cannot dispatch to the wrong branch.
+      */
+    private lazy val childrenInMatchOrder: List[(String, ??<:[A])] =
+      if (!Type.isUnionType[A]) directChildren.toList
+      else
+        // $COVERAGE-OFF$ union types exist only on Scala 3
+        directChildren.toList.sortBy { case (_, child) =>
+          import child.Underlying as A0
+          if (Type.isVal[A0] || Type.isObject[A0]) 0 // matched by value/identity
+          else if (Type.unionMemberRequiresTypeTest[A, A0]) 1 // matched by user-provided TypeTest
+          else 2 // matched by runtime class test
+        } // sortBy is stable: members of the same group keep their declaration order
+    // $COVERAGE-ON$
+
+    private def matchCaseFor[A0: Type](name: String): MatchCase[Expr[A0]] =
+      if (Type.isUnionType[A] && Type.unionMemberRequiresTypeTest[A, A0])
+        // $COVERAGE-OFF$ TypeTest-discriminated union members exist only on Scala 3
+        MatchCase.typeTestMatch[A, A0](name)
+      // $COVERAGE-ON$
+      // Use eqValue for enum vals with erased types (Scala 3 parameterless enum cases, Java enum vals)
+      // but NOT for case objects where typeMatch preserves exhaustivity checking
+      else if (Type.isVal[A0] && !Type.isObject[A0])
+        Expr.singletonOf[A0] match {
+          // $COVERAGE-OFF$ singletonOf returns Some only for Scala 3 enum vals, not testable on Scala 2
+          case Some(singleton) => MatchCase.eqValue[A0](singleton, name)
+          // $COVERAGE-ON$
+          case None => MatchCase.typeMatch[A0](name)
+        }
+      else MatchCase.typeMatch[A0](name)
+
     def matchOn[F[_]: DirectStyle: Applicative, B: Type](
         value: Expr[A]
     )(handle: Expr_??<:[A] => F[Expr[B]]): F[Option[Expr[B]]] =
-      directChildren.toList
+      childrenInMatchOrder
         .traverse { case (name, child) =>
           DirectStyle[F].scoped { runSafe =>
             import child.Underlying as A0
-            // Use eqValue for enum vals with erased types (Scala 3 parameterless enum cases, Java enum vals)
-            // but NOT for case objects where typeMatch preserves exhaustivity checking
-            val mc: MatchCase[Expr[A0]] =
-              if (Type.isVal[A0] && !Type.isObject[A0])
-                Expr.singletonOf[A0] match {
-                  // $COVERAGE-OFF$ singletonOf returns Some only for Scala 3 enum vals, not testable on Scala 2
-                  case Some(singleton) => MatchCase.eqValue[A0](singleton, name)
-                  // $COVERAGE-ON$
-                  case None => MatchCase.typeMatch[A0](name)
-                }
-              else MatchCase.typeMatch[A0](name)
-            mc.map { matched =>
+            matchCaseFor[A0](name).map { matched =>
               runSafe(handle(matched.as_??<:[A]))
             }
           }
@@ -403,22 +428,11 @@ trait Classes { this: MacroCommons =>
     def parMatchOn[F[_]: DirectStyle: Parallel, B: Type](
         value: Expr[A]
     )(handle: Expr_??<:[A] => F[Expr[B]]): F[Option[Expr[B]]] =
-      directChildren.toList
+      childrenInMatchOrder
         .parTraverse { case (name, child) =>
           DirectStyle[F].scoped { runSafe =>
             import child.Underlying as A0
-            // Use eqValue for enum vals with erased types (Scala 3 parameterless enum cases, Java enum vals)
-            // but NOT for case objects where typeMatch preserves exhaustivity checking
-            val mc: MatchCase[Expr[A0]] =
-              if (Type.isVal[A0] && !Type.isObject[A0])
-                Expr.singletonOf[A0] match {
-                  // $COVERAGE-OFF$ singletonOf returns Some only for Scala 3 enum vals, not testable on Scala 2
-                  case Some(singleton) => MatchCase.eqValue[A0](singleton, name)
-                  // $COVERAGE-ON$
-                  case None => MatchCase.typeMatch[A0](name)
-                }
-              else MatchCase.typeMatch[A0](name)
-            mc.map { matched =>
+            matchCaseFor[A0](name).map { matched =>
               runSafe(handle(matched.as_??<:[A]))
             }
           }
@@ -452,11 +466,14 @@ trait Classes { this: MacroCommons =>
       unapply(Type[A]) match {
         case Some(e) => ClassViewResult.Compatible(e)
         case None    =>
-          if (Type.isSealed[A] || Type.isEnumeration[A] || Type.isUnionType[A])
+          if (Type.isSealed[A] || Type.isEnumeration[A] || Type.isUnionType[A]) {
+            // For refused unions we might know an actionable reason (e.g. members that need a TypeTest) -
+            // unionRefusalReason is Scala 3-only and always None on Scala 2.
+            val reason = Type.unionRefusalReason[A].fold("")(r => s": $r")
             ClassViewResult.Incompatible(
-              s"${Type.prettyPrint[A]} is sealed/enumeration/union but has no direct children"
+              s"${Type.prettyPrint[A]} is sealed/enumeration/union but has no direct children$reason"
             )
-          else
+          } else
             ClassViewResult.Incompatible(
               s"${Type.prettyPrint[A]} is not sealed, not an enumeration, and not a union type"
             )

--- a/hearth/src/main/scala/hearth/typed/ExprCodecDerivation.scala
+++ b/hearth/src/main/scala/hearth/typed/ExprCodecDerivation.scala
@@ -58,7 +58,11 @@ trait ExprCodecDerivation { this: MacroCommons =>
             val fieldValue = product.productElement(idx)
             semiQuoteInternal[F](fieldValue.asInstanceOf[F], overrides) match {
               case Right(fieldExpr) =>
-                Right(acc + (field.name -> fieldExpr.as_??(using Expr.typeOf(fieldExpr))))
+                // Expr.typeOf can report a stale/abstract type for exprs built by generic built-in codecs (e.g. on
+                // Scala 2 SeqExprCodec[A] captures its own type parameter A) - fall back to the declared field type.
+                val exprType = Expr.typeOf(fieldExpr)
+                val fieldType0 = if (exprType <:< Type[F]) exprType else Type[F]
+                Right(acc + (field.name -> fieldExpr.as_??(using fieldType0)))
               case Left(err) => Left(err)
             }
         }
@@ -208,5 +212,18 @@ trait ExprCodecDerivation { this: MacroCommons =>
     else if (Type[F] =:= Type.of[BigInt]) Some(Expr.BigIntExprCodec.asInstanceOf[ExprCodec[Any]])
     else if (Type[F] =:= Type.of[BigDecimal]) Some(Expr.BigDecimalExprCodec.asInstanceOf[ExprCodec[Any]])
     else if (Type[F] =:= Type.of[hearth.data.Data]) Some(Expr.DataExprCodec.asInstanceOf[ExprCodec[Any]])
-    else None
+    else
+      // Vararg case-class fields/parameters are normalized to scala.collection.immutable.Seq[A], so Seq of
+      // built-in-codec elements has to be supported for vararg case classes to round-trip.
+      seqTypeCtor.unapply(Type[F]).flatMap { elem =>
+        import elem.Underlying as E
+        if (Type[F] =:= seqTypeCtor[E])
+          lookupBuiltInExprCodec[E].map { elemCodec =>
+            implicit val elemExprCodec: ExprCodec[E] = elemCodec.asInstanceOf[ExprCodec[E]]
+            Expr.SeqExprCodec[E].asInstanceOf[ExprCodec[Any]]
+          }
+        else None
+      }
+
+  private lazy val seqTypeCtor: Type.Ctor1[Seq] = Type.Ctor1.of[Seq]
 }

--- a/hearth/src/main/scala/hearth/typed/ExprCodecDerivation.scala
+++ b/hearth/src/main/scala/hearth/typed/ExprCodecDerivation.scala
@@ -58,11 +58,7 @@ trait ExprCodecDerivation { this: MacroCommons =>
             val fieldValue = product.productElement(idx)
             semiQuoteInternal[F](fieldValue.asInstanceOf[F], overrides) match {
               case Right(fieldExpr) =>
-                // Expr.typeOf can report a stale/abstract type for exprs built by generic built-in codecs (e.g. on
-                // Scala 2 SeqExprCodec[A] captures its own type parameter A) - fall back to the declared field type.
-                val exprType = Expr.typeOf(fieldExpr)
-                val fieldType0 = if (exprType <:< Type[F]) exprType else Type[F]
-                Right(acc + (field.name -> fieldExpr.as_??(using fieldType0)))
+                Right(acc + (field.name -> fieldExpr.as_??(using Expr.typeOf(fieldExpr))))
               case Left(err) => Left(err)
             }
         }

--- a/hearth/src/main/scala/hearth/typed/Exprs.scala
+++ b/hearth/src/main/scala/hearth/typed/Exprs.scala
@@ -1937,4 +1937,77 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
       val params: List[DestructuredExpr.Lambda.Param],
       val body: DestructuredExpr
   )
+
+  /** Utilities for working with annotation expressions returned by `Type.annotations`, `Method.annotations` and
+    * `Parameter.annotations`.
+    *
+    * Annotation expressions are constructor invocations (`new MyAnnotation(args...)`), so their arguments can be
+    * recovered structurally via [[DestructuredExpr]] - [[constructorArguments]] does exactly that. Combined with the
+    * `annotationsOfType`/`hasAnnotationOfType` filters this allows reading annotations without dropping to
+    * platform-specific APIs:
+    *
+    * {{{
+    * // Read the Int argument of the first @MyAnnotation(n) on type A:
+    * val n: Option[Int] = Type.annotationsOfType[A, MyAnnotation].headOption
+    *   .flatMap(ann => Annotations.constructorArguments(ann))
+    *   .flatMap(_.headOption)
+    *   .flatMap { arg =>
+    *     import arg.Underlying as ArgType
+    *     arg.value.semiEval.toOption.collect { case n: Int => n }
+    *   }
+    * }}}
+    *
+    * @since 0.4.0
+    */
+  object Annotations {
+
+    /** Filters annotation expressions to those whose type is a subtype of `Ann`, typing each result as `Expr[Ann]`.
+      *
+      * Subtype (`<:<`) matching is used (rather than `=:=`) so that a whole annotation hierarchy can be matched by its
+      * common base type. The upcast is safe because each annotation expression carries its exact type.
+      *
+      * @since 0.4.0
+      */
+    def filterOfType[Ann: Type](annotations: List[Expr_??]): List[Expr[Ann]] =
+      annotations.collect {
+        case ann if ann.Underlying <:< Type[Ann] =>
+          import ann.Underlying as ExactAnn
+          ann.value.upcast[Ann]
+      }
+
+    /** Extracts the constructor arguments of an annotation expression (`new MyAnnotation(args...)`).
+      *
+      * Returns the argument expressions flattened across all parameter lists, in order, each with its exact type
+      * (`Some(Nil)` for no-argument annotations). Returns `None` if the expression is not a constructor invocation.
+      *
+      * Individual arguments can then be decoded with `arg.value.semiEval` (after `import arg.Underlying`) or via
+      * [[ExprCodec]]-based `Expr.unapply`.
+      *
+      * @since 0.4.0
+      */
+    def constructorArguments(annotation: Expr_??): Option[List[Expr_??]] =
+      constructorArguments(annotation.value)
+
+    /** Extracts the constructor arguments of an annotation expression (`new MyAnnotation(args...)`).
+      *
+      * Variant of the `Expr_??` overload for already-typed annotation expressions, e.g. those returned by
+      * `annotationsOfType`.
+      *
+      * @since 0.4.0
+      */
+    def constructorArguments[A](annotation: Expr[A]): Option[List[Expr_??]] =
+      DestructuredExpr.parseUntyped(UntypedExpr.fromTyped(annotation)) match {
+        case mc: DestructuredExpr.MethodCall if mc.method.isConstructor =>
+          Some(
+            mc.applied
+              .collect { case av: DestructuredExpr.MethodCall.AppliedValues => av.args }
+              .flatten
+              .map { arg =>
+                import arg.tpe.Underlying as ArgType
+                arg.toUntypedExpr.asTyped[ArgType].as_??
+              }
+          )
+        case _ => None
+      }
+  }
 }

--- a/hearth/src/main/scala/hearth/typed/Exprs.scala
+++ b/hearth/src/main/scala/hearth/typed/Exprs.scala
@@ -1678,6 +1678,7 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
         }
       case lam: DestructuredExpr.Lambda => List(lam.body)
       case b: DestructuredExpr.Block    => b.statements :+ b.result
+      case va: DestructuredExpr.Varargs => va.elements
     }
 
     final def collect[B](pf: PartialFunction[DestructuredExpr, B]): List[B] = {
@@ -1900,6 +1901,31 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
         val stmts = (statements.map(_.plainPrint) :+ result.plainPrint).mkString("; ")
         s"{ $stmts }"
       }
+    }
+
+    /** A vararg (repeated) argument slot filled with individual elements: `method(a, b, c)` where the parameter is
+      * declared as `xs: A*`.
+      *
+      * The whole slot is represented as **one** argument inside [[MethodCall.AppliedValues]], mirroring how
+      * [[Method.ApplyValues]] expects a single `Expr[Seq[A]]` argument for a vararg parameter (see
+      * [[Parameter.isVararg]]). [[tpe]] is the normalized `scala.collection.immutable.Seq[A]` on both platforms, and
+      * the individual element expressions stay recoverable through [[elements]].
+      *
+      * Note: when the call site spreads an existing sequence (`method(seq*)`), there is no `Varargs` node — the slot is
+      * simply the destructured sequence expression itself (already of type `Seq[A]`).
+      *
+      * [[toUntypedExpr]] synthesizes a `scala.collection.immutable.Seq(elements*)` expression, since the raw repeated
+      * argument tree is not a valid standalone expression.
+      *
+      * @since 0.4.0
+      */
+    final class Varargs private[hearth] (
+        val tpe: ??,
+        val elements: List[DestructuredExpr],
+        private[hearth] val rebuild: () => UntypedExpr
+    ) extends DestructuredExpr {
+      def toUntypedExpr: UntypedExpr = rebuild()
+      def plainPrint: String = elements.map(_.plainPrint).mkString(", ")
     }
 
     /** A sub-expression that could not be destructured into a semantic node.

--- a/hearth/src/main/scala/hearth/typed/Exprs.scala
+++ b/hearth/src/main/scala/hearth/typed/Exprs.scala
@@ -434,6 +434,24 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
 
     def eqValue[A: Type](expr: Expr[A], freshName: FreshName = FreshName.FromExpr): MatchCase[Expr[A]]
 
+    /** Creates a case that matches the value with a user-provided `scala.reflect.TypeTest` extractor (Scala 3-only).
+      *
+      * Generates `case name @ tt(_) => ...` where `tt` is the implicit `scala.reflect.TypeTest[A, B]` summoned at the
+      * macro expansion point (`A` being the type of the matched value, `B` the type the case narrows it to). Used for
+      * union members that a runtime class test cannot discriminate soundly (same/related erasure like
+      * `List[Int] | List[String]`, abstract types, type parameters) - the `TypeTest` acts as a total runtime
+      * discriminator supplied by the user.
+      *
+      * Fails (with an `AssertionError`) when no implicit `scala.reflect.TypeTest[A, B]` is in scope; guard calls with
+      * [[Type.unionMemberRequiresTypeTest]] + [[Type.directChildren]] (which verifies summonability for unions), or
+      * make sure the instance exists. On Scala 2 (which has no `scala.reflect.TypeTest`) this method always fails the
+      * same way; guard calls with [[Type.isUnionType]] / [[Type.unionMemberRequiresTypeTest]], which are always `false`
+      * on Scala 2.
+      *
+      * @since 0.4.0
+      */
+    def typeTestMatch[A: Type, B: Type](freshName: FreshName = FreshName.FromType): MatchCase[Expr[B]]
+
     def matchOn[A: Type, B: Type](toMatch: Expr[A])(cases: NonEmptyVector[MatchCase[Expr[B]]]): Expr[B]
 
     def partition[A, B, C](matchCase: MatchCase[A])(f: A => Either[B, C]): Either[MatchCase[B], MatchCase[C]]

--- a/hearth/src/main/scala/hearth/typed/Exprs.scala
+++ b/hearth/src/main/scala/hearth/typed/Exprs.scala
@@ -2053,5 +2053,38 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
           )
         case _ => None
       }
+
+    /** Extracts the constructor arguments of an annotation expression and decodes each to its runtime value.
+      *
+      * Convenience over [[constructorArguments]] + `semiEval`: each argument is evaluated at macro time, so literal
+      * arguments (e.g. the `"first_name"` in `@fieldName("first_name")`) come back as plain values. Arguments that
+      * cannot be evaluated are returned as `Left` with the evaluation errors, without failing the whole list.
+      *
+      * Returns `None` if the expression is not a constructor invocation. Example:
+      *
+      * {{{
+      * // Read the String argument of the first @fieldName(...) on a constructor parameter:
+      * val name: Option[String] = param.annotationsOfType[fieldName].headOption
+      *   .flatMap(ann => Annotations.decodedConstructorArguments(ann))
+      *   .flatMap(_.headOption.flatMap(_.toOption))
+      *   .collect { case s: String => s }
+      * }}}
+      *
+      * @since 0.4.0
+      */
+    def decodedConstructorArguments(annotation: Expr_??): Option[List[Either[String, Any]]] =
+      decodedConstructorArguments(annotation.value)
+
+    /** Extracts the constructor arguments of an annotation expression and decodes each to its runtime value.
+      *
+      * Variant of the `Expr_??` overload for already-typed annotation expressions, e.g. those returned by
+      * `annotationsOfType`.
+      *
+      * @since 0.4.0
+      */
+    def decodedConstructorArguments[A](annotation: Expr[A]): Option[List[Either[String, Any]]] =
+      constructorArguments(annotation).map(_.map { arg =>
+        (arg.value.semiEval: Either[NonEmptyVector[String], Any]).left.map(_.mkString(", "))
+      })
   }
 }

--- a/hearth/src/main/scala/hearth/typed/Exprs.scala
+++ b/hearth/src/main/scala/hearth/typed/Exprs.scala
@@ -1986,7 +1986,7 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
     * `Parameter.annotations`.
     *
     * Annotation expressions are constructor invocations (`new MyAnnotation(args...)`), so their arguments can be
-    * recovered structurally via [[DestructuredExpr]] - [[constructorArguments]] does exactly that. Combined with the
+    * recovered structurally via [[DestructuredExpr]] - `constructorArguments` does exactly that. Combined with the
     * `annotationsOfType`/`hasAnnotationOfType` filters this allows reading annotations without dropping to
     * platform-specific APIs:
     *
@@ -2056,7 +2056,7 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
 
     /** Extracts the constructor arguments of an annotation expression and decodes each to its runtime value.
       *
-      * Convenience over [[constructorArguments]] + `semiEval`: each argument is evaluated at macro time, so literal
+      * Convenience over `constructorArguments` + `semiEval`: each argument is evaluated at macro time, so literal
       * arguments (e.g. the `"first_name"` in `@fieldName("first_name")`) come back as plain values. Arguments that
       * cannot be evaluated are returned as `Left` with the evaluation errors, without failing the whole list.
       *

--- a/hearth/src/main/scala/hearth/typed/Methods.scala
+++ b/hearth/src/main/scala/hearth/typed/Methods.scala
@@ -599,4 +599,12 @@ trait Methods { this: MacroCommons =>
 
   /** Class/Method might package private/protected modifier but we are in the same package */
   case object AtCallSite extends Accessible
+
+  /** No accessibility requirement - every class/method matches, regardless of its visibility.
+    *
+    * Useful when we only want to enumerate members (e.g. all case fields) without filtering out the non-public ones.
+    *
+    * @since 0.4.0
+    */
+  case object Unrestricted extends Accessible
 }

--- a/hearth/src/main/scala/hearth/typed/Methods.scala
+++ b/hearth/src/main/scala/hearth/typed/Methods.scala
@@ -31,7 +31,12 @@ trait Methods { this: MacroCommons =>
     *   - annotations
     *   - resolved type
     *   - checking if parameter is by-name
+    *   - checking if parameter is vararg (repeated)
     *   - checking if parameter is implicit
+    *
+    * For vararg parameters [[tpe]] is normalized to `scala.collection.immutable.Seq[A]` on both platforms (instead of
+    * the platform-specific repeated-parameter marker type `A*`), and the argument passed for such parameter should be
+    * an `Expr[Seq[A]]` - it will be spliced into the call as `seq: _*`.
     *
     * @since 0.1.0
     */
@@ -70,6 +75,16 @@ trait Methods { this: MacroCommons =>
     }
 
     lazy val isByName: Boolean = asUntyped.isByName
+
+    /** Whether the parameter is a vararg/repeated parameter (`xs: A*`).
+      *
+      * For such parameters [[tpe]] is normalized to `scala.collection.immutable.Seq[A]` on both platforms, and the
+      * argument provided when calling the method (via [[Method.ApplyValues]], `fold`, etc.) should be an `Expr[Seq[A]]` -
+      * it will be spliced into the call as `seq: _*`.
+      *
+      * @since 0.4.0
+      */
+    lazy val isVararg: Boolean = asUntyped.isVararg
     lazy val isImplicit: Boolean = asUntyped.isImplicit
   }
 

--- a/hearth/src/main/scala/hearth/typed/Methods.scala
+++ b/hearth/src/main/scala/hearth/typed/Methods.scala
@@ -74,6 +74,30 @@ trait Methods { this: MacroCommons =>
       UntypedExpr.as_??(expr, tpe)
     }
 
+    /** Annotations on this parameter whose type is a subtype of `Ann`, with each expression typed as `Expr[Ann]`.
+      *
+      * Subtype (`<:<`) matching is used (rather than `=:=`) so that a whole annotation hierarchy can be matched by its
+      * common base type. The constructor arguments of a matched annotation can be read with
+      * [[Annotations.constructorArguments]].
+      *
+      * Example - finding case-class fields that carry a marker annotation (e.g. `@sensitiveData`):
+      *
+      * {{{
+      * val sensitiveFields = caseClass.primaryConstructor.totalParameters.flatten.collect {
+      *   case (name, param) if param.hasAnnotationOfType[sensitiveData] => name
+      * }
+      * }}}
+      *
+      * @since 0.4.0
+      */
+    def annotationsOfType[Ann: Type]: List[Expr[Ann]] = Annotations.filterOfType[Ann](annotations)
+
+    /** Whether this parameter has at least one annotation whose type is a subtype of `Ann`.
+      *
+      * @since 0.4.0
+      */
+    def hasAnnotationOfType[Ann: Type]: Boolean = annotations.exists(_.Underlying <:< Type[Ann])
+
     lazy val isByName: Boolean = asUntyped.isByName
 
     /** Whether the parameter is a vararg/repeated parameter (`xs: A*`).
@@ -160,6 +184,22 @@ trait Methods { this: MacroCommons =>
       asUntyped.annotations.zip(asUntyped.annotationTypes).map { case (expr, tpe) =>
         UntypedExpr.as_??(expr, tpe)
       }
+
+    /** Annotations on this method whose type is a subtype of `Ann`, with each expression typed as `Expr[Ann]`.
+      *
+      * Subtype (`<:<`) matching is used (rather than `=:=`) so that a whole annotation hierarchy can be matched by its
+      * common base type. The constructor arguments of a matched annotation can be read with
+      * [[Annotations.constructorArguments]].
+      *
+      * @since 0.4.0
+      */
+    final def annotationsOfType[Ann: Type]: List[Expr[Ann]] = Annotations.filterOfType[Ann](annotations)
+
+    /** Whether this method has at least one annotation whose type is a subtype of `Ann`.
+      *
+      * @since 0.4.0
+      */
+    final def hasAnnotationOfType[Ann: Type]: Boolean = annotations.exists(_.Underlying <:< Type[Ann])
 
     final lazy val isConstructor: Boolean = asUntyped.isConstructor
 

--- a/hearth/src/main/scala/hearth/typed/Types.scala
+++ b/hearth/src/main/scala/hearth/typed/Types.scala
@@ -206,6 +206,29 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
     final def isNamedTuple[A: Type]: Boolean = UntypedType.fromTyped[A].isNamedTuple
     final def isUnionType[A: Type]: Boolean = UntypedType.fromTyped[A].isUnionType
 
+    /** Whether the member `B` of the union type `A` has to be discriminated with a user-provided
+      * `scala.reflect.TypeTest[A, B]` rather than a runtime class test (Scala 3-only).
+      *
+      * `true` for non-singleton union members whose runtime class either cannot be determined (abstract types, type
+      * parameters) or is not disjoint from another member's runtime class (same/related erasure, e.g. `List[Int]` and
+      * `List[String]`). Always `false` on Scala 2 (which has no union types).
+      *
+      * @since 0.4.0
+      */
+    final def unionMemberRequiresTypeTest[A: Type, B: Type]: Boolean =
+      UntypedType.fromTyped[A].unionMemberRequiresTypeTest(UntypedType.fromTyped[B])
+
+    /** Human-readable reason why [[directChildren]] refused to decompose the union type `A` (Scala 3-only).
+      *
+      * Currently provided only when some members are not runtime-distinguishable and no implicit
+      * `scala.reflect.TypeTest[A, Member]` was found for them - the message names the missing instances. Returns `None`
+      * when the type is not a refused union, or when the refusal has no actionable fix (e.g. members with static
+      * subtype relationships). Always `None` on Scala 2 (which has no union types).
+      *
+      * @since 0.4.0
+      */
+    final def unionRefusalReason[A: Type]: Option[String] = UntypedType.fromTyped[A].unionRefusalReason
+
     final def isAbstract[A: Type]: Boolean = UntypedType.fromTyped[A].isAbstract
     final def isFinal[A: Type]: Boolean = UntypedType.fromTyped[A].isFinal
     final def isTrait[A: Type]: Boolean = UntypedType.fromTyped[A].isTrait
@@ -753,6 +776,8 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
     def isTuple: Boolean = Type.isTuple(using tpe)
     def isNamedTuple: Boolean = Type.isNamedTuple(using tpe)
     def isUnionType: Boolean = Type.isUnionType(using tpe)
+    def unionMemberRequiresTypeTest[B: Type]: Boolean = Type.unionMemberRequiresTypeTest[A, B](using tpe, Type[B])
+    def unionRefusalReason: Option[String] = Type.unionRefusalReason(using tpe)
 
     def isAbstract: Boolean = Type.isAbstract(using tpe)
     def isFinal: Boolean = Type.isFinal(using tpe)

--- a/hearth/src/main/scala/hearth/typed/Types.scala
+++ b/hearth/src/main/scala/hearth/typed/Types.scala
@@ -28,6 +28,29 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
     */
   type Type[A]
 
+  /** Phantom type constructor of kind `* -> *`, standing in for a type constructor that was discovered during macro
+    * execution rather than written literally in the macro's sources (see [[Type.decompose1]]).
+    *
+    * It is never instantiated nor extended — only its role as a placeholder label matters: a `Type[AnyK1[X]]` returned
+    * by APIs using this placeholder is backed by the platform representation of the real constructor (e.g. `G[X]`), so
+    * printing, comparisons and implicit summoning all see the real type, even though static typing shows `AnyK1`.
+    *
+    * @since 0.4.0
+    */
+  sealed trait AnyK1[A]
+
+  /** Phantom type constructor of kind `(*, *) -> *`, standing in for a type constructor that was discovered during
+    * macro execution rather than written literally in the macro's sources (see [[Type.decompose2]]).
+    *
+    * It is never instantiated nor extended — only its role as a placeholder label matters: a `Type[AnyK2[X, Y]]`
+    * returned by APIs using this placeholder is backed by the platform representation of the real constructor (e.g.
+    * `G[X, Y]`), so printing, comparisons and implicit summoning all see the real type, even though static typing shows
+    * `AnyK2`.
+    *
+    * @since 0.4.0
+    */
+  sealed trait AnyK2[A, B]
+
   val Type: TypeModule
   trait TypeModule extends Ctors with TypeCrossQuotes with TypeCompat { this: Type.type =>
 
@@ -263,6 +286,70 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
 
     final def isSubtypeOf[A: Type, B: Type]: Boolean = UntypedType.fromTyped[A] <:< UntypedType.fromTyped[B]
     final def isSameAs[A: Type, B: Type]: Boolean = UntypedType.fromTyped[A] =:= UntypedType.fromTyped[B]
+
+    /** Type arguments of an applied type, e.g. `List(Type[Int])` for `List[Int]`, `Nil` for non-applied types.
+      *
+      * Typed counterpart of `UntypedType.typeArguments`.
+      *
+      * @since 0.4.0
+      */
+    final def typeArguments[A: Type]: List[??] = UntypedType.typeArguments(UntypedType.fromTyped[A]).map(_.as_??)
+
+    /** Checks whether 2 types are built from the same type constructor (compared by type symbol, after dealiasing),
+      * ignoring their type arguments, e.g. `List[Int]` and `List[String]` agree, but `List[Int]` and `Vector[Int]` do
+      * not.
+      *
+      * Typed counterpart of `UntypedType.sameTypeConstructorAs`. To compare against a constructor obtained from
+      * `Type.CtorN`, use `ctor.sameTypeConstructorAs(other)` instead.
+      *
+      * @since 0.4.0
+      */
+    final def hasSameTypeConstructor[A: Type, B: Type]: Boolean =
+      UntypedType.sameTypeConstructorAs(UntypedType.fromTyped[A], UntypedType.fromTyped[B])
+
+    /** Decomposes an applied type `G[X]` (where the constructor `G` is NOT known statically) into its type constructor
+      * and its type argument, e.g. turns `Type[List[Int]]` into `Type.Ctor1` of `List` and `Type[Int]` (as `??`).
+      *
+      * The constructor is returned as a fully functional `Type.Ctor1` (created via `Type.Ctor1.fromUntyped`), so it can
+      * be re-applied to other types (`ctor[B]`), pattern-matched against other applied types (`ctor.unapply`), compared
+      * (`ctor.sameTypeConstructorAs`), or passed where `Type.Ctor1` is expected (e.g. `Type.CtorK1#apply` to build
+      * `Type[HKT[G]]` and summon a type class for the discovered constructor). Since `G` has no statically known name,
+      * the phantom label [[AnyK1]] is used in its place - the underlying platform representation is the real
+      * constructor.
+      *
+      * Returns `None` for non-applied types and for types applied to a number of arguments different than 1 (the type
+      * is dealiased first, so e.g. `type StringMap[V] = Map[String, V]` decomposes as `Map[String, V]` would - into 2
+      * arguments - rather than as a unary constructor).
+      *
+      * @since 0.4.0
+      */
+    final def decompose1[A: Type]: Option[(Ctor1[AnyK1], ??)] = {
+      val dealiased = UntypedType.dealias(UntypedType.fromTyped[A])
+      UntypedType.typeArguments(dealiased) match {
+        case arg :: Nil => Some((Ctor1.fromUntyped[AnyK1](UntypedType.typeConstructor(dealiased)), arg.as_??))
+        case _          => None
+      }
+    }
+
+    /** Decomposes an applied type `G[X, Y]` (where the constructor `G` is NOT known statically) into its type
+      * constructor and its type arguments, e.g. turns `Type[Map[String, Int]]` into `Type.Ctor2` of `Map` and
+      * `(Type[String], Type[Int])` (as `??`s).
+      *
+      * Binary-constructor counterpart of [[decompose1]] - see its documentation for the details of the contract. Since
+      * `G` has no statically known name, the phantom label [[AnyK2]] is used in its place.
+      *
+      * Returns `None` for non-applied types and for types applied to a number of arguments different than 2.
+      *
+      * @since 0.4.0
+      */
+    final def decompose2[A: Type]: Option[(Ctor2[AnyK2], (??, ??))] = {
+      val dealiased = UntypedType.dealias(UntypedType.fromTyped[A])
+      UntypedType.typeArguments(dealiased) match {
+        case arg1 :: arg2 :: Nil =>
+          Some((Ctor2.fromUntyped[AnyK2](UntypedType.typeConstructor(dealiased)), (arg1.as_??, arg2.as_??)))
+        case _ => None
+      }
+    }
 
     // Literal types
 

--- a/hearth/src/main/scala/hearth/typed/Types.scala
+++ b/hearth/src/main/scala/hearth/typed/Types.scala
@@ -160,6 +160,24 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
     )
     final def isTypeSystemSpecial[A: Type]: Boolean = UntypedType.fromTyped[A].isTypeSystemSpecial
     final def isOpaqueType[A: Type]: Boolean = UntypedType.fromTyped[A].isOpaqueType
+
+    /** Underlying type of an opaque type, as seen from outside its defining scope (Scala 3-only).
+      *
+      * Resolves the right-hand side of `opaque type X = Y` even through:
+      *   - bounds (`opaque type X <: Int = Int` resolves to `Int`, not the bound),
+      *   - chains of opaque types (`opaque type Outer = Inner` where `Inner` is itself opaque resolves to the innermost
+      *     underlying type),
+      *   - applied parameterized opaques (`opaque type Wrapper[A] = List[A]` applied as `Wrapper[Int]` resolves to
+      *     `List[Int]`),
+      *   - plain aliases to opaque types (`type Alias = X` resolves to `X`'s underlying type).
+      *
+      * Returns `None` when the type is not an opaque type, or when the underlying type cannot be determined. Always
+      * returns `None` on Scala 2 (which has no opaque types).
+      *
+      * @since 0.4.0
+      */
+    final def opaqueUnderlyingType[A: Type]: Option[??] =
+      UntypedType.fromTyped[A].opaqueUnderlyingType.map(_.as_??)
     final def isTuple[A: Type]: Boolean = UntypedType.fromTyped[A].isTuple
     final def isNamedTuple[A: Type]: Boolean = UntypedType.fromTyped[A].isNamedTuple
     final def isUnionType[A: Type]: Boolean = UntypedType.fromTyped[A].isUnionType
@@ -705,6 +723,7 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
     def isJvmBuiltIn: Boolean = Type.isJvmBuiltIn(using tpe)
     def isTypeSystemSpecial: Boolean = Type.isTypeSystemSpecial(using tpe)
     def isOpaqueType: Boolean = Type.isOpaqueType(using tpe)
+    def opaqueUnderlyingType: Option[??] = Type.opaqueUnderlyingType(using tpe)
     def isTuple: Boolean = Type.isTuple(using tpe)
     def isNamedTuple: Boolean = Type.isNamedTuple(using tpe)
     def isUnionType: Boolean = Type.isUnionType(using tpe)

--- a/hearth/src/main/scala/hearth/typed/Types.scala
+++ b/hearth/src/main/scala/hearth/typed/Types.scala
@@ -119,6 +119,30 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
       }
     }
 
+    /** Annotations on type `A` whose type is a subtype of `Ann`, with each expression typed as `Expr[Ann]`.
+      *
+      * Subtype (`<:<`) matching is used (rather than `=:=`) so that a whole annotation hierarchy can be matched by its
+      * common base type. The constructor arguments of a matched annotation can be read with
+      * [[Annotations.constructorArguments]].
+      *
+      * Example - finding case-class fields that carry a marker annotation (e.g. `@sensitiveData`):
+      *
+      * {{{
+      * val sensitiveFields = caseClass.primaryConstructor.totalParameters.flatten.collect {
+      *   case (name, param) if param.hasAnnotationOfType[sensitiveData] => name
+      * }
+      * }}}
+      *
+      * @since 0.4.0
+      */
+    final def annotationsOfType[A: Type, Ann: Type]: List[Expr[Ann]] = Annotations.filterOfType[Ann](annotations[A])
+
+    /** Whether type `A` has at least one annotation whose type is a subtype of `Ann`.
+      *
+      * @since 0.4.0
+      */
+    final def hasAnnotationOfType[A: Type, Ann: Type]: Boolean = annotations[A].exists(_.Underlying <:< Type[Ann])
+
     /** Types which might be compiled to both JVM primitives and java.lang.Object: Boolean, Byte, Short, Char, Int,
       * Long, Float, Double.
       */
@@ -711,6 +735,8 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
     def exhaustiveChildren: Option[NonEmptyMap[String, ??<:[A]]] = Type.exhaustiveChildren(using tpe)
 
     def annotations: List[Expr_??] = Type.annotations(using tpe)
+    def annotationsOfType[Ann: Type]: List[Expr[Ann]] = Type.annotationsOfType[A, Ann](using tpe, Type[Ann])
+    def hasAnnotationOfType[Ann: Type]: Boolean = Type.hasAnnotationOfType[A, Ann](using tpe, Type[Ann])
 
     def summonExpr: SummoningResult[A] = Expr.summonImplicit(using tpe)
     def summonExprIgnoring(excluded: UntypedMethod*): SummoningResult[A] =

--- a/hearth/src/main/scala/hearth/untyped/UntypedMethods.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedMethods.scala
@@ -96,6 +96,7 @@ trait UntypedMethods { this: MacroCommons =>
     def annotationTypes: List[UntypedType]
 
     def isByName: Boolean
+    def isVararg: Boolean
     def isImplicit: Boolean
     def hasDefault: Boolean
 
@@ -157,7 +158,7 @@ trait UntypedMethods { this: MacroCommons =>
             // Default value is called on the same instance as it's method, and without any arguments
             method.unsafeApply(instanceTpe)(instance, Map.empty)
           }
-          arguments.get(paramName).orElse(defaultValue).getOrElse {
+          val provided = arguments.get(paramName).orElse(defaultValue).getOrElse {
             // $COVERAGE-OFF$
             hearthRequirementFailed(
               s"""Expected that ${instanceTpe.prettyPrint}'s ${method.name} parameter `$paramName` would be provided or have a default value.
@@ -165,9 +166,20 @@ trait UntypedMethods { this: MacroCommons =>
             )
             // $COVERAGE-ON$
           }
+          // Vararg (repeated) parameters expect an Expr[Seq[A]] argument - splice it as `seq: _*`.
+          if (untyped.isVararg) adaptVarargArgument(provided) else provided
         }.toList
       }
   }
+
+  /** Platform-specific: wraps an `Expr[Seq[A]]` argument so that it can be spliced into a vararg (repeated) parameter
+    * position - the equivalent of writing `method(seq: _*)` (Scala 2) / `method(seq*)` (Scala 3) in source code.
+    *
+    * Used by [[UntypedArgumentsMethods.adaptToParams]] when the corresponding [[UntypedParameter]] `isVararg`.
+    *
+    * @since 0.4.0
+    */
+  protected def adaptVarargArgument(expr: UntypedExpr): UntypedExpr
 
   /** Platform-specific method representation (`c.universe.MethodSymbol` in 2, `quotes.reflect.Symbol` in 3).
     *

--- a/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
@@ -131,6 +131,28 @@ trait UntypedTypes { this: MacroCommons =>
     def isNamedTuple(instanceTpe: UntypedType): Boolean = false
     def isUnionType(instanceTpe: UntypedType): Boolean = false
 
+    /** Whether the given member of the given union type has to be discriminated with a user-provided
+      * `scala.reflect.TypeTest[Union, Member]` rather than a runtime class test (Scala 3-only).
+      *
+      * `true` for non-singleton union members whose runtime class either cannot be determined (abstract types, type
+      * parameters) or is not disjoint from another member's runtime class (same/related erasure, e.g. `List[Int]` and
+      * `List[String]`). Always `false` on Scala 2 (which has no union types).
+      *
+      * @since 0.4.0
+      */
+    def unionMemberRequiresTypeTest(unionTpe: UntypedType, member: UntypedType): Boolean = false
+
+    /** Human-readable reason why [[directChildren]] refused to decompose the given union type (Scala 3-only).
+      *
+      * Currently provided only when some members are not runtime-distinguishable and no implicit
+      * `scala.reflect.TypeTest[Union, Member]` was found for them - the message names the missing instances. Returns
+      * `None` when the type is not a refused union, or when the refusal has no actionable fix (e.g. members with static
+      * subtype relationships). Always `None` on Scala 2 (which has no union types).
+      *
+      * @since 0.4.0
+      */
+    def unionRefusalReason(instanceTpe: UntypedType): Option[String] = None
+
     def isAbstract(instanceTpe: UntypedType): Boolean
     def isFinal(instanceTpe: UntypedType): Boolean
     def isTrait(instanceTpe: UntypedType): Boolean
@@ -243,6 +265,9 @@ trait UntypedTypes { this: MacroCommons =>
     def isTuple: Boolean = UntypedType.isTuple(untyped)
     def isNamedTuple: Boolean = UntypedType.isNamedTuple(untyped)
     def isUnionType: Boolean = UntypedType.isUnionType(untyped)
+    def unionMemberRequiresTypeTest(member: UntypedType): Boolean =
+      UntypedType.unionMemberRequiresTypeTest(untyped, member)
+    def unionRefusalReason: Option[String] = UntypedType.unionRefusalReason(untyped)
 
     def isAbstract: Boolean = UntypedType.isAbstract(untyped)
     def isFinal: Boolean = UntypedType.isFinal(untyped)

--- a/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
@@ -162,7 +162,13 @@ trait UntypedTypes { this: MacroCommons =>
       val isEnum = instanceTpe.isEnumeration
       directChildren(instanceTpe)
         .flatMap(_.foldLeft[Option[Vector[(String, UntypedType)]]](Some(Vector.empty)) {
-          case (None, _)                                                                    => None
+          case (None, _) => None
+          // Stable singleton subtypes (case objects, Scala 3 enum case vals, Java enum values) are leaves:
+          // they are matched by value, so we must NOT recurse into them even when their type symbol points
+          // at a sealed parent (e.g. Color.Red.type's type symbol is the sealed enum class Color). Keeping
+          // the entry as-is preserves the key chosen by directChildren (e.g. plainPrint for union members).
+          case (Some(vector), nameSubtype @ (_, subtype)) if subtype.isObject || subtype.isVal =>
+            Some(vector :+ nameSubtype)
           case (Some(vector), (_, subtype)) if subtype.isSealed && !subtype.isJavaEnumValue =>
             exhaustiveChildren(subtype).map(vector ++ _.toVector)
           // For enumerations, children are value instances — they may appear abstract due to the Value class

--- a/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
@@ -110,6 +110,23 @@ trait UntypedTypes { this: MacroCommons =>
 
     def isInJavaLangPackage(instanceTpe: UntypedType): Boolean
     def isOpaqueType(instanceTpe: UntypedType): Boolean
+
+    /** Underlying type of an opaque type, as seen from outside its defining scope (Scala 3-only).
+      *
+      * Resolves the right-hand side of `opaque type X = Y` even through:
+      *   - bounds (`opaque type X <: Int = Int` resolves to `Int`, not the bound),
+      *   - chains of opaque types (`opaque type Outer = Inner` where `Inner` is itself opaque resolves to the innermost
+      *     underlying type),
+      *   - applied parameterized opaques (`opaque type Wrapper[A] = List[A]` applied as `Wrapper[Int]` resolves to
+      *     `List[Int]`),
+      *   - plain aliases to opaque types (`type Alias = X` resolves to `X`'s underlying type).
+      *
+      * Returns `None` when the type is not an opaque type, or when the underlying type cannot be determined. Always
+      * returns `None` on Scala 2 (which has no opaque types).
+      *
+      * @since 0.4.0
+      */
+    def opaqueUnderlyingType(instanceTpe: UntypedType): Option[UntypedType]
     def isTuple(instanceTpe: UntypedType): Boolean
     def isNamedTuple(instanceTpe: UntypedType): Boolean = false
     def isUnionType(instanceTpe: UntypedType): Boolean = false
@@ -222,6 +239,7 @@ trait UntypedTypes { this: MacroCommons =>
     def isJvmBuiltIn: Boolean = UntypedType.isJvmBuiltIn(untyped)
     def isTypeSystemSpecial: Boolean = UntypedType.isTypeSystemSpecial(untyped)
     def isOpaqueType: Boolean = UntypedType.isOpaqueType(untyped)
+    def opaqueUnderlyingType: Option[UntypedType] = UntypedType.opaqueUnderlyingType(untyped)
     def isTuple: Boolean = UntypedType.isTuple(untyped)
     def isNamedTuple: Boolean = UntypedType.isNamedTuple(untyped)
     def isUnionType: Boolean = UntypedType.isUnionType(untyped)

--- a/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
@@ -224,8 +224,34 @@ trait UntypedTypes { this: MacroCommons =>
         .flatMap(NonEmptyMap.fromListMap(_))
     }
 
+    /** Strips type aliases, e.g. turns `type StringList = List[String]` into `List[String]`.
+      *
+      * @since 0.4.0
+      */
+    def dealias(untyped: UntypedType): UntypedType
+
+    /** Extracts the type constructor of an applied type (after dealiasing), e.g. `List` for `List[Int]`.
+      *
+      * For non-applied types returns the (dealiased) type itself. The result can be re-applied with [[applyTypeArgs]],
+      * or wrapped back into the typed layer with `Type.CtorN.fromUntyped`.
+      *
+      * @since 0.4.0
+      */
+    def typeConstructor(untyped: UntypedType): UntypedType
+
     def typeArguments(untyped: UntypedType): List[UntypedType]
     def applyTypeArgs(untyped: UntypedType, args: List[UntypedType]): UntypedType
+
+    /** Checks whether 2 types are built from the same type constructor (compared by type symbol, after dealiasing),
+      * ignoring their type arguments, e.g. `List[Int]` and `List[String]` agree, but `List[Int]` and `Vector[Int]` do
+      * not.
+      *
+      * Works for both applied types (`List[Int]`) and bare constructors (`List` obtained from [[typeConstructor]] or
+      * `Type.CtorN.asUntyped`).
+      *
+      * @since 0.4.0
+      */
+    def sameTypeConstructorAs(a: UntypedType, b: UntypedType): Boolean
 
     def annotations(untyped: UntypedType): List[UntypedExpr]
     def annotationTypes(untyped: UntypedType): List[UntypedType]
@@ -307,7 +333,9 @@ trait UntypedTypes { this: MacroCommons =>
 
     def defaultValue(param: UntypedParameter): Option[UntypedMethod] = UntypedMethod.defaultValue(untyped)(param)
 
+    def typeArguments: List[UntypedType] = UntypedType.typeArguments(untyped)
     def applyTypeArgs(args: List[UntypedType]): UntypedType = UntypedType.applyTypeArgs(untyped, args)
+    def sameTypeConstructorAs(other: UntypedType): Boolean = UntypedType.sameTypeConstructorAs(untyped, other)
 
     def annotations: List[UntypedExpr] = UntypedType.annotations(untyped)
     def annotationTypes: List[UntypedType] = UntypedType.annotationTypes(untyped)

--- a/project/TypeConstructorsGen.scala
+++ b/project/TypeConstructorsGen.scala
@@ -92,6 +92,13 @@ object TypeConstructorsGen {
         |      def apply[G[_]](using GCtor: Type.Ctor1[G]): Type[HKT[G]]
         |      def unapply[A](A: Type[A]): Option[UntypedType]
         |      def asUntyped: UntypedType
+        |
+        |      /** Checks whether this type constructor and `other` (a bare constructor or an applied type) share the same
+        |        * type constructor symbol (after dealiasing).
+        |        *
+        |        * @since 0.4.0
+        |        */
+        |      final def sameTypeConstructorAs(other: UntypedType): Boolean = UntypedType.sameTypeConstructorAs(asUntyped, other)
         |    }
         |    object CtorK1 {
         |
@@ -201,6 +208,13 @@ object TypeConstructorsGen {
     sb ++= s"        def apply[${ArityGen.applyParams(n)}]: Type[HKT[${allParams(n)}]]\n"
     sb ++= s"        def unapply[A](A: Type[A]): Option[${boundsTuple(n)}]\n"
     sb ++= s"        def asUntyped: UntypedType\n"
+    sb ++= s"\n"
+    sb ++= s"        /** Checks whether this type constructor and `other` (a bare constructor or an applied type) share the same\n"
+    sb ++= s"          * type constructor symbol (after dealiasing), e.g. `Type.Ctor1.of[List].sameTypeConstructorAs(UntypedType.fromTyped[List[Int]])`.\n"
+    sb ++= s"          *\n"
+    sb ++= s"          * @since 0.4.0\n"
+    sb ++= s"          */\n"
+    sb ++= s"        final def sameTypeConstructorAs(other: UntypedType): Boolean = UntypedType.sameTypeConstructorAs(asUntyped, other)\n"
 
     // set methods
     for (pos <- 0 until n) {
@@ -504,6 +518,13 @@ object TypeConstructorsGen {
         |      def apply[G[_]](implicit GCtor: Type.Ctor1[G]): Type[HKT[G]]
         |      def unapply[A](A: Type[A]): Option[UntypedType]
         |      def asUntyped: UntypedType = CtorK1.reflectiveAsUntyped(this)
+        |
+        |      /** Checks whether this type constructor and `other` (a bare constructor or an applied type) share the same
+        |        * type constructor symbol (after dealiasing).
+        |        *
+        |        * @since 0.4.0
+        |        */
+        |      final def sameTypeConstructorAs(other: UntypedType): Boolean = UntypedType.sameTypeConstructorAs(asUntyped, other)
         |    }
         |    object CtorK1 {
         |
@@ -564,6 +585,13 @@ object TypeConstructorsGen {
       sb ++= s"        /** Returns the underlying untyped type constructor representation. */\n"
     }
     sb ++= s"        def asUntyped: UntypedType = $cn.Bounded.reflectiveAsUntyped(this)\n"
+    sb ++= s"\n"
+    sb ++= s"        /** Checks whether this type constructor and `other` (a bare constructor or an applied type) share the same\n"
+    sb ++= s"          * type constructor symbol (after dealiasing), e.g. `Type.Ctor1.of[List].sameTypeConstructorAs(UntypedType.fromTyped[List[Int]])`.\n"
+    sb ++= s"          *\n"
+    sb ++= s"          * @since 0.4.0\n"
+    sb ++= s"          */\n"
+    sb ++= s"        final def sameTypeConstructorAs(other: UntypedType): Boolean = UntypedType.sameTypeConstructorAs(asUntyped, other)\n"
 
     // set methods
     for (pos <- 0 until n) {


### PR DESCRIPTION
## Summary

19 commits hardening Hearth for the 0.4 release, based on a five-track research audit (ecosystem gap analysis, test-quality audit, compiler-semantics research) plus the three Kindlings-reported issues. Test suite grew from 951/1055 (Scala 2/3) to 1036/1156; every commit was verified green with `quick-clean ; quick-test` on both Scala versions before landing.

### Soundness fixes
- **Union member disjointness** was unsound: `List[Int] | Seq[String]` dispatched to the wrong branch (`=:=`-equality erasure check missed related classes). Now checked via compiler class symbols (`classSymbol` + `derivesFrom` + boxed-symbol normalization) — works for types compiled in the same run (`Class.forName`-based intermediate fix regressed on those; caught against Kindlings and fixed).
- Singleton union members (`Color.Red.type | Color.Blue.type`) are matched **by value** (eqValue) instead of being refused.
- **TypeTest fallback**: same-erasure unions (`List[Int] | List[String]`) work when user `scala.reflect.TypeTest` givens are in scope (extractor-pattern CaseDefs; compiler-synthesized TypeTests are filtered out to keep unsound cases refused); refusals now name the missing instance.

### New APIs (`@since 0.4.0`)
- `Type.opaqueUnderlyingType` via `TypeRef.isOpaqueAlias` + `translucentSuperType` (with type-arg re-substitution for applied parameterized opaques); `IsValueTypeProviderForOpaque` rewired to use it; opaque union members resolved through it.
- `annotationsOfType[Ann]` / `hasAnnotationOfType[Ann]` on `Type`/`Method`/`Parameter`, `Annotations.constructorArguments` / `decodedConstructorArguments` (**#283**).
- `Type.decompose1/decompose2` (returning live, re-applicable Ctors), `Type.typeArguments`, `sameTypeConstructorAs` on all `CtorN`/`CtorK1`/`UntypedType`, untyped `dealias`/`typeConstructor` (**#284**).
- `Parameter.isVararg` with cross-platform `Seq[A]` normalization, vararg call splicing, `A*` rendering, `DestructuredExpr.Varargs`, Java varargs support.
- Positioned reporting: `reportInfo/Warn/Error/ErrorAndAbort(msg, position)`.
- `caseFieldValuesAt` defaults to new `Accessible.Unrestricted` (no more silent dropping of non-public case fields); Scala 2 `$access$N` accessor visibility + field-name keys normalized cross-platform.

### Cross-quotes fix (**#285**)
`implicit val ConfigT: Type[Configuration] = Type.of[Configuration]` no longer self-references: Scala 2 shadows the in-definition implicit inside the generated block; Scala 3 plugin excludes the self-definition from injected casted givens. Also fixes a silent wrong-code case (Scala 2 class-level val compiled to `ConfigT = ConfigT`, NPE at expansion).

### Bug fixes found along the way
- Scala 3 `Parameter.isByName` always returned `false`.
- Scala 3 annotation exprs were unspliceable under `-Xcheck-macros` (trees rebuilt with proper spans).
- Scala 2 `ExprCodec` exprs reported the codec's free type param instead of the concrete type.
- Scala 3 no-pos `reportWarn` emitted `report.info` instead of a real warning.

### Tests
Direct coverage added for `semiQuote`, semiEval error aggregation, `Method.foldF`, all 8 `AnonymousInstanceError` variants, revert-verified regression tests for previously-untested fix commits (68e1781, 7c82fc9, 481f734), wildcard-type pins, vararg/by-name edge types, and convention cleanup (weak `contains` assertions → full structural `<==>`).

### Downstream verification
All three issues verified end-to-end against Kindlings (`kindlings-investigations` branch): workarounds replaced with the new APIs, all module tests green (circe 376/419, cats 279/279, commons 20/20). ~2,200 lines of Kindlings workaround code become deletable.

Closes #283. Closes #284. Closes #285.