### PR TITLE
Close Kindlings mock/wiring gaps: AnonymousInstance (generics, member shapes, this.type, ctx-fn) + DI (self-type, by-name)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,7 +313,8 @@ The `Method` API has a layered architecture with platform-specific untyped code 
 - `AnonymousInstanceError` sealed trait with 8 error variants (rendered to strings at API boundary)
 - `MethodClassification` with 4 variants: `MustOverride`, `MayOverride`, `CannotOverride`, `DiamondConflict`
 - `ClassifiedMethod` pairs a `Method` with its classification and declaring type
-- `OverrideContext` provides `self: Expr_??` (this reference + novel type), `method: UntypedMethod`, `parameters: List[Expr_??]`, `returnType: ??`
+- `OverrideContext` provides `self: Expr_??` (this reference + novel type), `method: UntypedMethod`, `parameters: List[Expr_??]`, `returnType: ??`, `typeParameters: List[??]`
+- `returnType`/`typeParameters` are supplied by the platform `unsafeNewSubtype` (via the `UntypedOverride.body` callback `(self, params, returnType, typeParams)`), resolved against the freshly synthesized member — so a generic override `def f[T](t: T): String` sees `returnType = String` (not `Any`), and `def emptyList[T]: List[T]` can name `T` via `typeParameters` (Issue A)
 - `OverrideBody` functional interface for override body callbacks
 - `AnonymousInstance[A]` class view with `parse`, `parseWithMixins`, `construct`
 - Validation: rejects final/sealed types, checks constructor accessibility, at most one class parent
@@ -323,6 +324,7 @@ The `Method` API has a layered architecture with platform-specific untyped code 
 - Scala 2: quasiquotes `q"new $parent(..$args) with ..$traits { ..$overrides }"`
 - Scala 3: `Symbol.newClass` + `ClassDef.apply` via Java reflection (avoiding `@experimental`)
 - Scala 3: prepends `AnyRef` when first parent is a trait (required by `Symbol.newClass`)
+- Member-shape handling (Issue B): symbolic names use the symbol's encoded name (`$plus`, not a fresh `TermName("+")`); `implicit`/`using` clauses keep their modifier; abstract `val` targets emit a `val` (Scala 3: `Symbol.newVal` + `declaredFields`); `this.type` returns are retargeted to the synthesized subtype's `this.type` (Scala 2: `tq"this.type"`; Scala 3: `replaceResult` onto `This(cls).tpe`, detected via `Symbol.tree` returnTpt being a `ThisType`); context-function returns (`Int ?=> String`) already work on the primary Scala 3
 
 **Test infrastructure:**
 - `hearth-tests/src/main/scala/hearth/typed/AnonymousInstanceFixturesImpl.scala` — shared fixtures

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,8 +313,9 @@ The `Method` API has a layered architecture with platform-specific untyped code 
 - `AnonymousInstanceError` sealed trait with 8 error variants (rendered to strings at API boundary)
 - `MethodClassification` with 4 variants: `MustOverride`, `MayOverride`, `CannotOverride`, `DiamondConflict`
 - `ClassifiedMethod` pairs a `Method` with its classification and declaring type
-- `OverrideContext` provides `self: Expr_??` (this reference + novel type), `method: UntypedMethod`, `parameters: List[Expr_??]`, `returnType: ??`, `typeParameters: List[??]`
-- `returnType`/`typeParameters` are supplied by the platform `unsafeNewSubtype` (via the `UntypedOverride.body` callback `(self, params, returnType, typeParams)`), resolved against the freshly synthesized member — so a generic override `def f[T](t: T): String` sees `returnType = String` (not `Any`), and `def emptyList[T]: List[T]` can name `T` via `typeParameters` (Issue A)
+- `OverrideContext` provides `self: Expr_??` (this reference + novel type), `method: UntypedMethod`, `parameters: List[Expr_??]`, `returnType: ??`, `typeParameters: List[??]`, `returnsThisType: Boolean`
+- `returnType`/`typeParameters`/`returnsThisType` are supplied by the platform `unsafeNewSubtype` (via the `UntypedOverride.body` callback `(self, params, returnType, typeParams, returnsThisType)`), resolved against the freshly synthesized member — so a generic override `def f[T](t: T): String` sees `returnType = String` (not `Any`), and `def emptyList[T]: List[T]` can name `T` via `typeParameters` (Issue A)
+- `returnsThisType` is the gate for fluent (`def chain: this.type`) methods: `returnType` is the widened parent (indistinguishable from `def f: Parent` by `=:=`/`<:<`), so a body returns `self` iff `returnsThisType` is true
 - `OverrideBody` functional interface for override body callbacks
 - `AnonymousInstance[A]` class view with `parse`, `parseWithMixins`, `construct`
 - Validation: rejects final/sealed types, checks constructor accessibility, at most one class parent
@@ -324,7 +325,7 @@ The `Method` API has a layered architecture with platform-specific untyped code 
 - Scala 2: quasiquotes `q"new $parent(..$args) with ..$traits { ..$overrides }"`
 - Scala 3: `Symbol.newClass` + `ClassDef.apply` via Java reflection (avoiding `@experimental`)
 - Scala 3: prepends `AnyRef` when first parent is a trait (required by `Symbol.newClass`)
-- Member-shape handling (Issue B): symbolic names use the symbol's encoded name (`$plus`, not a fresh `TermName("+")`); `implicit`/`using` clauses keep their modifier; abstract `val` targets emit a `val` (Scala 3: `Symbol.newVal` + `declaredFields`); `this.type` returns are retargeted to the synthesized subtype's `this.type` (Scala 2: `tq"this.type"`; Scala 3: `replaceResult` onto `This(cls).tpe`, detected via `Symbol.tree` returnTpt being a `ThisType`); context-function returns (`Int ?=> String`) already work on the primary Scala 3
+- Member-shape handling (Issue B): symbolic names use the symbol's encoded name (`$plus`, not a fresh `TermName("+")`); `implicit`/`using` clauses keep their modifier; abstract `val` targets emit a `val` (Scala 3: `Symbol.newVal` + `declaredFields`); `this.type` returns are retargeted to the synthesized subtype's `this.type` (Scala 2: `tq"this.type"`; Scala 3: `replaceResult` onto `This(cls).tpe`, detected via `Symbol.tree` returnTpt being a `ThisType`) and signalled to the body via `OverrideContext.returnsThisType`; context-function returns (`B ?=> C`) are detected via `Symbol.tree` returnTpt (`scala.ContextFunctionN`) and `truncateToResult` strips the desugared trailing `using` clause that Scala 3.8.4 introduces (no-op on 3.3.8, which does not desugar)
 
 **Test infrastructure:**
 - `hearth-tests/src/main/scala/hearth/typed/AnonymousInstanceFixturesImpl.scala` — shared fixtures

--- a/hearth-tests/src/main/scala-2/hearth/EnclosuresFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/EnclosuresFixtures.scala
@@ -12,6 +12,7 @@ final private class EnclosuresFixtures(val c: blackbox.Context) extends MacroCom
   def testCallEnclosingHelperImpl: c.Expr[Int] = testCallEnclosingHelper
   def testEnclosingLocalValuesImpl: c.Expr[Data] = testEnclosingLocalValues
   def testSumEnclosingLocalIntsImpl: c.Expr[Int] = testSumEnclosingLocalInts
