### PR TITLE
chore: bump sbt-kubuszok to 0.2.3 + pin sbt to 1.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -8,7 +8,9 @@ updates.ignore = [
 updates.pin = [
   # Use Scala 3 LTS, ignore Scala 3 Next releases
   { groupId="org.scala-lang", artifactId="scala3-library", version="3.3." },
-  { groupId="org.scala-lang", artifactId="scala3-library_sjs1", version="3.3." }
+  { groupId="org.scala-lang", artifactId="scala3-library_sjs1", version="3.3." },
+  # Stay on sbt 1.x: sbt 2.0 requires JDK 17 while hearth deliberately targets older JDKs.
+  { groupId="org.scala-sbt", artifactId="sbt", version="1." }
 ]
 pullRequests.grouping = [
   { name="scala-versions", "title"="Scala compiler updates", "filter"=[{"group" = "org.scala-lang"}, {"group" = "org.scoverage"}] }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // kubuszok plugin (bundles: sbt-git, sbt-scalafmt, sbt-scoverage, sbt-projectmatrix, sbt-commandmatrix, sbt-pgp, sbt-mima-plugin, sbt-ide-settings, sbt-welcome, sbt-scalajs, sbt-scala-native)
-addSbtPlugin("com.kubuszok" % "sbt-kubuszok" % "0.2.1")
+addSbtPlugin("com.kubuszok" % "sbt-kubuszok" % "0.2.3")
 // benchmarks
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.8")
 


### PR DESCRIPTION
Bumps the sbt-kubuszok plugin to 0.2.3 (the org-wide cross-published release) and pins sbt to 1.x in scala-steward so it never proposes sbt 2.0 (sbt 2.0 needs JDK 17, which hearth deliberately does not target).

- `project/plugins.sbt`: sbt-kubuszok 0.2.1 → 0.2.3
- `project/build.properties`: unchanged (stays on sbt 1.x)
- `.scala-steward.conf`: add `{ groupId="org.scala-sbt", artifactId="sbt", version="1." }` pin
- `-Yfuture-lazy-vals` conditional already present — unchanged.

hearth's source is unchanged (build tooling only); verified locally (2432 tests green on JDK 24). No tagged release — master merge publishes a new snapshot for downstream (kindlings/pipez/refined-compat).