### PR TITLE
chore(scala-steward): block Scala-3 Next bumps + pin sbt to 1.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,14 +1,17 @@
 updates.ignore = [
-  # We're using the last version of 2.13 that didn't change API, but we're testing against newer versions
-  # and apparently Scala Steward does not respect update.pin so have to ignore all of that:
+  # Scala compiler/stdlib versions are managed BY HAND. We deliberately build both the 3.3 LTS
+  # (3.3.8) AND a Scala 3 Next axis (3.8.4) for regression testing, and Scala Steward does not
+  # respect updates.pin for Scala versions — it "unifies" the LTS up to the Next version (it bumped
+  # `val scala3` 3.3.8 -> 3.8.4 in #294 despite the pin). Same for the 2.13 line. So ignore all of
+  # the Scala libs and bump 3.3.x by hand.
   { groupId="org.scala-lang", artifactId="scala-compiler" },
   { groupId="org.scala-lang", artifactId="scala-library" },
-  { groupId="org.scala-lang", artifactId="scala-reflect" }
+  { groupId="org.scala-lang", artifactId="scala-reflect" },
+  { groupId="org.scala-lang", artifactId="scala3-library" },
+  { groupId="org.scala-lang", artifactId="scala3-library_sjs1" },
+  { groupId="org.scala-lang", artifactId="scala3-library_native0.5" }
 ]
 updates.pin = [
-  # Use Scala 3 LTS, ignore Scala 3 Next releases
-  { groupId="org.scala-lang", artifactId="scala3-library", version="3.3." },
-  { groupId="org.scala-lang", artifactId="scala3-library_sjs1", version="3.3." },
   # Stay on sbt 1.x: sbt 2.0 requires JDK 17 while hearth deliberately targets older JDKs.
   { groupId="org.scala-sbt", artifactId="sbt", version="1." }
 ]


### PR DESCRIPTION
Strengthens Scala Steward config (config-only):
- **Ignore the Scala 3 libs** (`scala3-library`,`_sjs1`,`_native0.5`) — this repo builds both 3.3 LTS and a 3.8.4 axis, and Steward does not respect `updates.pin` for Scala versions (it unified hearth's `val scala3` 3.3.8 → 3.8.4 in hearth#294 despite the pin). Ignoring is the reliable block; 3.3.x bumps are manual.
- **Pin sbt to 1.x** (`org.scala-sbt:sbt` `version="1."`) so Steward never proposes sbt 2.0 (which would break the sbt-1.x-driven cross-build / JDK targets).