+  def testEnclosingClassHasSelfTypeMemberImpl: c.Expr[Data] = testEnclosingClassHasSelfTypeMember
 }
 
 object EnclosuresFixtures {
@@ -21,4 +22,5 @@ object EnclosuresFixtures {
   def testCallEnclosingHelper: Int = macro EnclosuresFixtures.testCallEnclosingHelperImpl
   def testEnclosingLocalValues: Data = macro EnclosuresFixtures.testEnclosingLocalValuesImpl
   def testSumEnclosingLocalInts: Int = macro EnclosuresFixtures.testSumEnclosingLocalIntsImpl
+  def testEnclosingClassHasSelfTypeMember: Data = macro EnclosuresFixtures.testEnclosingClassHasSelfTypeMemberImpl
 }

--- a/hearth-tests/src/main/scala-2/hearth/typed/AnonymousInstanceFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/AnonymousInstanceFixtures.scala
@@ -50,6 +50,20 @@ final private class AnonymousInstanceFixtures(val c: blackbox.Context)
   def testAnonymousInstanceConstructOverloadsImpl: c.Expr[String] = testAnonymousInstanceConstructOverloads
 
   def testAnonymousInstanceConstructGenericImpl: c.Expr[String] = testAnonymousInstanceConstructGeneric
+
+  def testAnonymousInstanceConstructGenericConcreteReturnImpl: c.Expr[String] =
+    testAnonymousInstanceConstructGenericConcreteReturn
+
+  def testAnonymousInstanceConstructGenericFactoryImpl: c.Expr[String] =
+    testAnonymousInstanceConstructGenericFactory
+
+  def testAnonymousInstanceConstructSymbolicImpl: c.Expr[String] = testAnonymousInstanceConstructSymbolic
+
+  def testAnonymousInstanceConstructImplicitParamImpl: c.Expr[String] = testAnonymousInstanceConstructImplicitParam
+
+  def testAnonymousInstanceConstructAbstractValImpl: c.Expr[String] = testAnonymousInstanceConstructAbstractVal
+
+  def testAnonymousInstanceConstructThisTypeImpl: c.Expr[String] = testAnonymousInstanceConstructThisType
 }
 
 object AnonymousInstanceFixtures {
@@ -94,4 +108,22 @@ object AnonymousInstanceFixtures {
 
   def testAnonymousInstanceConstructGeneric: String =
     macro AnonymousInstanceFixtures.testAnonymousInstanceConstructGenericImpl
+
+  def testAnonymousInstanceConstructGenericConcreteReturn: String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceConstructGenericConcreteReturnImpl
+
+  def testAnonymousInstanceConstructGenericFactory: String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceConstructGenericFactoryImpl
+
+  def testAnonymousInstanceConstructSymbolic: String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceConstructSymbolicImpl
+
+  def testAnonymousInstanceConstructImplicitParam: String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceConstructImplicitParamImpl
+
+  def testAnonymousInstanceConstructAbstractVal: String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceConstructAbstractValImpl
+
+  def testAnonymousInstanceConstructThisType: String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceConstructThisTypeImpl
 }

--- a/hearth-tests/src/main/scala-3/hearth/EnclosuresFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/EnclosuresFixtures.scala
@@ -27,4 +27,8 @@ object EnclosuresFixtures {
   inline def testSumEnclosingLocalInts: Int = ${ testSumEnclosingLocalIntsImpl }
   private def testSumEnclosingLocalIntsImpl(using q: Quotes): Expr[Int] =
     new EnclosuresFixtures(q).testSumEnclosingLocalInts
+
+  inline def testEnclosingClassHasSelfTypeMember: Data = ${ testEnclosingClassHasSelfTypeMemberImpl }
+  private def testEnclosingClassHasSelfTypeMemberImpl(using q: Quotes): Expr[Data] =
+    new EnclosuresFixtures(q).testEnclosingClassHasSelfTypeMember
 }

--- a/hearth-tests/src/main/scala-3/hearth/examples/anonymous_instances-s3.scala
+++ b/hearth-tests/src/main/scala-3/hearth/examples/anonymous_instances-s3.scala
@@ -1,0 +1,10 @@
+package hearth
+package examples
+package anonymous_instances
+
+/** Context-function return (`Int ?=> String`) — Scala 3-only. The override's result must stay a context function, not
+  * be flattened into a trailing `using` parameter clause (which would change the member's arity).
+  */
+trait TraitWithContextFunctionReturn {
+  def build(k: String): Int ?=> String
+}

--- a/hearth-tests/src/main/scala-3/hearth/typed/AnonymousInstanceFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/AnonymousInstanceFixtures.scala
@@ -96,4 +96,32 @@ object AnonymousInstanceFixtures {
   inline def testAnonymousInstanceConstructGeneric: String = ${ testAnonymousInstanceConstructGenericImpl }
   private def testAnonymousInstanceConstructGenericImpl(using q: Quotes): Expr[String] =
     new AnonymousInstanceFixtures(q).testAnonymousInstanceConstructGeneric
+
+  inline def testAnonymousInstanceConstructGenericConcreteReturn: String = ${
+    testAnonymousInstanceConstructGenericConcreteReturnImpl
+  }
+  private def testAnonymousInstanceConstructGenericConcreteReturnImpl(using q: Quotes): Expr[String] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceConstructGenericConcreteReturn
+
+  inline def testAnonymousInstanceConstructGenericFactory: String = ${
+    testAnonymousInstanceConstructGenericFactoryImpl
+  }
+  private def testAnonymousInstanceConstructGenericFactoryImpl(using q: Quotes): Expr[String] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceConstructGenericFactory
+
+  inline def testAnonymousInstanceConstructSymbolic: String = ${ testAnonymousInstanceConstructSymbolicImpl }
+  private def testAnonymousInstanceConstructSymbolicImpl(using q: Quotes): Expr[String] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceConstructSymbolic
+
+  inline def testAnonymousInstanceConstructImplicitParam: String = ${ testAnonymousInstanceConstructImplicitParamImpl }
+  private def testAnonymousInstanceConstructImplicitParamImpl(using q: Quotes): Expr[String] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceConstructImplicitParam
+
+  inline def testAnonymousInstanceConstructAbstractVal: String = ${ testAnonymousInstanceConstructAbstractValImpl }
+  private def testAnonymousInstanceConstructAbstractValImpl(using q: Quotes): Expr[String] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceConstructAbstractVal
+
+  inline def testAnonymousInstanceConstructThisType: String = ${ testAnonymousInstanceConstructThisTypeImpl }
+  private def testAnonymousInstanceConstructThisTypeImpl(using q: Quotes): Expr[String] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceConstructThisType
 }

--- a/hearth-tests/src/main/scala-3/hearth/typed/AnonymousInstanceScala3Fixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/AnonymousInstanceScala3Fixtures.scala
@@ -1,0 +1,42 @@
+package hearth
+package typed
+
+import scala.quoted.*
+
+/** Scala 3-only AnonymousInstance fixtures for shapes that cannot be expressed in shared (Scala 2 + 3) sources — here,
+  * a context-function return type (`Int ?=> String`).
+  */
+final private class AnonymousInstanceScala3Fixtures(q: Quotes) extends MacroCommonsScala3(using q) {
+
+  def testContextFunctionReturn: Expr[String] =
+    AnonymousInstance.parse(using Type.of[examples.anonymous_instances.TraitWithContextFunctionReturn]) match {
+      case ClassViewResult.Compatible(ai) =>
+        val overrides: Map[UntypedMethod, OverrideBody] = ai.mustOverride.map { cm =>
+          cm.method.asUntyped -> new OverrideBody {
+            def apply(ctx: OverrideContext): Expr_?? = {
+              val kE = ctx.parameters.head
+              import kE.Underlying as K
+              val k: Expr[K] = kE.value
+              // `build(k): Int ?=> String` — the override must return a context function, NOT a method taking an
+              // extra `using Int`. Build `(i: Int) ?=> k.toString + i`.
+              val cf: Expr[Int ?=> String] = '{ (i: Int) ?=> $k.toString + i.toString }
+              cf.as_??(using Type.of[Int ?=> String])
+            }
+          }
+        }.toMap
+        ai.construct(None, Map.empty, overrides) match {
+          case Right(constructed) =>
+            val inst = constructed.asInstanceOf[Expr[examples.anonymous_instances.TraitWithContextFunctionReturn]]
+            '{ $inst.build("k")(using 7) }
+          case Left(errors) => Expr(s"errors: ${errors.toVector.mkString("; ")}")
+        }
+      case ClassViewResult.Incompatible(reason) => Expr(s"incompatible: $reason")
+    }
+}
+
+object AnonymousInstanceScala3Fixtures {
+
+  inline def testContextFunctionReturn: String = ${ testContextFunctionReturnImpl }
+  private def testContextFunctionReturnImpl(using q: Quotes): Expr[String] =
+    new AnonymousInstanceScala3Fixtures(q).testContextFunctionReturn
+}

--- a/hearth-tests/src/main/scala/hearth/EnclosuresFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/EnclosuresFixturesImpl.scala
@@ -53,6 +53,18 @@ trait EnclosuresFixturesImpl { this: MacroCommons =>
     call.getOrElse(Environment.reportErrorAndAbort("No nullary Int-returning `helper` found in the enclosing scope"))
   }
 
+  /** Render whether the immediately-enclosing class exposes a member named `fromSelfType` (declared on a self-type
+    * requirement `this: Provider =>`, not on the trait itself). Proves self-type members are folded into the enclosing
+    * class's `members`, which wiring/DI relies on. Returns `<no class>` if there is no enclosing class.
+    */
+  def testEnclosingClassHasSelfTypeMember: Expr[Data] = {
+    val result = enclosingScope.iterator
+      .collectFirst { case enc: Enclosure.Class => enc.members.map(_.name).toSet }
+      .map(names => Data(names("fromSelfType")))
+      .getOrElse(Data("<no class>"))
+    Expr(result)
+  }
+
   /** Render the `localValues` of the immediately-enclosing method as a list of `{name, type}` maps. Proves that local
     * `val`s declared before the macro call are discoverable (the macwire case).
     */

--- a/hearth-tests/src/main/scala/hearth/examples/anonymous_instances.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/anonymous_instances.scala
@@ -81,6 +81,47 @@ trait TraitWithBoundedGenericMethod {
   def firstOf[T <: AnyRef](xs: List[T]): T
 }
 
+/** Generic method whose declared return is CONCRETE (`String`), independent of the method's type parameter. The
+  * override body must see `OverrideContext.returnType = String` (not `Any`) — the regression Kindlings hit while
+  * porting ScalaMock.
+  */
+trait TraitWithGenericConcreteReturn {
+  def describe[T](x: T): String
+}
+
+/** Generic method with NO value parameter list, so the override body cannot recover the type parameter from any
+  * argument — it must use `OverrideContext.typeParameters` to name `T` and `returnType` (`List[T]`) to build a result.
+  */
+trait TraitWithGenericFactory {
+  def emptyList[T]: List[T]
+}
+
+/** Symbolic / operator method name — the override member must be emitted under the operator name `+`. */
+trait TraitWithSymbolicMethod {
+  def +(x: Int): Int
+}
+
+/** Method with a trailing implicit parameter clause — the override must keep the `implicit` modifier on the second
+  * clause, otherwise it stays abstract (signature mismatch) and the instance cannot be constructed.
+  */
+trait TraitWithImplicitParam {
+  def run(cmd: String)(implicit cfg: Int): String
+}
+
+/** Abstract `val` member — overriding it with a `def` is rejected ("stable, immutable value required"), so the override
+  * must be emitted as a `val`.
+  */
+trait TraitWithAbstractVal {
+  val abstractVal: String
+}
+
+/** `this.type` return — the override's declared result must be the synthesized subtype's `this.type`, otherwise
+  * returning `this` does not conform (the member type's `this.type` points at the parent trait).
+  */
+trait TraitWithThisTypeReturn {
+  def chain: this.type
+}
+
 @scala.annotation.nowarn
 trait TraitWithVisibility {
   def publicMethod: Int

--- a/hearth-tests/src/main/scala/hearth/examples/anonymous_instances.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/anonymous_instances.scala
@@ -116,10 +116,14 @@ trait TraitWithAbstractVal {
 }
 
 /** `this.type` return — the override's declared result must be the synthesized subtype's `this.type`, otherwise
-  * returning `this` does not conform (the member type's `this.type` points at the parent trait).
+  * returning `this` does not conform (the member type's `this.type` points at the parent trait). `sibling` is an
+  * ordinary method (`returnsThisType = false`), so an override body must tell the two apart via
+  * `OverrideContext.returnsThisType` — returning `self` for `chain` but a real value for `sibling`. A wrong flag in
+  * either direction is a compile error (self is not an `Int`; `7` is not a `this.type`).
   */
 trait TraitWithThisTypeReturn {
   def chain: this.type
+  def sibling: Int
 }
 
 @scala.annotation.nowarn

--- a/hearth-tests/src/main/scala/hearth/typed/AnonymousInstanceFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/AnonymousInstanceFixturesImpl.scala
@@ -393,6 +393,189 @@ trait AnonymousInstanceFixturesImpl { this: MacroCommons =>
     }
   }
 
+  /** Overrides `describe[T](x: T): String` — a generic method with a CONCRETE return. The body asserts that
+    * `ctx.returnType` is `String` (not `Any`), proving the resolved-return fix. Invoked at two instantiations.
+    */
+  def testAnonymousInstanceConstructGenericConcreteReturn: Expr[String] = {
+    implicit val StringType: Type[String] = stringTypeAI
+    implicit val GenericType: Type[examples.anonymous_instances.TraitWithGenericConcreteReturn] =
+      Type.of[examples.anonymous_instances.TraitWithGenericConcreteReturn]
+
+    AnonymousInstance.parse[examples.anonymous_instances.TraitWithGenericConcreteReturn] match {
+      case ClassViewResult.Compatible(ai) =>
+        val overrides: Map[UntypedMethod, OverrideBody] = ai.mustOverride.map { cm =>
+          cm.method.asUntyped -> new OverrideBody {
+            def apply(ctx: OverrideContext): Expr_?? = {
+              import ctx.returnType.Underlying as R
+              // returnType MUST be String here, not Any — otherwise this branch is not taken and the body is
+              // typed `Any`, which fails to override a method declared to return String.
+              if (Type[R] =:= Type[String]) Expr("described").as_??
+              else Expr(s"wrong-return-type: ${Type[R].plainPrint}").as_??
+            }
+          }
+        }.toMap
+        ai.construct(None, Map.empty, overrides) match {
+          case Right(constructed) =>
+            Expr.quote {
+              val inst = Expr.splice(constructed)
+              inst.describe("hello") + "|" + inst.describe(42)
+            }
+          case Left(errors) =>
+            Expr(s"errors: ${errors.toVector.mkString("; ")}")
+        }
+      case ClassViewResult.Incompatible(reason) =>
+        Expr(s"incompatible: $reason")
+    }
+  }
+
+  /** Overrides `emptyList[T]: List[T]` — a generic method with no value parameters, so the body must use
+    * `ctx.typeParameters` to name `T` and build `List.empty[T]`. Proves type parameters are threaded into the context.
+    */
+  def testAnonymousInstanceConstructGenericFactory: Expr[String] = {
+    implicit val StringType: Type[String] = stringTypeAI
+    implicit val FactoryType: Type[examples.anonymous_instances.TraitWithGenericFactory] =
+      Type.of[examples.anonymous_instances.TraitWithGenericFactory]
+
+    AnonymousInstance.parse[examples.anonymous_instances.TraitWithGenericFactory] match {
+      case ClassViewResult.Compatible(ai) =>
+        val overrides: Map[UntypedMethod, OverrideBody] = ai.mustOverride.map { cm =>
+          cm.method.asUntyped -> new OverrideBody {
+            def apply(ctx: OverrideContext): Expr_?? = {
+              val tParam = ctx.typeParameters.head
+              import tParam.Underlying as T
+              implicit val listOfT: Type[List[T]] = Type.of[List[T]]
+              Expr.quote(List.empty[T]).as_??
+            }
+          }
+        }.toMap
+        ai.construct(None, Map.empty, overrides) match {
+          case Right(constructed) =>
+            Expr.quote {
+              val inst = Expr.splice(constructed)
+              inst.emptyList[String].mkString("[", ",", "]") + "|" + inst.emptyList[Int].sum.toString
+            }
+          case Left(errors) =>
+            Expr(s"errors: ${errors.toVector.mkString("; ")}")
+        }
+      case ClassViewResult.Incompatible(reason) =>
+        Expr(s"incompatible: $reason")
+    }
+  }
+
+  /** Overrides the symbolic method `+(x: Int): Int` to return its argument, proving an operator-named member is
+    * synthesized and resolved.
+    */
+  def testAnonymousInstanceConstructSymbolic: Expr[String] = {
+    implicit val OpsType: Type[examples.anonymous_instances.TraitWithSymbolicMethod] =
+      Type.of[examples.anonymous_instances.TraitWithSymbolicMethod]
+
+    AnonymousInstance.parse[examples.anonymous_instances.TraitWithSymbolicMethod] match {
+      case ClassViewResult.Compatible(ai) =>
+        val overrides: Map[UntypedMethod, OverrideBody] = ai.mustOverride.map { cm =>
+          cm.method.asUntyped -> new OverrideBody {
+            def apply(ctx: OverrideContext): Expr_?? = ctx.parameters.head
+          }
+        }.toMap
+        ai.construct(None, Map.empty, overrides) match {
+          case Right(constructed) =>
+            Expr.quote {
+              val inst = Expr.splice(constructed)
+              (inst + 41).toString
+            }
+          case Left(errors) => Expr(s"errors: ${errors.toVector.mkString("; ")}")
+        }
+      case ClassViewResult.Incompatible(reason) => Expr(s"incompatible: $reason")
+    }
+  }
+
+  /** Overrides `run(cmd: String)(implicit cfg: Int): String`, joining both parameters, proving the trailing implicit
+    * clause is preserved on the override (so the member is no longer abstract).
+    */
+  def testAnonymousInstanceConstructImplicitParam: Expr[String] = {
+    implicit val StringType: Type[String] = stringTypeAI
+    implicit val RunType: Type[examples.anonymous_instances.TraitWithImplicitParam] =
+      Type.of[examples.anonymous_instances.TraitWithImplicitParam]
+
+    AnonymousInstance.parse[examples.anonymous_instances.TraitWithImplicitParam] match {
+      case ClassViewResult.Compatible(ai) =>
+        val overrides: Map[UntypedMethod, OverrideBody] = ai.mustOverride.map { cm =>
+          cm.method.asUntyped -> new OverrideBody {
+            def apply(ctx: OverrideContext): Expr_?? = {
+              val cmdE = ctx.parameters.head
+              val cfgE = ctx.parameters(1)
+              import cmdE.Underlying as Cmd
+              import cfgE.Underlying as Cfg
+              Expr
+                .quote(Expr.splice(cmdE.value: Expr[Cmd]).toString + Expr.splice(cfgE.value: Expr[Cfg]).toString)
+                .as_??
+            }
+          }
+        }.toMap
+        ai.construct(None, Map.empty, overrides) match {
+          case Right(constructed) =>
+            Expr.quote {
+              implicit val cfg: Int = 7
+              val inst = Expr.splice(constructed)
+              inst.run("go")
+            }
+          case Left(errors) => Expr(s"errors: ${errors.toVector.mkString("; ")}")
+        }
+      case ClassViewResult.Incompatible(reason) => Expr(s"incompatible: $reason")
+    }
+  }
+
+  /** Overrides the abstract `val abstractVal: String`, proving a `val` member (not a `def`) is synthesized. */
+  def testAnonymousInstanceConstructAbstractVal: Expr[String] = {
+    implicit val StringType: Type[String] = stringTypeAI
+    implicit val HasValType: Type[examples.anonymous_instances.TraitWithAbstractVal] =
+      Type.of[examples.anonymous_instances.TraitWithAbstractVal]
+
+    AnonymousInstance.parse[examples.anonymous_instances.TraitWithAbstractVal] match {
+      case ClassViewResult.Compatible(ai) =>
+        val overrides: Map[UntypedMethod, OverrideBody] = ai.mustOverride.map { cm =>
+          cm.method.asUntyped -> new OverrideBody {
+            def apply(ctx: OverrideContext): Expr_?? = Expr("the-val").as_??
+          }
+        }.toMap
+        ai.construct(None, Map.empty, overrides) match {
+          case Right(constructed) =>
+            Expr.quote {
+              val inst = Expr.splice(constructed)
+              inst.abstractVal
+            }
+          case Left(errors) => Expr(s"errors: ${errors.toVector.mkString("; ")}")
+        }
+      case ClassViewResult.Incompatible(reason) => Expr(s"incompatible: $reason")
+    }
+  }
+
+  /** Overrides `chain: this.type` by returning `this` (`ctx.self`), then checks the returned reference is the
+    * constructed instance — proving the override's `this.type` result resolves to the synthesized subtype.
+    */
+  def testAnonymousInstanceConstructThisType: Expr[String] = {
+    implicit val StringType: Type[String] = stringTypeAI
+    implicit val ChainType: Type[examples.anonymous_instances.TraitWithThisTypeReturn] =
+      Type.of[examples.anonymous_instances.TraitWithThisTypeReturn]
+
+    AnonymousInstance.parse[examples.anonymous_instances.TraitWithThisTypeReturn] match {
+      case ClassViewResult.Compatible(ai) =>
+        val overrides: Map[UntypedMethod, OverrideBody] = ai.mustOverride.map { cm =>
+          cm.method.asUntyped -> new OverrideBody {
+            def apply(ctx: OverrideContext): Expr_?? = ctx.self
+          }
+        }.toMap
+        ai.construct(None, Map.empty, overrides) match {
+          case Right(constructed) =>
+            Expr.quote {
+              val inst = Expr.splice(constructed)
+              (inst.chain eq inst).toString
+            }
+          case Left(errors) => Expr(s"errors: ${errors.toVector.mkString("; ")}")
+        }
+      case ClassViewResult.Incompatible(reason) => Expr(s"incompatible: $reason")
+    }
+  }
+
   private def constructWithDefaults[A: Type](ai: AnonymousInstance[A])(implicit
       IntType: Type[Int],
       StringType: Type[String],

--- a/hearth-tests/src/main/scala/hearth/typed/AnonymousInstanceFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/AnonymousInstanceFixturesImpl.scala
@@ -553,7 +553,7 @@ trait AnonymousInstanceFixturesImpl { this: MacroCommons =>
     * constructed instance — proving the override's `this.type` result resolves to the synthesized subtype.
     */
   def testAnonymousInstanceConstructThisType: Expr[String] = {
-    implicit val StringType: Type[String] = stringTypeAI
+    implicit val IntType: Type[Int] = intTypeAI
     implicit val ChainType: Type[examples.anonymous_instances.TraitWithThisTypeReturn] =
       Type.of[examples.anonymous_instances.TraitWithThisTypeReturn]
 
@@ -561,14 +561,19 @@ trait AnonymousInstanceFixturesImpl { this: MacroCommons =>
       case ClassViewResult.Compatible(ai) =>
         val overrides: Map[UntypedMethod, OverrideBody] = ai.mustOverride.map { cm =>
           cm.method.asUntyped -> new OverrideBody {
-            def apply(ctx: OverrideContext): Expr_?? = ctx.self
+            def apply(ctx: OverrideContext): Expr_?? =
+              // The fluent-mock pattern: a `this.type` method must return `self`; an ordinary method must return a
+              // real value. `returnsThisType` is the only signal that distinguishes them (the resolved `returnType`
+              // cannot). A wrong flag is a compile error here (self isn't an Int; 7 isn't a this.type).
+              if (ctx.returnsThisType) ctx.self
+              else Expr(7).as_??
           }
         }.toMap
         ai.construct(None, Map.empty, overrides) match {
           case Right(constructed) =>
             Expr.quote {
               val inst = Expr.splice(constructed)
-              (inst.chain eq inst).toString
+              (inst.chain eq inst).toString + "|" + inst.sibling.toString
             }
           case Left(errors) => Expr(s"errors: ${errors.toVector.mkString("; ")}")
         }

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -148,7 +148,8 @@ trait MethodsFixturesImpl { this: MacroCommons =>
             "isImplicit" -> Data(param.isImplicit),
             "hasDefault" -> Data(param.hasDefault),
             "isByName" -> Data(param.isByName),
-            "isVararg" -> Data(param.isVararg)
+            "isVararg" -> Data(param.isVararg),
+            "byNameUnderlying" -> Data(param.byNameUnderlying.map(_.plainPrint).getOrElse("<none>"))
           )
         }
       }

--- a/hearth-tests/src/test/scala-3/hearth/typed/AnonymousInstanceScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/AnonymousInstanceScala3Spec.scala
@@ -1,0 +1,17 @@
+package hearth
+package typed
+
+/** Macro implementation is in [[AnonymousInstanceScala3Fixtures]] — Scala 3-only AnonymousInstance shapes. */
+final class AnonymousInstanceScala3Spec extends MacroSuite {
+
+  group("typed.Classes") {
+
+    group("AnonymousInstance (Scala 3-only)") {
+
+      test("context-function return stays a context function (not a using-param clause)") {
+        // build(k): Int ?=> String — override returns `(i) ?=> k + i`, invoked as build("k")(using 7)
+        AnonymousInstanceScala3Fixtures.testContextFunctionReturn <==> "k7"
+      }
+    }
+  }
+}

--- a/hearth-tests/src/test/scala-3/hearth/typed/MethodsScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/MethodsScala3Spec.scala
@@ -209,7 +209,8 @@ final class MethodsScala3Spec extends MacroSuite {
               "isImplicit" -> Data(true),
               "hasDefault" -> Data(false),
               "isByName" -> Data(false),
-              "isVararg" -> Data(false)
+              "isVararg" -> Data(false),
+              "byNameUnderlying" -> Data("<none>")
             )
           )
         }

--- a/hearth-tests/src/test/scala/hearth/EnclosuresSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/EnclosuresSpec.scala
@@ -28,6 +28,15 @@ final class EnclosuresSpec extends MacroSuite {
     def callsHelper: Int = EnclosuresFixtures.testCallEnclosingHelper
   }
 
+  // A trait carrying a self-type requirement: the member `fromSelfType` is declared on the required `SelfProvider`,
+  // NOT on `SelfTyped` itself, so it is only visible through `this`. The macro is expanded inside `SelfTyped`.
+  trait SelfProvider {
+    def fromSelfType: Int
+  }
+  trait SelfTyped { this: SelfProvider =>
+    def selfTypeMembers: Data = EnclosuresFixtures.testEnclosingClassHasSelfTypeMember
+  }
+
   // The macro is expanded inside a method that declares local vals BEFORE the call (and one AFTER, which must not be
   // discovered). Defined as plain methods (not test lambdas) to avoid synthetic `$anonfun` owners.
   object LocalNest {
@@ -77,6 +86,13 @@ final class EnclosuresSpec extends MacroSuite {
 
       test("locates and calls a nullary Int-returning member on the enclosing object") {
         NestObj.callsHelper ==> 7
+      }
+
+      // Regression: a trait's self-type requirement (`this: SelfProvider =>`) contributes members visible on `this`.
+      // These must appear in the enclosing class's `members` (wiring/DI relies on it) on BOTH platforms.
+      test("includes self-type requirement members of the enclosing trait") {
+        val instance = new SelfTyped with SelfProvider { def fromSelfType: Int = 1 }
+        instance.selfTypeMembers <==> Data(true)
       }
     }
 

--- a/hearth-tests/src/test/scala/hearth/typed/AnonymousInstanceSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/AnonymousInstanceSpec.scala
@@ -328,6 +328,36 @@ final class AnonymousInstanceSpec extends MacroSuite {
           AnonymousInstanceFixtures.testAnonymousInstanceConstructGeneric <==> "hello|42"
         }
 
+        test("generic method with concrete return sees returnType=String (not Any)") {
+          // describe[T](x): String — override returns a String, requires ctx.returnType to be the concrete String
+          AnonymousInstanceFixtures.testAnonymousInstanceConstructGenericConcreteReturn <==> "described|described"
+        }
+
+        test("generic method with no value params can name its type parameter via ctx.typeParameters") {
+          // emptyList[T]: List[T] — override builds List.empty[T] using ctx.typeParameters.head
+          AnonymousInstanceFixtures.testAnonymousInstanceConstructGenericFactory <==> "[]|0"
+        }
+
+        test("symbolic/operator method name is synthesized and resolved") {
+          // +(x: Int): Int — override returns its argument
+          AnonymousInstanceFixtures.testAnonymousInstanceConstructSymbolic <==> "41"
+        }
+
+        test("method with a trailing implicit parameter clause keeps the implicit modifier") {
+          // run(cmd)(implicit cfg): String — override joins both, invoked with implicit cfg = 7
+          AnonymousInstanceFixtures.testAnonymousInstanceConstructImplicitParam <==> "go7"
+        }
+
+        test("abstract val is overridden with a val member") {
+          // val abstractVal: String — override emits a val
+          AnonymousInstanceFixtures.testAnonymousInstanceConstructAbstractVal <==> "the-val"
+        }
+
+        test("this.type return resolves to the synthesized subtype") {
+          // chain: this.type — override returns `this`, which must conform to the override's this.type
+          AnonymousInstanceFixtures.testAnonymousInstanceConstructThisType <==> "true"
+        }
+
         test("class parent with trait mixin") {
           testAnonymousInstanceConstructWithMixins[
             examples.anonymous_instances.AbstractClassNoArgs,

--- a/hearth-tests/src/test/scala/hearth/typed/AnonymousInstanceSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/AnonymousInstanceSpec.scala
@@ -353,9 +353,10 @@ final class AnonymousInstanceSpec extends MacroSuite {
           AnonymousInstanceFixtures.testAnonymousInstanceConstructAbstractVal <==> "the-val"
         }
 
-        test("this.type return resolves to the synthesized subtype") {
-          // chain: this.type — override returns `this`, which must conform to the override's this.type
-          AnonymousInstanceFixtures.testAnonymousInstanceConstructThisType <==> "true"
+        test("this.type return resolves to the synthesized subtype, gated via OverrideContext.returnsThisType") {
+          // chain: this.type returns `this` (returnsThisType=true); sibling: Int returns 7 (returnsThisType=false) —
+          // proves the flag distinguishes them and `this` conforms to the override's this.type
+          AnonymousInstanceFixtures.testAnonymousInstanceConstructThisType <==> "true|7"
         }
 
         test("class parent with trait mixin") {

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -1506,7 +1506,8 @@ final class MethodsSpec extends MacroSuite {
               "isImplicit" -> Data(true),
               "hasDefault" -> Data(false),
               "isByName" -> Data(false),
-              "isVararg" -> Data(false)
+              "isVararg" -> Data(false),
+              "byNameUnderlying" -> Data("<none>")
             )
           )
         }
@@ -1517,7 +1518,8 @@ final class MethodsSpec extends MacroSuite {
               "isImplicit" -> Data(false),
               "hasDefault" -> Data(false),
               "isByName" -> Data(false),
-              "isVararg" -> Data(false)
+              "isVararg" -> Data(false),
+              "byNameUnderlying" -> Data("<none>")
             )
           )
         }
@@ -1528,7 +1530,8 @@ final class MethodsSpec extends MacroSuite {
               "isImplicit" -> Data(false),
               "hasDefault" -> Data(false),
               "isByName" -> Data(false),
-              "isVararg" -> Data(false)
+              "isVararg" -> Data(false),
+              "byNameUnderlying" -> Data("<none>")
             )
           )
         }
