### PR TITLE
Fix #246: add CaseClass.copyMethod; enable MiMa against 0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,13 +187,19 @@ Agent: [Updates dev.properties to set ide.scala = 3]
 
 ### Binary Compatibility
 
-The project uses **MiMa** (Migration Manager) for binary compatibility checking.
+The project uses **MiMa** (Migration Manager) for binary compatibility checking, enabled against the last released
+version (`mimaPreviousVersion` in `build.sbt`, currently `0.4.0`).
 
 When making changes:
 - Be aware of binary compatibility constraints
 - Breaking changes require major version bumps
-- MiMa checks run automatically via CI
-- Consult MCP server for compatibility reports
+- MiMa checks run automatically via CI (`mimaReportBinaryIssues` is part of the `ci-*` aliases)
+- **Before suppressing any MiMa error**, read [Binary compatibility and mix-ins](docs/contributing/binary-compatibility-and-mixins.md):
+  because Hearth's public API is traits that users mix in, a **top-level** trait member added between releases is
+  breaking (forwarder obligation during linearization), while a member added in a **nested** scope is not
+  user-observable (the implementation is evicted together with the interface) and may be suppressed in
+  `mimaBinaryIssueFilters` with a comment citing why
+- Bump `mimaPreviousVersion` on every release
 
 ### CI/CD Pipeline
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import sbtwelcome.UsefulTask
 import commandmatrix.extra.*
 import kubuszok.sbt._
 import kubuszok.sbt.KubuszokPlugin.autoImport._
+import com.typesafe.tools.mima.core._
+import com.typesafe.tools.mima.core.ProblemFilters._
 
 // Used to compile tests against the newest Scala versions, to check for regressions.
 lazy val isNewestScalaTests = sys.env.get("NEWEST_SCALA_TESTS").contains("true")
@@ -277,28 +279,56 @@ val publishSettings = Seq(
   projectType := ProjectType.ScalaLibrary
 )
 
+// The last released version we check binary compatibility against. Bump this on every release.
+val mimaPreviousVersion = "0.4.0"
+
 val mimaSettings = Seq(
   mimaPreviousArtifacts := {
     val previousVersions = moduleName.value match {
       case "hearth-better-printers" | "hearth-cross-quotes" | "hearth-micro-fp" | "hearth" | "hearth-munit" =>
-        Set() // fix after 0.2.0 release
+        Set(mimaPreviousVersion)
       case "hearth-build" | "hearth-tests" | "hearth-sandwich-examples-213" | "hearth-sandwich-examples-3" |
           "hearth-sandwich-tests" | "debug-hearth-better-printers" | "debug-hearth" =>
         Set()
       case name => sys.error(s"All modules should be explicitly checked or ignored for MiMa, missing: $name")
     }
-    previousVersions.map(organization.value %% moduleName.value % _)
+    // `.cross(crossVersion.value)` applies the project's own, platform-aware cross-version (CrossVersion.binary on
+    // JVM, ScalaJSCrossVersion.binary on JS, ScalaNativeCrossVersion.binary on Native) so that MiMa compares each
+    // artifact against the matching previous one (`hearth_sjs1_2.13`, `hearth_native0.5_2.13`, ...) instead of always
+    // resolving the JVM artifact (`hearth_2.13`) - which would report all JVM-only classes as "missing".
+    previousVersions.map(v => (organization.value % moduleName.value % v).cross(crossVersion.value))
   },
   mimaFailOnNoPrevious := {
     moduleName.value match {
       case "hearth-better-printers" | "hearth-cross-quotes" | "hearth-micro-fp" | "hearth" | "hearth-munit" =>
-        false // fix after 0.2.0 release
+        true
       case "hearth-build" | "hearth-tests" | "hearth-sandwich-examples-213" | "hearth-sandwich-examples-3" |
           "hearth-sandwich-tests" | "debug-hearth-better-printers" | "debug-hearth" =>
         false
       case name => sys.error(s"All modules should be explicitly checked or ignored for MiMa, missing: $name")
     }
-  }
+  },
+  // Binary-compatibility exceptions.
+  //
+  // Hearth's public surface is a set of traits (MacroCommons and the traits it mixes in) that ONLY we implement and
+  // that USERS mix into their own macro bundles. For such mix-ins the rule that matters is:
+  //
+  //   * A NEW TOP-LEVEL member (val/var/object, or an abstract def) added to a mixed-in trait IS breaking: during
+  //     linearization the user's bundle must now provide/forward it, so a bundle compiled against the old version
+  //     fails to link against the new one. MiMa flags these as ReversedMissingMethodProblem / (Inherited)
+  //     NewAbstractMethodProblem - keep them.
+  //   * A member added inside a NESTED scope (a method/val/object on a nested class or object, e.g. a method on
+  //     `Classes#CaseClass`) is NOT observable by users: the only code that instantiates or mixes in those nested
+  //     definitions is Hearth's own, which is evicted together with the interface. A user upgrading gets both the
+  //     new interface and its new implementation atomically, so the change can never be witnessed as a link error.
+  //     (MiMa does not even report adding a method to a nested *class* - only trait members turn into forwarders.)
+  //
+  // Only the second kind may be excluded here, and each exclusion must cite why it is not user-observable. See
+  // docs/contributing/binary-compatibility-and-mixins.md for the full policy and worked examples.
+  //
+  // Example of an allowed exclusion (a member added to a NESTED trait/object that MiMa would otherwise flag):
+  //   exclude[ReversedMissingMethodProblem]("hearth.typed.SomeTrait#SomeNestedTrait.newHelper")
+  mimaBinaryIssueFilters ++= Seq.empty[ProblemFilter]
 )
 
 val noPublishSettings =

