### PR TITLE
std: zero-closure foreach & Either fold, MatchCase owner fix, IsCollectionOf.asMap

### DIFF
--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -1457,7 +1457,11 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             // val body = '{ val _ = $toSuppress; $result }
             val body = Block(
               List(Expr.suppressUnused(toSuppress).asTerm),
-              stripInlined(result.asTerm)
+              // Re-own the case body to the splice owner (like the scrutinee above). Without this, definitions
+              // nested in the body that were built in another context — e.g. a `ValDefs.createVal` whose value
+              // contains an inline lambda — keep stale owners and trip "Block contains definitions with different
+              // owners" when the body is spliced into the CaseDef.
+              stripInlined(result.asTerm).changeOwner(Symbol.spliceOwner)
             )
 
             val sym = TypeRepr.of[Matched].typeSymbol
@@ -1474,7 +1478,11 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             // val body = '{ val _ = $toSuppress; $result }
             val body = Block(
               List(Expr.suppressUnused(toSuppress).asTerm),
-              stripInlined(result.asTerm)
+              // Re-own the case body to the splice owner (like the scrutinee above). Without this, definitions
+              // nested in the body that were built in another context — e.g. a `ValDefs.createVal` whose value
+              // contains an inline lambda — keep stale owners and trip "Block contains definitions with different
+              // owners" when the body is spliced into the CaseDef.
+              stripInlined(result.asTerm).changeOwner(Symbol.spliceOwner)
             )
 
             // case tt(name @ _) => ... - the TypeTest instance is the extractor, its unapply is total