@@ -1543,7 +1546,8 @@ final class MethodsSpec extends MacroSuite {
               "isImplicit" -> Data(false),
               "hasDefault" -> Data(false),
               "isByName" -> Data(false),
-              "isVararg" -> Data(true)
+              "isVararg" -> Data(true),
+              "byNameUnderlying" -> Data("<none>")
             )
           )
         }
@@ -1554,7 +1558,8 @@ final class MethodsSpec extends MacroSuite {
               "isImplicit" -> Data(false),
               "hasDefault" -> Data(false),
               "isByName" -> Data(false),
-              "isVararg" -> Data(false)
+              "isVararg" -> Data(false),
+              "byNameUnderlying" -> Data("<none>")
             )
           )
         }
@@ -1565,7 +1570,8 @@ final class MethodsSpec extends MacroSuite {
               "isImplicit" -> Data(false),
               "hasDefault" -> Data(false),
               "isByName" -> Data(true),
-              "isVararg" -> Data(false)
+              "isVararg" -> Data(false),
+              "byNameUnderlying" -> Data("scala.Int")
             )
           )
         }

--- a/hearth-tests/src/test/scalajvm/hearth/typed/MethodsJvmSpec.scala
+++ b/hearth-tests/src/test/scalajvm/hearth/typed/MethodsJvmSpec.scala
@@ -779,7 +779,8 @@ final class MethodsJvmSpec extends MacroSuite {
               "isImplicit" -> Data(false),
               "hasDefault" -> Data(false),
               "isByName" -> Data(false),
-              "isVararg" -> Data(true)
+              "isVararg" -> Data(true),
+              "byNameUnderlying" -> Data("<none>")
             )
           )
         }