--- a/docs/contributing/_index.md
+++ b/docs/contributing/_index.md
@@ -9,6 +9,7 @@ as well as guide agentic coding and debugging.
  1. [Architecture overview](architecture-overview.md) - always relevant for implementing new features and debugging or fixing existing ones
  2. [Guidelines for code style](guidelines-for-code-style.md) - always relevant for creating new or modifying existing code
  3. [Guidelines for tests](guidelines-for-tests.md) - relevant for writing new tests
+ 4. [Binary compatibility and mix-ins](binary-compatibility-and-mixins.md) - how MiMa is configured and which breakages actually affect users (mix-in linearization vs. nested additions); read before suppressing any MiMa error
 
 
 ## Instructions for adding new code, tests and documentation

--- a/docs/contributing/binary-compatibility-and-mixins.md
+++ b/docs/contributing/binary-compatibility-and-mixins.md
@@ -1,0 +1,123 @@
+# Binary compatibility and mix-ins
+
+Hearth is a published library, so we check binary compatibility with [MiMa](https://github.com/lightbend-labs/mima)
+against the last released version on every build. This document explains **which** binary-compatibility breakages
+actually affect our users and which are safe to suppress — a distinction that is unusual for Hearth because of how its
+public API is shaped.
+
+If you are only here to make CI green: **do not blanket-suppress MiMa errors.** Read the
+[decision procedure](#decision-procedure) below and suppress *only* the breakages that are provably not observable by
+users, each with a comment citing why.
+
+
+## Where MiMa is configured
+
+Everything lives in `build.sbt`:
+
+- `mimaPreviousVersion` — the last released version we compare against. **Bump it on every release.**
+- `mimaSettings` — sets `mimaPreviousArtifacts` for the published modules
+  (`hearth-better-printers`, `hearth-cross-quotes`, `hearth-micro-fp`, `hearth`, `hearth-munit`) and
+  `mimaFailOnNoPrevious := true` for them (a missing previous artifact is an error, never a silent skip).
+- `mimaBinaryIssueFilters` — the allow-list of suppressed breakages. Keep it minimal and commented.
+
+The previous artifact is built with `.cross(crossVersion.value)` rather than `%%`, so each project compares against the
+**platform-matching** previous artifact (`hearth_2.13`, `hearth_sjs1_2.13`, `hearth_native0.5_3`, …). Using plain `%%`
+would make every platform resolve the JVM artifact (`hearth_2.13`), and MiMa would then report all JVM-only classes
+(e.g. the `hearth.std.extensions.*ForJava*` providers) as "missing" on JS/Native — a false positive.
+
+`mimaReportBinaryIssues` is already part of the `ci-*` aliases, so CI runs it for every published module on every
+platform (JVM, JS, Native) and both Scala versions. This is supported: sbt-mima 1.1.6 reads the JVM `.class` files that
+scalac emits alongside the `.sjsir` / native IR, so MiMa works on Scala.js and Scala Native for **both** Scala 2.13 and
+Scala 3. `hearth-cross-quotes` is compiled but not MiMa-reported (it is a Scala 3 compiler plugin / a Scala 2 macro
+library, not a normal library API surface).
+
+
+## Why Hearth's public API is unusual
+
+Hearth's public surface is not a set of concrete classes with methods. It is a set of **traits** — `MacroCommons` and
+the traits it mixes in (`Types`, `Exprs`, `Methods`, `Classes`, …). The intended usage is:
+
+```scala
+// User code — a macro bundle that mixes Hearth in:
+final class MyMacros(val c: blackbox.Context) extends MacroCommonsScala2 with MyOwnLogic
+// or on Scala 3:
+final class MyMacros(q: Quotes) extends MacroCommonsScala3(using q), MyOwnLogic
+```
+
+Two facts follow from this:
+
+1. **We are the only ones who implement these traits.** `MacroCommonsScala2` / `MacroCommonsScala3` and the
+   platform-specific traits they pull in are maintained exclusively by us.
+2. **Users mix these traits into their own final bundle classes.** The linker resolves the mixin composition of the
+   user's bundle against *whichever version of Hearth is on their classpath at build time*.
+
+This is what makes the usual "adding a member is safe" intuition only partially true here.
+
+
+## The mechanics: trait members become forwarders
+
+When a trait is mixed into a class, the Scala compiler emits, in the mixing class, **forwarder** members for the
+trait's concrete members (and requires implementations for its abstract members). The set of forwarders/obligations is
+baked into the mixing class's bytecode **at the version it was compiled against**.
+
+So consider a user's bundle `MyMacros` compiled against Hearth *N*, then run against Hearth *N+1*:
+
+- If *N+1* **added a top-level member to a trait that `MyMacros` mixes in** (a new `val`/`var`/`object`, or a new
+  abstract `def`), then `MyMacros`'s bytecode does not carry the forwarder/implementation that *N+1*'s linearization now
+  expects. The result is a `LinkageError` / `AbstractMethodError` at class-load or call time. **This is a real, breaking
+  change** and MiMa reports it as `ReversedMissingMethodProblem`, `NewAbstractMethodProblem`, or
+  `InheritedNewAbstractMethodProblem`. **Keep these.**
+
+- If *N+1* only **changed something nested** — a method/`val`/`object` added to a *nested* class or object such as
+  `Classes#CaseClass`, or a `def` local to another member — then no new obligation lands on `MyMacros`. Those nested
+  definitions are only ever instantiated or mixed in by **Hearth's own code**, which ships in the very same artifact as
+  the interface. When the user upgrades to *N+1* they evict *N*'s `hearth.jar` and get *N+1*'s interface **and** *N+1*'s
+  implementation atomically. There is no window in which the user's bytecode sees the new interface but an old
+  implementation, so the change **can never be witnessed as a link error by user code**.
+
+Put differently: the only observer who could ever notice a nested change is Hearth itself — and Hearth is part of what
+gets evicted, so it upgrades in lockstep. That is why nested additions are not user-observable even when they are, in a
+strict bytecode sense, "different".
+
+> Note: MiMa does not even *report* adding a method to a nested **class** — added class methods are forward-compatible.
+> The nested exception matters for the cases MiMa *does* flag: members added to a nested **trait** or **object** that it
+> turns into forwarders/obligations.
+
+
+## Decision procedure
+
+When MiMa reports a problem, classify the changed member:
+
+1. **Is it a top-level member of a trait that users mix in** (directly or transitively through `MacroCommons`)?
+   → **Breaking. Do not suppress.** Either revert the change, make the addition non-breaking (e.g. give a trait `def` a
+   concrete default body instead of leaving it abstract, so no new obligation is imposed — MiMa may still flag it, in
+   which case re-evaluate), or accept it and bump the **major**/**minor** version per the project's versioning policy.
+
+2. **Is it nested inside a class/object/def, reachable and implemented only by Hearth's own code?**
+   → **Not user-observable. Safe to suppress** with a `mimaBinaryIssueFilters` entry that **cites why** it is nested and
+   not observable.
+
+3. **Not sure?** Treat it as breaking (case 1). The cost of a false "safe" is a runtime `LinkageError` in a user's
+   macro; the cost of a false "breaking" is a version bump.
+
+
+## How to suppress (only case 2)
+
+Add an entry to `mimaBinaryIssueFilters` in `build.sbt`, with a comment explaining why it is not user-observable:
+
+```scala
+mimaBinaryIssueFilters ++= Seq(
+  // Nested addition: `newHelper` was added to the nested trait `SomeTrait#SomeNestedTrait`, which is only mixed in by
+  // Hearth's own code (evicted together with this interface), so no user bundle carries a forwarder obligation for it.
+  exclude[ReversedMissingMethodProblem]("hearth.typed.SomeTrait#SomeNestedTrait.newHelper")
+)
+```
+
+Never add a filter that matches a top-level trait member, and never use broad wildcards that could also hide a genuine
+top-level breakage.
+
+
+## On releases
+
+Bump `mimaPreviousVersion` in `build.sbt` to the version you just released, so the next development cycle is checked
+against it. When you do, prune any `mimaBinaryIssueFilters` entries that were only relevant to older comparisons.

--- a/docs/user-guide/basic-utilities.md
+++ b/docs/user-guide/basic-utilities.md
@@ -3031,6 +3031,20 @@ Specialized view for case classes, providing access to primary constructor and c
 | `cc.primaryConstructor`    | `Method`                             | primary constructor           |
 | `cc.nonPrimaryConstructors`| `List[Method]`                       | other constructors            |
 | `cc.caseFields`            | `List[Method]`                       | case class fields             |
+| `cc.copyMethod()`          | `Option[Method.OnInstance.Of[A]]`    | canonical `copy` method       |
+
+!!! tip "`cc.copyMethod()` for updating case class instances"
+
+    `copyMethod` returns the compiler-synthesized `copy` — the instance method whose value-parameter clauses mirror the
+    primary constructor (so it handles multiple parameter lists like `case class Boo(i: Int)(s: Int)` and generic case
+    classes). It returns `None` when no such method is accessible — e.g. a `sealed abstract case class` (no `copy` is
+    generated), or when `copy` is not visible under the requested scope.
+
+    The optional `visibility: Accessible` parameter defaults to `AtCallSite`, the safe default for derivation: the
+    method is returned only if `instance.copy(...)` would compile at the macro-expansion point. Pass `Everywhere` to
+    require it to be public, or `Anywhere` to ignore accessibility. Because it is a builder chain, drive it as
+    `copy.apply(instance)` → (type args, for generics) → `.apply(args)` → `.build()`; arguments you omit fall back to
+    `copy`'s defaults (the original field values), so you only supply the fields you want to change.
 
 !!! example "Constructing case class instances"
 

--- a/hearth-tests/src/main/scala-2/hearth/typed/ClassesFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ClassesFixtures.scala
@@ -30,6 +30,12 @@ final private class ClassesFixtures(val c: blackbox.Context) extends MacroCommon
   def testCaseClassCaseFieldValuesAtAnywhereImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[String] =
     testCaseClassCaseFieldValuesAtAnywhere[A](expr)
 
+  def testCaseClassCopyMethodImpl[A: c.WeakTypeTag]: c.Expr[Data] =
+    testCaseClassCopyMethod[A]
+
+  def testCaseClassCopyRoundTripImpl[A: c.WeakTypeTag](instance: c.Expr[A]): c.Expr[String] =
+    testCaseClassCopyRoundTrip[A](instance)
+
   def testEnumParMatchOnNestedQuoteImpl[A: c.WeakTypeTag](expr: c.Expr[A], suffix: c.Expr[String]): c.Expr[String] =
     testEnumParMatchOnNestedQuote[A](expr, suffix)
 
@@ -87,6 +93,11 @@ object ClassesFixtures {
 
   def testCaseClassCaseFieldValuesAtAnywhere[A](expr: A): String =
     macro ClassesFixtures.testCaseClassCaseFieldValuesAtAnywhereImpl[A]
+
+  def testCaseClassCopyMethod[A]: Data = macro ClassesFixtures.testCaseClassCopyMethodImpl[A]
+
+  def testCaseClassCopyRoundTrip[A](instance: A): String =
+    macro ClassesFixtures.testCaseClassCopyRoundTripImpl[A]
 
   def testEnumParMatchOnNestedQuote[A](expr: A, suffix: String): String =
     macro ClassesFixtures.testEnumParMatchOnNestedQuoteImpl[A]

--- a/hearth-tests/src/main/scala-3/hearth/typed/ClassesFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ClassesFixtures.scala
@@ -47,6 +47,16 @@ object ClassesFixtures {
   private def testCaseClassCaseFieldValuesAtAnywhereImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[String] =
     new ClassesFixtures(q).testCaseClassCaseFieldValuesAtAnywhere[A](expr)
 
+  inline def testCaseClassCopyMethod[A]: Data = ${ testCaseClassCopyMethodImpl[A] }
+  private def testCaseClassCopyMethodImpl[A: Type](using q: Quotes): Expr[Data] =
+    new ClassesFixtures(q).testCaseClassCopyMethod[A]
+
+  inline def testCaseClassCopyRoundTrip[A](inline instance: A): String = ${
+    testCaseClassCopyRoundTripImpl[A]('instance)
+  }
+  private def testCaseClassCopyRoundTripImpl[A: Type](instance: Expr[A])(using q: Quotes): Expr[String] =
+    new ClassesFixtures(q).testCaseClassCopyRoundTrip[A](instance)
+
   inline def testEnumParMatchOnNestedQuote[A](inline expr: A, inline suffix: String): String = ${
     testEnumParMatchOnNestedQuoteImpl[A]('expr, 'suffix)
   }

--- a/hearth-tests/src/main/scala/hearth/examples/classes.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/classes.scala
@@ -16,6 +16,18 @@ case class ExampleCaseClassWithVarargs(xs: Int*)
 case class ExampleCaseClassWithTypeParam[A](a: A)
 case class ExampleCaseClassWithDefaults(a: Int, b: String = "default-b")
 
+// Examples for CaseClass.copyMethod (issue #246).
+
+// Multiple parameter lists: the canonical `copy` mirrors them, i.e. `def copy(i: Int = i)(s: String = s)`.
+case class ExampleCaseClassMultipleParamLists(i: Int)(val s: String)
+
+// A private primary constructor makes the synthesized `copy` non-public, so it is dropped by AtCallSite/Everywhere
+// but kept by Anywhere.
+case class ExampleCaseClassPrivateCopy private (a: Int)
+
+// An abstract case class has no synthesized `copy` at all, so `copyMethod` is None under every visibility.
+sealed abstract case class ExampleSealedAbstractCaseClass(a: Int)
+
 // Example for caseFieldValuesAt(instance, visibility) field filtering by accessibility.
 // `b` is `private[hearth]`: accessible from within the `hearth` package, so it is kept by the
 // default (AtCallSite) and by AtCallSite when expanding inside hearth, but it is not public, so

--- a/hearth-tests/src/main/scala/hearth/typed/ClassesFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ClassesFixturesImpl.scala
@@ -223,6 +223,54 @@ trait ClassesFixturesImpl { this: MacroCommons =>
     }
   }
 
+  /** Issue #246: reports the canonical `copy` method discovered by [[CaseClass.copyMethod]] under each visibility
+    * scope. Renders the untyped parameter-name shape (e.g. `(i)(s)`) so the assertion is stable across Scala 2/3, or
+    * `<none>` when no accessible canonical copy exists (private copy under AtCallSite/Everywhere, abstract case class
+    * under any scope).
+    */
+  def testCaseClassCopyMethod[A: Type]: Expr[Data] = {
+    def describe(visibility: Accessible)(cc: CaseClass[A]): Data =
+      cc.copyMethod(visibility) match {
+        case None       => Data("<none>")
+        case Some(copy) => Data(copy.asUntyped.parameters.map(_.keys.mkString("(", ", ", ")")).mkString)
+      }
+    Expr(
+      CaseClass.parse[A].toOption.fold(Data("<no case class>")) { cc =>
+        Data.map(
+          "atCallSite" -> describe(AtCallSite)(cc),
+          "everywhere" -> describe(Everywhere)(cc),
+          "anywhere" -> describe(Anywhere)(cc)
+        )
+      }
+    )
+  }
+
+  /** Issue #246: exercises the [[CaseClass.copyMethod]] builder chain by overriding every `Int` field with `99` and
+    * leaving the remaining fields at their defaults (i.e. the original values, via `copy`'s default arguments), then
+    * evaluates the resulting instance's `toString` at runtime.
+    */
+  def testCaseClassCopyRoundTrip[A: Type](instance: Expr[A]): Expr[String] = {
+    implicit val IntType: Type[Int] = intType
+    CaseClass.parse[A].toOption.flatMap(cc => cc.copyMethod().map(cc -> _)) match {
+      case None            => Expr("<no copy>")
+      case Some((_, copy)) =>
+        copy.fold(
+          onInstance = _ => instance.as_??,
+          onTypes = _ => Map.empty,
+          onValues = av =>
+            av.parameters.flatten.flatMap { case (name, parameter) =>
+              import parameter.tpe.Underlying as FieldType
+              if (FieldType <:< Type[Int]) List(name -> Expr(99).as_??) else Nil
+            }.toMap
+        ) match {
+          case Right(result) =>
+            import result.{Underlying, value}
+            Expr.quote(Expr.splice(value).toString)
+          case Left(error) => Expr(s"<failed: $error>")
+        }
+    }
+  }
+
   def testEnumMatchOnAndParMatchOn[A: Type](expr: Expr[A]): Expr[String] =
     Enum.parse[A].toOption.fold(Expr("<no enum>")) { enumm =>
       implicit val StringType: Type[String] = stringType

--- a/hearth-tests/src/test/scala/hearth/typed/ClassesSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ClassesSpec.scala
@@ -405,6 +405,74 @@ final class ClassesSpec extends MacroSuite {
       }
     }
 
+    // Issue #246: CaseClass.copyMethod returns the canonical, compiler-synthesized `copy` (matching the primary
+    // constructor's value-parameter clauses), filtered by an availability scope that defaults to AtCallSite.
+    group("CaseClass[A].copyMethod (issue #246)") {
+      import ClassesFixtures.testCaseClassCopyMethod
+
+      test("finds the canonical copy for a simple case class under every visibility") {
+        testCaseClassCopyMethod[examples.classes.ExampleCaseClass] <==> Data.map(
+          "atCallSite" -> Data("(a)"),
+          "everywhere" -> Data("(a)"),
+          "anywhere" -> Data("(a)")
+        )
+      }
+
+      test("matches multiple parameter lists of the primary constructor") {
+        testCaseClassCopyMethod[examples.classes.ExampleCaseClassMultipleParamLists] <==> Data.map(
+          "atCallSite" -> Data("(i)(s)"),
+          "everywhere" -> Data("(i)(s)"),
+          "anywhere" -> Data("(i)(s)")
+        )
+      }
+
+      test("finds the canonical copy for a generic case class (untyped params known before type args)") {
+        testCaseClassCopyMethod[examples.classes.ExampleCaseClassWithTypeParam[Int]] <==> Data.map(
+          "atCallSite" -> Data("(a)"),
+          "everywhere" -> Data("(a)"),
+          "anywhere" -> Data("(a)")
+        )
+      }
+
+      test("returns None for a vararg case class (no copy is synthesized on either platform)") {
+        // Neither Scala 2 nor Scala 3 generates `copy` for a case class with a repeated parameter, so there is no
+        // canonical copy to return regardless of visibility.
+        testCaseClassCopyMethod[examples.classes.ExampleCaseClassWithVarargs] <==> Data.map(
+          "atCallSite" -> Data("<none>"),
+          "everywhere" -> Data("<none>"),
+          "anywhere" -> Data("<none>")
+        )
+      }
+
+      test("respects the availability scope for a private-constructor copy") {
+        // A private primary constructor makes `copy` non-public on Scala 3 (dropped by AtCallSite/Everywhere, kept
+        // by Anywhere), whereas Scala 2.13 leaves `copy` public. Either way, `copyMethod` reflects the platform's
+        // own accessibility via the availability filter.
+        val expected =
+          if (LanguageVersion.byHearth.isScala2_13)
+            Data.map("atCallSite" -> Data("(a)"), "everywhere" -> Data("(a)"), "anywhere" -> Data("(a)"))
+          else
+            Data.map("atCallSite" -> Data("<none>"), "everywhere" -> Data("<none>"), "anywhere" -> Data("(a)"))
+        testCaseClassCopyMethod[examples.classes.ExampleCaseClassPrivateCopy] <==> expected
+      }
+
+      test("an abstract case class has no synthesized copy under any visibility") {
+        testCaseClassCopyMethod[examples.classes.ExampleSealedAbstractCaseClass] <==> Data.map(
+          "atCallSite" -> Data("<none>"),
+          "everywhere" -> Data("<none>"),
+          "anywhere" -> Data("<none>")
+        )
+      }
+    }
+
+    test("CaseClass[A].copyMethod round-trip: override an Int field, keep the rest at their defaults") {
+      import ClassesFixtures.testCaseClassCopyRoundTrip
+
+      testCaseClassCopyRoundTrip(hearth.examples.classes.ExampleCaseClass(1)) <==> "ExampleCaseClass(99)"
+      testCaseClassCopyRoundTrip(hearth.examples.classes.ExampleCaseClassWithDefaults(1, "kept")) <==>
+        "ExampleCaseClassWithDefaults(99,kept)"
+    }
+
     test("Enum[A].{matchOn and parMatchOn} should match on the sealed trait") {
       import ClassesFixtures.testEnumMatchOnAndParMatchOn
 

--- a/hearth/src/main/scala/hearth/typed/Classes.scala
+++ b/hearth/src/main/scala/hearth/typed/Classes.scala
@@ -227,6 +227,41 @@ trait Classes { this: MacroCommons =>
       constructors.filter(_ != primaryConstructor)
     lazy val caseFields: List[Method] = methods.filter(_.isCaseField)
 
+    /** The canonical, compiler-synthesized `copy` method, if one exists.
+      *
+      * The "canonical" `copy` is the instance method named `copy` whose value-parameter clauses mirror the primary
+      * constructor's value-parameter clauses (same number of clauses, and the same parameter names, in order). This is
+      * exactly the shape scalac generates, so it also handles multiple parameter lists (`case class Boo(i: Int)(s:
+      * Int)` → `def copy(i: Int = i)(s: Int = s): Boo`) and generic case classes (`case class Foo[A](a: A)` →
+      * `def copy[A1](a: A1 = a): Foo[A1]`). The comparison is done on the untyped parameter names so it works even for
+      * generic `copy`, whose value parameters are only known once its type arguments are applied.
+      *
+      * Returns [[scala.None]] when the compiler synthesizes no `copy` at all - e.g. a `sealed abstract case class`, or
+      * a case class with a repeated/vararg parameter (`case class Foo(xs: Int*)`), for which neither Scala 2 nor Scala
+      * 3 generates `copy` (a repeated parameter cannot carry the default argument `copy` would need) - or when the
+      * `copy` exists but is not accessible under `visibility`.
+      *
+      * By default ([[AtCallSite]]) the method is returned only if it is accessible at the macro-expansion point - the
+      * safe default for derivation, since the generated `instance.copy(...)` has to compile there. Pass [[Everywhere]]
+      * to require it to be public, or [[Anywhere]] to ignore accessibility entirely.
+      *
+      * The returned [[Method.OnInstance]] is a fresh builder chain: apply the instance, then (for generic case classes)
+      * the type arguments, then the argument map, then `build()`.
+      *
+      * @since 0.4.1
+      */
+    def copyMethod(visibility: Accessible = AtCallSite): Option[Method.OnInstance.Of[A]] =
+      canonicalCopyMethod.filter(_.isAvailable(visibility))
+
+    private lazy val canonicalCopyMethod: Option[Method.OnInstance.Of[A]] = {
+      val constructorShape = primaryConstructor.asUntyped.parameters.map(_.keys.toList)
+      methods.collectFirst {
+        case oi: Method.OnInstance
+            if oi.name == "copy" && oi.asUntyped.parameters.map(_.keys.toList) == constructorShape =>
+          oi.asInstanceOf[Method.OnInstance.Of[A]]
+      }
+    }
+
     def construct[F[_]: DirectStyle: Applicative](
         makeArgument: CaseClass.ConstructField[F],
         visibility: Accessible = Everywhere


### PR DESCRIPTION
Closes #246.

## Part 1 — `CaseClass.copyMethod`

Adds a helper on `hearth.typed.Classes.CaseClass`:

```scala
def copyMethod(visibility: Accessible = AtCallSite): Option[Method.OnInstance.Of[A]]
```

- Returns the **canonical**, compiler-synthesized `copy` — the instance method whose value-parameter clauses mirror the primary constructor's.
- Matching is done on **untyped parameter names**, so it works for **generic** `copy` (whose typed `totalParameters` are only known once type arguments are applied) and for **multiple parameter lists** (`case class Boo(i: Int)(s: Int)`).
- Returns `None` when the compiler synthesizes no `copy` at all — a `sealed abstract case class`, or a case class with a **repeated/vararg parameter** (neither Scala 2 nor Scala 3 generates `copy` for those, since a repeated parameter cannot carry the default argument `copy` would need) — or when `copy` is not accessible under `visibility`.
- The availability filter defaults to **`AtCallSite`** — the safe default for derivation, since the generated `instance.copy(...)` must compile at the macro-expansion point. `Everywhere` (public only) and `Anywhere` (ignore accessibility) are also supported.
- Returns the precise `Option[Method.OnInstance.Of[A]]` so callers get a typed `apply(Expr[A])` and drive the builder chain: `copy.apply(instance)` → (type args, for generics) → `.apply(args)` → `.build()`. Omitted arguments fall back to `copy`'s defaults (the original field values).

Cross-platform tests in `ClassesSpec` cover discovery (simple / multiple param lists / generic / abstract→None / vararg→None), the availability filter, and a runtime round-trip.

## Part 2 — MiMa against 0.4.0 + mix-in policy

- Enables MiMa for the published modules against `0.4.0` (`mimaPreviousVersion` constant, `mimaFailOnNoPrevious := true`).
- **Platform-aware previous artifacts:** `mimaPreviousArtifacts` uses `.cross(crossVersion.value)` instead of `%%`, so each project compares against its **own** platform artifact (`hearth_sjs1_2.13`, `hearth_native0.5_3`, …). With plain `%%`, JS/Native resolved the JVM artifact (`hearth_2.13`) and MiMa falsely reported every JVM-only class (e.g. the `hearth.std.extensions.*ForJava*` providers) as missing.
- **Verified across the full matrix:** MiMa is green on **JVM / JS / Native × Scala 2.13 / 3** for every published module. sbt-mima 1.1.6 reads the JVM `.class` files scalac emits alongside the JS/Native IR, so it works on Scala.js and Scala Native on both Scala versions (confirmed empirically, incl. Scala 3 + Native).
- Documents the mix-in binary-compatibility policy in [`docs/contributing/binary-compatibility-and-mixins.md`](docs/contributing/binary-compatibility-and-mixins.md) (linked from the contributing index and AGENTS.md): a **top-level** member added to a mixed-in trait is breaking (forwarder obligation during linearization); a member added in a **nested** scope is not user-observable (evicted atomically with its implementation) and may be suppressed in `mimaBinaryIssueFilters` with a cited reason. `mimaBinaryIssueFilters` is left as a documented, empty hook (no suppression was needed for this change).

## Verification

- `quick-clean ; quick-test`: 1286 (2.13) + 1158 (3) tests pass, plus sandwich tests.
- `scalafmtCheckAll`: clean.
- MiMa `mimaReportBinaryIssues`: green on JVM/JS/Native × Scala 2.13/3 across all published modules.

`@since` is tagged `0.4.1` to match `mimaPreviousVersion`; change to `0.5.0` if this should be a minor release.