@@ -1493,7 +1501,11 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             // val body = '{ val _ = $valueRef; $result }
             val body = Block(
               List(Expr.suppressUnused(toSuppress).asTerm),
-              stripInlined(result.asTerm)
+              // Re-own the case body to the splice owner (like the scrutinee above). Without this, definitions
+              // nested in the body that were built in another context — e.g. a `ValDefs.createVal` whose value
+              // contains an inline lambda — keep stale owners and trip "Block contains definitions with different
+              // owners" when the body is spliced into the CaseDef.
+              stripInlined(result.asTerm).changeOwner(Symbol.spliceOwner)
             )
             val valueTerm = valueRef.asTerm
             valueTerm match {

--- a/hearth/src/main/scala/hearth/std/StdExtensions.scala
+++ b/hearth/src/main/scala/hearth/std/StdExtensions.scala
@@ -288,10 +288,17 @@ trait StdExtensions { this: MacroCommons =>
         case Some(item) =>
           import item.Underlying as I
           val castIterableExpr = iterableExpr.asInstanceOf[Expr[Iterable[I]]]
-          val lambda =
-            LambdaBuilder.of1[I]("item").buildWith(f.asInstanceOf[Expr[I] => Expr[Unit]])(using Type.of[Unit])
+          val fI = f.asInstanceOf[Expr[I] => Expr[Unit]]
+          // Zero-closure default: walk the iterator with a `while` loop and splice the per-item body directly into
+          // the loop, rather than allocating a `Function1` for `Iterable.foreach`. The closure form often fails to
+          // scalarize at megamorphic call sites (e.g. map entry encoding), so the `while` form is both never worse
+          // and frequently faster. Providers with a cheaper traversal (e.g. arrays by index) still override this.
           Expr.quote {
-            Expr.splice(castIterableExpr).foreach(Expr.splice(lambda))
+            val it = Expr.splice(castIterableExpr).iterator
+            while (it.hasNext) {
+              val elem = it.next()
+              Expr.splice(fI(Expr.quote(elem)))
+            }
           }
         case None =>
           hearthRequirementFailed(

--- a/hearth/src/main/scala/hearth/std/StdExtensions.scala
+++ b/hearth/src/main/scala/hearth/std/StdExtensions.scala
@@ -307,6 +307,14 @@ trait StdExtensions { this: MacroCommons =>
       }
     }
 
+    /** If this collection is actually a map, returns its map proof (whose `Pair` is this `Item`); `None` for a plain
+      * collection. Lets a caller that already holds an `IsCollectionOf` discover map-ness without a second
+      * `IsCollection.parse` and without an erasure-unsound `isInstanceOf[IsMapOf[?, ?]]`.
+      *
+      * @since 0.3.1
+      */
+    def asMap: Option[IsMapOf[CollA, Item]] = None
+
     type CtorResult
     @ImportedCrossTypeImplicit
     implicit val CtorResult: Type[CtorResult]
@@ -372,6 +380,8 @@ trait StdExtensions { this: MacroCommons =>
     def key(pair: Expr[Pair]): Expr[Key]
     def value(pair: Expr[Pair]): Expr[Value]
     def pair(key: Expr[Key], value: Expr[Value]): Expr[Pair]
+
+    override def asMap: Option[IsMapOf[MapKV, Pair]] = Some(this)
   }
 
   /** An alias indicating the type is a map of some key and value types, but the exact key and value types are an
@@ -389,7 +399,7 @@ trait StdExtensions { this: MacroCommons =>
 
     def parse[A: Type]: ProviderResult[IsMap[A]] =
       IsCollection.parse[A] match {
-        case ProviderResult.Matched(isCollection) if isCollection.value.isInstanceOf[IsMapOf[?, ?]] =>
+        case ProviderResult.Matched(isCollection) if isCollection.value.asMap.isDefined =>
           ProviderResult.Matched(isCollection.asInstanceOf[IsMap[A]])
         case ProviderResult.Matched(_) =>
           ProviderResult.skipped("IsMap", s"${Type[A].prettyPrint} is a collection but not a Map")

--- a/hearth/src/main/scala/hearth/std/extensions/IsEitherProviderForScalaEither.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsEitherProviderForScalaEither.scala
@@ -2,6 +2,9 @@ package hearth
 package std
 package extensions
 
+import hearth.fp.data.NonEmptyVector
+import hearth.fp.syntax.*
+
 /** Macro extension providing support for Scala eithers.
   *
   * Supports all Scala built-in eithers, turns them into [[scala.Either]] by upcasting. Treats them as types without
@@ -19,6 +22,8 @@ final class IsEitherProviderForScalaEither extends StandardMacroExtension { load
       override def name: String = loader.getClass.getName
 
       private lazy val Either = Type.Ctor2.of[Either]
+      private lazy val RightCtor = Type.Ctor2.of[Right]
+      private lazy val LeftCtor = Type.Ctor2.of[Left]
 
       private def isEither[A: Type, LeftValue0, RightValue0](
           toEither: Expr[A] => Expr[Either[LeftValue0, RightValue0]],
@@ -38,15 +43,24 @@ final class IsEitherProviderForScalaEither extends StandardMacroExtension { load
 
           override def fold[B: Type](
               either: Expr[A]
-          )(onLeft: Expr[LeftValue0] => Expr[B], onRight: Expr[RightValue0] => Expr[B]): Expr[B] =
-            Expr.quote {
-              Expr
-                .splice(toEither(either))
-                .fold[B](
-                  Expr.splice(LambdaBuilder.of1[LeftValue0]("left").buildWith(onLeft)),
-                  Expr.splice(LambdaBuilder.of1[RightValue0]("right").buildWith(onRight))
-                )
-            }
+          )(onLeft: Expr[LeftValue0] => Expr[B], onRight: Expr[RightValue0] => Expr[B]): Expr[B] = {
+            // Zero-closure fold: generate a `match` and splice the compile-time `onLeft`/`onRight` bodies directly
+            // into the branches, instead of `either.fold(<runtime closure>, <runtime closure>)`. `onLeft`/`onRight`
+            // are macro-level functions applied at expansion time, so no `Function1` is allocated at runtime.
+            implicit val EitherLR: Type[Either[LeftValue0, RightValue0]] = Either[LeftValue0, RightValue0]
+            implicit val RightLR: Type[Right[LeftValue0, RightValue0]] = RightCtor[LeftValue0, RightValue0]
+            implicit val LeftLR: Type[Left[LeftValue0, RightValue0]] = LeftCtor[LeftValue0, RightValue0]
+            MatchCase.matchOn[Either[LeftValue0, RightValue0], B](toEither(either))(
+              NonEmptyVector(
+                MatchCase.typeMatch[Right[LeftValue0, RightValue0]]("right").map { rightExpr =>
+                  onRight(Expr.quote(Expr.splice(rightExpr).value))
+                },
+                MatchCase.typeMatch[Left[LeftValue0, RightValue0]]("left").map { leftExpr =>
+                  onLeft(Expr.quote(Expr.splice(leftExpr).value))
+                }
+              )
+            )
+          }
 
           override def getOrElse(either: Expr[A])(default: Expr[RightValue0]): Expr[RightValue0] =
             Expr.quote {


### PR DESCRIPTION
Four reusable std-extension/codegen improvements driven by kindlings perf work (all on JVM 2.13 + 3, full macro suite green: 1152 + 1280 + sandwich).

- **`IsCollectionOf.foreach` default → zero-closure `while` loop** instead of `iterable.foreach(<Function1>)`. Only the Array provider overrode it before, so List/Vector/Map/Set allocated a closure per iteration; the default now walks the iterator with a `while` loop and splices the per-item body inline.
- **`IsEitherProviderForScalaEither.fold` → zero-closure `match`** via `MatchCase`, instead of `either.fold(<closure>, <closure>)`. `onLeft`/`onRight` are compile-time functions, so no `Function1` is allocated. Enables zero-allocation fail-fast field construction in derived `Either`-returning decoders.
- **`MatchCase.matchOn` (Scala 3): re-own case bodies to the splice owner**, matching the scrutinee. Without it, a case body nesting definitions built in another context (e.g. a `ValDefs.createVal` whose value contains an inline lambda) tripped "Block contains definitions with different owners".
- **`IsCollectionOf.asMap: Option[IsMapOf[CollA, Item]]`** (default `None`, `Some(this)` in `IsMapOf`) — typed map-ness check without a second `IsCollection.parse` or an erasure-unsound `isInstanceOf[IsMapOf[?, ?]]`. `IsMap.parse` now uses it.

Consumed by kindlings to make collection/map iteration zero-closure, fail-fast `Either` decode allocation-free (circe/yaml/pureconfig), and to parse `IsCollection` once per field.