--- a/hearth/src/main/scala-2/hearth/EnvironmentsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/EnvironmentsScala2.scala
@@ -126,7 +126,17 @@ trait EnvironmentsScala2 extends Environments { this: MacroCommonsScala2 =>
           )
         )
       } else if (symbol.isClass) {
-        val tpe: UntypedType = symbol.asClass.toType
+        val classTpe: UntypedType = symbol.asClass.toType
+        // A trait/class may declare a self-type requirement (`this: Provider =>`); its members are visible on `this`
+        // but absent from `toType`. Fold the self-type in (as an intersection) so the enclosing scope exposes them —
+        // wiring/DI draws candidates from `Enclosure.Class.members`. `typeOfThis` equals `toType` when there is no
+        // self-type, so non-self-typed classes are unaffected.
+        // `typeOfThis` (the type of `this`, including any self-type requirement) is only on the internal Symbol API.
+        val selfTpe: UntypedType =
+          symbol.asInstanceOf[scala.reflect.internal.Symbols#Symbol].typeOfThis.asInstanceOf[c.universe.Type]
+        val tpe: UntypedType =
+          if (selfTpe <:< classTpe) selfTpe
+          else c.internal.intersectionType(List(classTpe, selfTpe))
         val ev = UntypedType.as_??(tpe)
         import ev.Underlying
         val members = UntypedMethod.methods(tpe).map(_.asTyped[ev.Underlying])

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
@@ -27,6 +27,11 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
     }
     override def isImplicit: Boolean = symbol.isImplicit
     override def hasDefault: Boolean = symbol.asTerm.isParamWithDefault
+
+    // A by-name parameter's type is the applied wrapper `<byname>[A]`, so the underlying `A` is its sole type argument.
+    override def byNameUnderlying: Option[c.universe.Type] =
+      if (symbol.isByNameParam) symbol.typeSignature.typeArgs.headOption
+      else None
   }
 
   object UntypedParameter extends UntypedParameterModule {

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
@@ -295,7 +295,9 @@ trait UntypedTypesScala2 extends UntypedTypes { this: MacroCommonsScala2 =>
 
       val overrideDefs: List[Tree] = overrides.map { ovr =>
         val sym = ovr.method.symbol
-        val methodName = TermName(ovr.method.name)
+        // Use the symbol's ORIGINAL (encoded) name, not `ovr.method.name` (which is decoded): a symbolic member like
+        // `+` is encoded as `$plus`, and a freshly built `TermName("+")` would not match the abstract member.
+        val methodName = sym.name.toTermName
         val rawSig = sym.asMethod.typeSignatureIn(targetType)
         val paramLists = rawSig.paramLists
 
@@ -312,20 +314,43 @@ trait UntypedTypesScala2 extends UntypedTypes { this: MacroCommonsScala2 =>
           else tpe.substituteSymbols(originalTypeParams, newTypeParamSyms)
 
         val (paramDefs, paramRefs) = paramLists.map { paramList =>
+          // Preserve an `implicit` parameter clause: every param of an implicit clause carries the IMPLICIT flag, and
+          // the ValDefs of the override must carry it too, otherwise the trailing clause becomes a second explicit
+          // clause and the member stays abstract (signature mismatch).
+          val clauseFlags = if (paramList.headOption.exists(_.isImplicit)) Flag.PARAM | Flag.IMPLICIT else Flag.PARAM
           paramList.map { param =>
             val paramName = TermName(param.name.toString)
             val paramType = subst(param.typeSignature)
-            val vd = ValDef(Modifiers(Flag.PARAM), paramName, TypeTree(paramType), EmptyTree)
+            val vd = ValDef(Modifiers(clauseFlags), paramName, TypeTree(paramType), EmptyTree)
             val ref: UntypedExpr = Ident(paramName)
             (vd, ref)
           }.unzip
         }.unzip
 
-        val selfIdent: UntypedExpr = q"this"
-        val bodyExpr = ovr.body(selfIdent, paramRefs.flatten)
-
         val resultType = subst(rawSig.finalResultType)
-        DefDef(Modifiers(Flag.OVERRIDE), methodName, typeParamDefs, paramDefs, TypeTree(resultType), bodyExpr)
+        // A `this.type` result (e.g. `def chain: this.type` in a fluent builder) resolves, via `typeSignatureIn`, to
+        // the PARENT type — so emitting it verbatim makes the override return the parent, which does not conform to
+        // `this.type`. Detect it from the symbol's own (un-as-seen-from) signature and emit `this.type` instead, so
+        // the return is the synthesized subtype's `this.type`.
+        val isThisTypeReturn = sym.typeSignature.finalResultType match {
+          case ThisType(owner) => owner == sym.owner
+          case _               => false
+        }
+        // The re-bound type parameters, surfaced to the override body so it can name `T` for casts. These are the
+        // NEW symbols created above, hence in scope inside the generated DefDef.
+        val typeParamTypes: List[UntypedType] = newTypeParamSyms.map(_.asType.toType)
+
+        val selfIdent: UntypedExpr = q"this"
+        val bodyExpr = ovr.body(selfIdent, paramRefs.flatten, resultType, typeParamTypes)
+
+        val returnTpt: Tree = if (isThisTypeReturn) tq"this.type" else TypeTree(resultType)
+
+        // An abstract `val` must be overridden with a `val`, not a `def` ("stable, immutable value required"). A val
+        // member has no parameter lists or type parameters, so emit a plain ValDef carrying the override's body.
+        if (ovr.method.isVal && paramLists.isEmpty && originalTypeParams.isEmpty)
+          ValDef(Modifiers(Flag.OVERRIDE), methodName, returnTpt, bodyExpr)
+        else
+          DefDef(Modifiers(Flag.OVERRIDE), methodName, typeParamDefs, paramDefs, returnTpt, bodyExpr)
       }
 
       val classParentTypes = parentTypes.filterNot(pt => pt.typeSymbol.isClass && pt.typeSymbol.asClass.isTrait)

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
@@ -341,7 +341,7 @@ trait UntypedTypesScala2 extends UntypedTypes { this: MacroCommonsScala2 =>
         val typeParamTypes: List[UntypedType] = newTypeParamSyms.map(_.asType.toType)
 
         val selfIdent: UntypedExpr = q"this"
-        val bodyExpr = ovr.body(selfIdent, paramRefs.flatten, resultType, typeParamTypes)
+        val bodyExpr = ovr.body(selfIdent, paramRefs.flatten, resultType, typeParamTypes, isThisTypeReturn)
 
         val returnTpt: Tree = if (isThisTypeReturn) tq"this.type" else TypeTree(resultType)
 

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -74,6 +74,22 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
     override def isVararg: Boolean = isRepeatedParamType(symbol.termRef.widenTermRefByName)
     override def isImplicit: Boolean = symbol.flags.is(Flags.Implicit) || symbol.flags.is(Flags.Given)
     override def hasDefault: Boolean = symbol.flags.is(Flags.HasDefault)
+
+    // The underlying `A` of a by-name parameter `a: => A`. Like `isByName`, by-name-ness is only visible in the owning
+    // method's signature (the parameter's own termRef widens the `ByNameType` away), so we read `ByNameType(u)` there.
+    override def byNameUnderlying: Option[TypeRepr] = {
+      def loop(tpe: TypeRepr): Option[TypeRepr] = tpe match {
+        case MethodType(names, types, returnType) =>
+          names.zip(types).collectFirst { case (n, t) if n == symbol.name => t } match {
+            case Some(ByNameType(u)) => Some(u)
+            case Some(_)             => None
+            case None                => loop(returnType)
+          }
+        case PolyType(_, _, returnType) => loop(returnType)
+        case _                          => None
+      }
+      loop(safeMemberType(method.symbol.owner.typeRef, method.symbol))
+    }
   }
 
   object UntypedParameter extends UntypedParameterModule {
@@ -546,6 +562,7 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
     override def isVararg: Boolean = false
     override def isImplicit: Boolean = false
     override def hasDefault: Boolean = false
+    override def byNameUnderlying: Option[TypeRepr] = None
   }
 
   /** Synthetic constructor for NamedTuple types.

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -400,10 +400,63 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
     ): Either[NonEmptyVector[String], UntypedExpr] = {
       val owner = Symbol.spliceOwner
 
+      // Resolve a member's result type against its own (re-bound) type parameters. `memberType` is the abstract
+      // method's type as seen from the target (a PolyType over the ORIGINAL type-parameter binders for a generic
+      // method); applying it to the actual type arguments handed to the DefDef body substitutes those binders with
+      // the fresh type parameters and yields the concrete result — `String` for `def f[T](t: T): String`, the
+      // re-bound `T` for `def f[T](t: T): T`. This replaces the old `Any` fallback that lost concrete returns of
+      // generic methods. (We avoid `Symbol.info`, which is `@experimental`, hence the reuse of `memberType`.)
+      def methodResultType(memberType: TypeRepr, typeArgs: List[TypeRepr]): TypeRepr = {
+        val applied = memberType match {
+          case pt: PolyType if typeArgs.nonEmpty => pt.appliedTo(typeArgs)
+          case other                             => other
+        }
+        def walk(t: TypeRepr): TypeRepr = t match {
+          case MethodType(_, _, res) => walk(res)
+          case PolyType(_, _, res)   => walk(res)
+          // A nullary `def value: Int` (or an abstract `val v: Int`) has member type `ByNameType(Int)` (`=> Int`);
+          // the override's declared result is the strict `Int`, so strip the by-name wrapper to avoid synthesizing
+          // `null.asInstanceOf[=> Int]` (or an ill-typed val).
+          case ByNameType(res) => walk(res)
+          case other           => other
+        }
+        walk(applied)
+      }
+
+      // Replaces the final result type of a (possibly curried / polymorphic) member type, preserving every parameter
+      // clause. Used to retarget a `this.type` result onto the synthesized subtype.
+      def replaceResult(tpe: TypeRepr, newResult: TypeRepr): TypeRepr = tpe match {
+        case mt: MethodType => MethodType(mt.paramNames)(_ => mt.paramTypes, _ => replaceResult(mt.resType, newResult))
+        case pt: PolyType   =>
+          PolyType(pt.paramNames)(_ => pt.paramBounds, _ => replaceResult(pt.resType, newResult))
+        // A nullary `def chain: this.type` has member type `ByNameType(...)` (`=> ...`); keep the by-name wrapper so
+        // the synthesized symbol stays a method type (Scala 3 rejects a bare value type for a `def`).
+        case ByNameType(_) => ByNameType(newResult)
+        case _             => newResult
+      }
+
+      // Detects a `this.type` result (e.g. `def chain: this.type`). The member type, as seen from the target, has
+      // already widened `this.type` to the parent, so the only reliable signal is the symbol's own declared return.
+      def returnsThisType(sym: Symbol): Boolean =
+        try
+          sym.tree match {
+            case d: DefDef =>
+              d.returnTpt.tpe match {
+                case _: ThisType => true
+                case _           => false
+              }
+            case _ => false
+          }
+        catch { case _: Throwable => false }
+
       val overrideDecls = overrides.map { ovr =>
         val methodSym = ovr.method.symbol
         val memberType = safeMemberType(targetType, methodSym)
-        (ovr, methodSym, memberType)
+        // An abstract `val` must be overridden with a `val`, not a `def` (Scala 3 rejects a method overriding a
+        // stable value: "wrong type, expect a method type"). Vars keep the def/setter shape.
+        val isValTarget = ovr.method.isVal && !ovr.method.isVar
+        val isThisTypeTarget = !isValTarget && returnsThisType(methodSym)
+        (ovr, methodSym, memberType, isValTarget, isThisTypeTarget)
       }
 
       val effectiveParents =
@@ -416,28 +469,58 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
         "$anon",
         effectiveParents,
         decls = cls =>
-          overrideDecls.map { case (ovr, _, memberType) =>
-            Symbol.newMethod(
+          overrideDecls.map { case (ovr, _, memberType, isValTarget, isThisTypeTarget) =>
+            if isValTarget then Symbol.newVal(
               cls,
               ovr.method.name,
-              memberType,
+              methodResultType(memberType, Nil),
               flags = Flags.Override,
               privateWithin = Symbol.noSymbol
             )
+            else {
+              // For a `this.type` result, retarget the result onto the synthesized subtype's own `this.type`, so that
+              // returning `this` (`ctx.self`) conforms — otherwise the override returns the parent (does not conform).
+              val effectiveType =
+                if isThisTypeTarget then replaceResult(memberType, This(cls).tpe) else memberType
+              Symbol.newMethod(
+                cls,
+                ovr.method.name,
+                effectiveType,
+                flags = Flags.Override,
+                privateWithin = Symbol.noSymbol
+              )
+            }
           },
         selfType = None
       )
 
-      val overrideDefs = cls.declaredMethods.zip(overrideDecls).map { case (newMethodSym, (ovr, _, _)) =>
+      // `declaredMethods`/`declaredFields` each preserve creation order, so zipping them with the same-kind subset of
+      // `overrideDecls` (also in creation order) keeps the per-member alignment — including overloads sharing a name.
+      val methodTargets = overrideDecls.filterNot(_._4)
+      val valTargets = overrideDecls.filter(_._4)
+
+      val methodDefs = cls.declaredMethods.zip(methodTargets).map { case (newMethodSym, (ovr, _, memberType, _, _)) =>
         DefDef(
           newMethodSym,
           argss => {
             val selfExpr: Term = This(cls)
+            // Type arguments come first in `argss` for a generic member (re-bound type-parameter references), value
+            // arguments are the Terms. Splitting them lets us surface the type parameters to the override body and
+            // resolve the return type against this member's own type parameters.
+            val typeParamReprs: List[TypeRepr] = argss.flatten.collect { case t: TypeTree => t.tpe }
             val flatParams: List[Term] = argss.flatten.collect { case t: Term => t }
-            Some(ovr.body(selfExpr, flatParams).changeOwner(newMethodSym))
+            val returnTpe: TypeRepr = methodResultType(memberType, typeParamReprs)
+            Some(ovr.body(selfExpr, flatParams, returnTpe, typeParamReprs).changeOwner(newMethodSym))
           }
         )
       }
+
+      val valDefs = cls.declaredFields.zip(valTargets).map { case (newValSym, (ovr, _, memberType, _, _)) =>
+        val valType = methodResultType(memberType, Nil)
+        ValDef(newValSym, Some(ovr.body(This(cls), Nil, valType, Nil).changeOwner(newValSym)))
+      }
+
+      val overrideDefs = methodDefs ++ valDefs
 
       val classParent = effectiveParents.head
       val ctorSymbol = constructor.map(_.symbol).getOrElse(classParent.typeSymbol.primaryConstructor)

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -449,9 +449,52 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
           }
         catch { case _: Throwable => false }
 
+      def isContextFunctionType(tpe: TypeRepr): Boolean = {
+        val sym = tpe.dealias.typeSymbol
+        !sym.isNoSymbol && sym.fullName.startsWith("scala.ContextFunction")
+      }
+
+      // A context-function result `def f(x): B ?=> C`. On newer Scala 3 (e.g. 3.8.4) `safeMemberType` desugars the
+      // return into a trailing `using` parameter clause (`MethodType(x)(MethodType(using B)(C))`), which makes the
+      // synthesized override return `C` where the trait returns `B ?=> C` — a runtime `ClassCastException` at the call
+      // site. The source return type is still visible on the symbol's tree, so detect it there and recover both the
+      // ContextFunctionN result and the count of REAL (pre-desugaring) value parameter clauses. On 3.3.8 the member
+      // type is not desugared and this collapses to a no-op.
+      def contextFunctionReturn(sym: Symbol): Option[(Int, TypeRepr)] =
+        try
+          sym.tree match {
+            case d: DefDef if isContextFunctionType(d.returnTpt.tpe) =>
+              val valueClauses = d.paramss.count {
+                case _: TermParamClause => true
+                case _                  => false
+              }
+              Some((valueClauses, d.returnTpt.tpe))
+            case _ => None
+          }
+        catch { case _: Throwable => None }
+
+      // Keeps the first `valueClauses` value parameter clauses of `tpe` and replaces everything after with `result`
+      // (so a desugared trailing `using` clause from a context-function return is dropped). Type-parameter (Poly)
+      // clauses pass through without consuming a value-clause budget.
+      def truncateToResult(tpe: TypeRepr, valueClauses: Int, result: TypeRepr): TypeRepr =
+        if valueClauses <= 0 then result
+        else
+          tpe match {
+            case mt: MethodType =>
+              MethodType(mt.paramNames)(_ => mt.paramTypes, _ => truncateToResult(mt.resType, valueClauses - 1, result))
+            case pt: PolyType =>
+              PolyType(pt.paramNames)(_ => pt.paramBounds, _ => truncateToResult(pt.resType, valueClauses, result))
+            case _ => result
+          }
+
       val overrideDecls = overrides.map { ovr =>
         val methodSym = ovr.method.symbol
-        val memberType = safeMemberType(targetType, methodSym)
+        val rawMemberType = safeMemberType(targetType, methodSym)
+        // Recover a context-function return that a newer compiler desugared into a trailing `using` clause.
+        val memberType = contextFunctionReturn(methodSym) match {
+          case Some((valueClauses, ctxFn)) => truncateToResult(rawMemberType, valueClauses, ctxFn)
+          case None                        => rawMemberType
+        }
         // An abstract `val` must be overridden with a `val`, not a `def` (Scala 3 rejects a method overriding a
         // stable value: "wrong type, expect a method type"). Vars keep the def/setter shape.
         val isValTarget = ovr.method.isVal && !ovr.method.isVar
@@ -499,25 +542,28 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
       val methodTargets = overrideDecls.filterNot(_._4)
       val valTargets = overrideDecls.filter(_._4)
 
-      val methodDefs = cls.declaredMethods.zip(methodTargets).map { case (newMethodSym, (ovr, _, memberType, _, _)) =>
-        DefDef(
-          newMethodSym,
-          argss => {
-            val selfExpr: Term = This(cls)
-            // Type arguments come first in `argss` for a generic member (re-bound type-parameter references), value
-            // arguments are the Terms. Splitting them lets us surface the type parameters to the override body and
-            // resolve the return type against this member's own type parameters.
-            val typeParamReprs: List[TypeRepr] = argss.flatten.collect { case t: TypeTree => t.tpe }
-            val flatParams: List[Term] = argss.flatten.collect { case t: Term => t }
-            val returnTpe: TypeRepr = methodResultType(memberType, typeParamReprs)
-            Some(ovr.body(selfExpr, flatParams, returnTpe, typeParamReprs).changeOwner(newMethodSym))
-          }
-        )
-      }
+      val methodDefs =
+        cls.declaredMethods.zip(methodTargets).map { case (newMethodSym, (ovr, _, memberType, _, isThisTypeTarget)) =>
+          DefDef(
+            newMethodSym,
+            argss => {
+              val selfExpr: Term = This(cls)
+              // Type arguments come first in `argss` for a generic member (re-bound type-parameter references), value
+              // arguments are the Terms. Splitting them lets us surface the type parameters to the override body and
+              // resolve the return type against this member's own type parameters.
+              val typeParamReprs: List[TypeRepr] = argss.flatten.collect { case t: TypeTree => t.tpe }
+              val flatParams: List[Term] = argss.flatten.collect { case t: Term => t }
+              val returnTpe: TypeRepr = methodResultType(memberType, typeParamReprs)
+              Some(
+                ovr.body(selfExpr, flatParams, returnTpe, typeParamReprs, isThisTypeTarget).changeOwner(newMethodSym)
+              )
+            }
+          )
+        }
 
       val valDefs = cls.declaredFields.zip(valTargets).map { case (newValSym, (ovr, _, memberType, _, _)) =>
         val valType = methodResultType(memberType, Nil)
-        ValDef(newValSym, Some(ovr.body(This(cls), Nil, valType, Nil).changeOwner(newValSym)))
+        ValDef(newValSym, Some(ovr.body(This(cls), Nil, valType, Nil, false).changeOwner(newValSym)))
       }
 
       val overrideDefs = methodDefs ++ valDefs

--- a/hearth/src/main/scala/hearth/typed/Classes.scala
+++ b/hearth/src/main/scala/hearth/typed/Classes.scala
@@ -711,11 +711,26 @@ trait Classes { this: MacroCommons =>
       declaredIn: ??
   )
 
+  /** Context passed to an [[OverrideBody]] when synthesizing an override for an anonymous instance.
+    *
+    *   - `self` — a reference to the `$anon` instance being constructed (`this`),
+    *   - `method` — the abstract method being overridden,
+    *   - `parameters` — references to the override's own value parameters, typed with their resolved types,
+    *   - `returnType` — the override's result type, fully resolved against the instance type and the method's
+    *     (re-bound) type parameters. For a generic method with a concrete declared return (e.g. `def f[T](t: T):
+    *     String`) this is the concrete type, NOT `Any`; for `def f[T](t: T): T` it is the re-bound `T`,
+    *   - `typeParameters` — the override's own type parameters (re-bound to the synthesized member). A body can use
+    *     these to name `T` (e.g. for `null.asInstanceOf[T]`) when no parameter already carries it; empty for a
+    *     monomorphic method.
+    *
+    * @since 0.4.0
+    */
   final case class OverrideContext(
       self: Expr_??,
       method: UntypedMethod,
       parameters: List[Expr_??],
-      returnType: ??
+      returnType: ??,
+      typeParameters: List[??]
   )
 
   @FunctionalInterface
@@ -786,16 +801,23 @@ trait Classes { this: MacroCommons =>
           val effectiveParents = if (parentTypes.isEmpty) List(instanceTpe) else parentTypes
 
           val overrideList = overrides.toList.map { case (untypedMethod, body) =>
-            val typedMethod = untypedMethod.asTyped[A]
-            val returnTpe: ?? = typedMethod.knownReturning.getOrElse(Type.of[Any].as_??)
             UntypedType.UntypedOverride(
               untypedMethod,
-              (selfExpr: UntypedExpr, params: List[UntypedExpr]) => {
+              // The platform tree generator supplies the return type and type parameters resolved against the
+              // freshly synthesized member symbol — for a generic method these reference NEW type-parameter
+              // symbols, which is why they cannot be precomputed here (the old code fell back to `Any`).
+              (
+                  selfExpr: UntypedExpr,
+                  params: List[UntypedExpr],
+                  returnTpe: UntypedType,
+                  typeParams: List[UntypedType]
+              ) => {
                 val ctx = OverrideContext(
                   self = selfExpr.as_??,
                   method = untypedMethod,
                   parameters = params.map(_.as_??),
-                  returnType = returnTpe
+                  returnType = returnTpe.as_??,
+                  typeParameters = typeParams.map(_.as_??)
                 )
                 UntypedExpr.fromTyped(body(ctx).value)
               }

--- a/hearth/src/main/scala/hearth/typed/Classes.scala
+++ b/hearth/src/main/scala/hearth/typed/Classes.scala
@@ -721,7 +721,11 @@ trait Classes { this: MacroCommons =>
     *     String`) this is the concrete type, NOT `Any`; for `def f[T](t: T): T` it is the re-bound `T`,
     *   - `typeParameters` — the override's own type parameters (re-bound to the synthesized member). A body can use
     *     these to name `T` (e.g. for `null.asInstanceOf[T]`) when no parameter already carries it; empty for a
-    *     monomorphic method.
+    *     monomorphic method,
+    *   - `returnsThisType` — whether the overridden method declares a `this.type` result (e.g. a fluent
+    *     `def chain: this.type`). Because `returnType` is the widened parent type (indistinguishable from an ordinary
+    *     method by `=:=`/`<:<`), this flag is the reliable way to gate a "return `self`" body: when `true`, return
+    *     `self` (the only inhabitant of the subtype's `this.type`) WITHOUT casting it to `returnType`.
     *
     * @since 0.4.0
     */
@@ -730,7 +734,8 @@ trait Classes { this: MacroCommons =>
       method: UntypedMethod,
       parameters: List[Expr_??],
       returnType: ??,
-      typeParameters: List[??]
+      typeParameters: List[??],
+      returnsThisType: Boolean
   )
 
   @FunctionalInterface
@@ -810,14 +815,16 @@ trait Classes { this: MacroCommons =>
                   selfExpr: UntypedExpr,
                   params: List[UntypedExpr],
                   returnTpe: UntypedType,
-                  typeParams: List[UntypedType]
+                  typeParams: List[UntypedType],
+                  returnsThisType: Boolean
               ) => {
                 val ctx = OverrideContext(
                   self = selfExpr.as_??,
                   method = untypedMethod,
                   parameters = params.map(_.as_??),
                   returnType = returnTpe.as_??,
-                  typeParameters = typeParams.map(_.as_??)
+                  typeParameters = typeParams.map(_.as_??),
+                  returnsThisType = returnsThisType
                 )
                 UntypedExpr.fromTyped(body(ctx).value)
               }

--- a/hearth/src/main/scala/hearth/typed/Methods.scala
+++ b/hearth/src/main/scala/hearth/typed/Methods.scala
@@ -110,6 +110,17 @@ trait Methods { this: MacroCommons =>
       */
     lazy val isVararg: Boolean = asUntyped.isVararg
     lazy val isImplicit: Boolean = asUntyped.isImplicit
+
+    /** For a by-name parameter (`a: => A`), the underlying type `A` (typed); `None` for any non-by-name parameter.
+      *
+      * Useful for wiring/DI macros that need to satisfy a by-name parameter with a strict value of `A`: unlike [[tpe]]
+      * (which is the by-name wrapper, represented differently on Scala 2 and 3), this recovers `A` uniformly across
+      * platforms — on Scala 3 the parameter type is a `ByNameType(A)` whose `A` is not reachable via
+      * `Type.typeArguments`.
+      *
+      * @since 0.4.0
+      */
+    lazy val byNameUnderlying: Option[??] = asUntyped.byNameUnderlying.map(UntypedType.as_??)
   }
 
   /** Ordered map of [[Parameter]]s by their name.

--- a/hearth/src/main/scala/hearth/untyped/UntypedMethods.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedMethods.scala
@@ -100,6 +100,16 @@ trait UntypedMethods { this: MacroCommons =>
     def isImplicit: Boolean
     def hasDefault: Boolean
 
+    /** For a by-name parameter (`a: => A`), the underlying type `A`; `None` for any non-by-name parameter.
+      *
+      * Normalizes a platform difference: on Scala 2 a by-name parameter's type is the applied wrapper `<byname>[A]` (so
+      * `A` is recoverable as its sole type argument), while on Scala 3 it is a `ByNameType(A)` which is NOT an applied
+      * type (so `typeArguments` returns `Nil`). This surfaces `A` uniformly across platforms.
+      *
+      * @since 0.4.0
+      */
+    def byNameUnderlying: Option[UntypedType]
+
     final def default(instanceTpe: UntypedType): Option[UntypedMethod] = UntypedMethod.defaultValue(instanceTpe)(this)
   }
 

--- a/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
@@ -178,9 +178,25 @@ trait UntypedTypes { this: MacroCommons =>
     def parents(instanceTpe: UntypedType): List[UntypedType]
     def baseClasses(instanceTpe: UntypedType): List[UntypedType]
 
+    /** Describes a single member override for [[unsafeNewSubtype]].
+      *
+      * The `body` callback is invoked by the platform-specific tree generator once it has synthesized the override's
+      * member symbol, so it receives information that only exists at that point and that the shared layer cannot
+      * compute on its own (in particular, the return type and type parameters resolved against the freshly created
+      * member symbol, which for a generic method like `def f[T](t: T): T` reference NEW type-parameter symbols):
+      *
+      *   - `self` — a reference to the enclosing `$anon` instance (`this`),
+      *   - `parameters` — references to the override's own value parameters,
+      *   - `returnType` — the override's result type, fully resolved against the instance type and the re-bound type
+      *     parameters (never `Any` for a method whose declared return is concrete, even when the method is generic),
+      *   - `typeParameters` — the override's own type parameters (re-bound to the synthesized member), so a body can
+      *     name `T` to cast through it; empty for a monomorphic method.
+      *
+      * @since 0.4.0
+      */
     final case class UntypedOverride(
         method: UntypedMethod,
-        body: (UntypedExpr, List[UntypedExpr]) => UntypedExpr
+        body: (UntypedExpr, List[UntypedExpr], UntypedType, List[UntypedType]) => UntypedExpr
     )
 
     def unsafeNewSubtype(

--- a/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
@@ -190,13 +190,16 @@ trait UntypedTypes { this: MacroCommons =>
       *   - `returnType` — the override's result type, fully resolved against the instance type and the re-bound type
       *     parameters (never `Any` for a method whose declared return is concrete, even when the method is generic),
       *   - `typeParameters` — the override's own type parameters (re-bound to the synthesized member), so a body can
-      *     name `T` to cast through it; empty for a monomorphic method.
+      *     name `T` to cast through it; empty for a monomorphic method,
+      *   - `returnsThisType` — whether the overridden method declares a `this.type` result. The `returnType` is the
+      *     widened parent (indistinguishable from an ordinary method by `=:=`/`<:<`), so this is the only reliable
+      *     signal that the body must return `self` (the only inhabitant of the subtype's `this.type`).
       *
       * @since 0.4.0
       */
     final case class UntypedOverride(
         method: UntypedMethod,
-        body: (UntypedExpr, List[UntypedExpr], UntypedType, List[UntypedType]) => UntypedExpr
+        body: (UntypedExpr, List[UntypedExpr], UntypedType, List[UntypedType], Boolean) => UntypedExpr
     )
 
     def unsafeNewSubtype(


### PR DESCRIPTION
Addresses the gaps Kindlings hit while porting ScalaMock-style mocking (`mock`) and macwire-style DI (`di`) on top of Hearth. All fixes are cross-platform (Scala 2.13 + 3) and verified against Scala 3.3.8, 2.13.16, and the 3.8.4/2.13.18 regression versions.

## AnonymousInstance / OverrideContext

**Issue A — generic override methods.** `OverrideContext` now carries the resolved `returnType` (never `Any` for a concrete-return generic like `def describe[T](x: T): String`) and a new `typeParameters: List[??]` (so a body can name `T`, e.g. `def emptyList[T]: List[T]`). These are computed by the platform `unsafeNewSubtype` against the freshly synthesized member and threaded through the widened `UntypedOverride.body` callback. Scala 3 uses `memberType.appliedTo(typeArgs)` (avoiding `@experimental Symbol.info`).

**Issue B — `unsafeNewSubtype` member shapes.**
- Symbolic/operator names (`def +`): use the symbol's encoded name, not a fresh `TermName("+")`.
- `implicit`/`using` parameter clauses keep their modifier (Scala 2).
- Abstract `val` targets emit a `val` (Scala 2 `ValDef`; Scala 3 `Symbol.newVal` + `declaredFields`).
- `this.type` returns are retargeted to the synthesized subtype's `this.type` on **both** platforms (Scala 2 `tq"this.type"`; Scala 3 `replaceResult` onto `This(cls).tpe`), and surfaced to the body via the new `OverrideContext.returnsThisType` (the resolved `returnType` widens to the parent and can't distinguish a fluent `def chain: this.type` from `def f: Parent`).
- Context-function returns (`B ?=> C`): fine on 3.3.8; on 3.8.4 the return is desugared into a trailing `using` clause, causing a `ClassCastException` at the call site. Detected via `Symbol.tree` returnTpt (`scala.ContextFunctionN`) and `truncateToResult` strips the desugared clause.

## DI

- **Self-type providers (Scala 2):** `EnvironmentsScala2.toEnclosure` folds an enclosing trait's self-type (`this: Provider =>`) into `Enclosure.Class.members` via `typeOfThis` ∩ `toType`. Scala 3 already worked.
- **By-name underlying (Scala 3):** new cross-platform `Parameter.byNameUnderlying: Option[??]` recovers `A` from `ByNameType(A)` (Scala 3) / `<byname>[A]` (Scala 2).

## Tests

New AnonymousInstance cases (generic concrete-return, generic factory, symbolic, implicit, abstract val, this.type gated on `returnsThisType`, Scala 3-only context-function), a self-typed-trait enclosure test, and `byNameUnderlying` assertions in the Methods specs.

- `quick-test` green on 3.3.8 + 2.13.16 (1152 + 1280, sandwich 10 + 9).
- AnonymousInstance / Methods / Enclosures specs green on 3.8.4 + 2.13.18 (`NEWEST_SCALA_TESTS=true`), including the context-function and this.type cases.

Verified end-to-end against Kindlings (`mock` and `di` modules) at the published `0.3.1-49` snapshot: both DI gaps closed, all 6 mock gaps resolved.