### PR TITLE
Fix ValDefs.map2 evaluating its by-name argument twice

### DIFF
--- a/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ExprsFixtures.scala
@@ -65,6 +65,8 @@ final private class ExprsFixtures(val c: blackbox.Context) extends MacroCommonsS
   def testValDefsTraverseAndCloseImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[B] =
     testValDefsTraverseAndClose[A, B](expr)
 
+  def testValDefsMap2DoesNotDoubleCreateImpl: c.Expr[Data] = testValDefsMap2DoesNotDoubleCreate
+
   def testValDefBuilderCreateAndUseImpl: c.Expr[Data] = testValDefBuilderCreateAndUse
 
   def testValDefBuilderPartitionAndCloseImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[B] =
@@ -204,6 +206,8 @@ object ExprsFixtures {
   def testValDefsPartitionAndClose[A, B](expr: A): B = macro ExprsFixtures.testValDefsPartitionAndCloseImpl[A, B]
 
   def testValDefsTraverseAndClose[A, B](expr: A): B = macro ExprsFixtures.testValDefsTraverseAndCloseImpl[A, B]
+
+  def testValDefsMap2DoesNotDoubleCreate: Data = macro ExprsFixtures.testValDefsMap2DoesNotDoubleCreateImpl
 
   def testValDefBuilderCreateAndUse: Data = macro ExprsFixtures.testValDefBuilderCreateAndUseImpl
 

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
@@ -126,6 +126,10 @@ object ExprsFixtures {
   private def testValDefsTraverseAndCloseImpl[A: Type, B: Type](expr: Expr[A])(using q: Quotes): Expr[B] =
     new ExprsFixtures(q).testValDefsTraverseAndClose[A, B](expr)
 
+  inline def testValDefsMap2DoesNotDoubleCreate: Data = ${ testValDefsMap2DoesNotDoubleCreateImpl }
+  private def testValDefsMap2DoesNotDoubleCreateImpl(using q: Quotes): Expr[Data] =
+    new ExprsFixtures(q).testValDefsMap2DoesNotDoubleCreate
+
   inline def testValDefBuilderCreateAndUse: Data = ${ testValDefBuilderCreateAndUseImpl }
   private def testValDefBuilderCreateAndUseImpl(using q: Quotes): Expr[Data] =
     new ExprsFixtures(q).testValDefBuilderCreateAndUse

--- a/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
@@ -387,6 +387,26 @@ trait ExprsFixturesImpl { this: MacroCommons =>
     option.fold[Expr[B]](runtimeFail)(_.close)
   }
 
+  def testValDefsMap2DoesNotDoubleCreate: Expr[Data] = {
+    implicit val intType: Type[Int] = IntType
+
+    // Regression: ValDefs.map2's second argument is by-name. When `traverse`/`sequence` route a freshly
+    // created val through it, forcing it twice would materialize two conflicting fresh vals - the emitted
+    // definitions coming from the first evaluation while the referenced Ref comes from the second (discarded)
+    // one, producing a dangling reference in the generated code. Each element must be created exactly once.
+    val summed: Expr[Int] = List(Expr(10), Expr(20), Expr(30))
+      .traverse(e => ValDefs.createVal(e, "x"))
+      .use { (refs: List[Expr[Int]]) =>
+        refs.foldLeft(Expr(0))((acc, ref) => Expr.quote(Expr.splice(acc) + Expr.splice(ref)))
+      }
+
+    Expr.quote {
+      Data.map(
+        "summed" -> Data(Expr.splice(summed))
+      )
+    }
+  }
+
   // ValDefBuilder methods
 
   def testValDefBuilderCreateAndUse: Expr[Data] = {

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -577,6 +577,14 @@ final class ExprsSpec extends MacroSuite {
 
         testValDefsDirectStyleAndClose[Seq[Int], List[Int]](List(1, 2, 3)) ==> List(1, 2, 3)
       }
+
+      test("ValDefs.map2 should evaluate its by-name argument exactly once (no double-created definitions)") {
+        import ExprsFixtures.testValDefsMap2DoesNotDoubleCreate
+
+        testValDefsMap2DoesNotDoubleCreate ==> Data.map(
+          "summed" -> Data(10 + 20 + 30)
+        )
+      }
     }
 
     group("type ValDefBuilder") {

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -1389,8 +1389,13 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
 
       override def pure[A](a: A): ValDefs[A] = new ValDefs[A](Vector.empty, a)
 
-      override def map2[A, B, C](fa: ValDefs[A], fb: => ValDefs[B])(f: (A, B) => C): ValDefs[C] =
-        new ValDefs[C](fa.definitions ++ fb.definitions, f(fa.value, fb.value))
+      override def map2[A, B, C](fa: ValDefs[A], fb: => ValDefs[B])(f: (A, B) => C): ValDefs[C] = {
+        // fb is by-name, so we MUST evaluate it exactly once: forcing it twice (once for .definitions and
+        // once for .value) would materialize its definitions twice, e.g. create a fresh val/var/def twice
+        // and leave the .value referring to a definition that was discarded.
+        val fbValue = fb
+        new ValDefs[C](fa.definitions ++ fbValue.definitions, f(fa.value, fbValue.value))
+      }
 
       override def traverse[G[_]: fp.Applicative, A, B](fa: ValDefs[A])(f: A => G[B]): G[ValDefs[B]] =
         f(fa.value).map(b => new ValDefs[B](fa.definitions, b))

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -1661,8 +1661,13 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
 
       override def pure[A](a: A): ValDefs[A] = new ValDefs[A](Vector.empty, a)
 
-      override def map2[A, B, C](fa: ValDefs[A], fb: => ValDefs[B])(f: (A, B) => C): ValDefs[C] =
-        new ValDefs[C](fa.definitions ++ fb.definitions, f(fa.value, fb.value))
+      override def map2[A, B, C](fa: ValDefs[A], fb: => ValDefs[B])(f: (A, B) => C): ValDefs[C] = {
+        // fb is by-name, so we MUST evaluate it exactly once: forcing it twice (once for .definitions and
+        // once for .value) would materialize its definitions twice, e.g. create a fresh val/var/def twice
+        // and leave the .value referring to a definition that was discarded.
+        val fbValue = fb
+        new ValDefs[C](fa.definitions ++ fbValue.definitions, f(fa.value, fbValue.value))
+      }
 
       override def traverse[G[_]: fp.Applicative, A, B](fa: ValDefs[A])(f: A => G[B]): G[ValDefs[B]] =
         f(fa.value).map(b => new ValDefs[B](fa.definitions, b))


### PR DESCRIPTION
## Problem

`ValDefs`' `ApplicativeTraverse.map2` forced its by-name second argument **twice**:

```scala
override def map2[A, B, C](fa: ValDefs[A], fb: => ValDefs[B])(f: (A, B) => C): ValDefs[C] =
  new ValDefs[C](fa.definitions ++ fb.definitions, f(fa.value, fb.value))
//                              ^^ 1st eval             ^^ 2nd eval
```

Because `fb` is by-name, each access re-evaluates the thunk. When `fb` is a freshly created `createVal`/`createVar`/`createLazy`/`createDef`, each evaluation mints a **new unique symbol**, so:

- `fb.definitions` come from **evaluation #1** (emits `val x$1 = …`)
- `fb.value` (a `Ref`) comes from **evaluation #2** (points at `val x$2`, whose definition is discarded)

The generated code then references a `val` that was never emitted → a dangling reference (e.g. `not found: value x$macro$2`).

This surfaces through `traverse`/`sequence` over `ValDefs`: the `List`/`Vector` traverse instances call `bufferG.map2(f(a))(…)` with a freshly created `ValDefs` per element, so every element hit the double-evaluation. The one in-repo `map2` caller passed pre-bound `val`s, which re-read the same already-created object — which is why it stayed hidden.

## Fix

Force `fb` exactly once into a local `val`, on both Scala 2 (`ExprsScala2.scala`) and Scala 3 (`ExprsScala3.scala`).

## Scope check

Audited every `map2`/`parMap2` and by-name effect parameter in the codebase — the micro-fp instances (`Id`, `Option`, `Either`+`List`/`Vector`, `Try`, `List`, `Vector`, `NonEmptyList`, `NonEmptyVector`), `MIO` (including the fork/join `parMap2`), and `MEval` all reference their by-name argument once. The two `ValDefs` instances were the only affected spots.

## Tests

Added `testValDefsMap2DoesNotDoubleCreate` (fixtures + Scala 2/3 bridges + spec) exercising the `List(...).traverse(createVal) -> use` path. Verified it **fails** on the unpatched code (`not found: value x$macro$2`) and **passes** with the fix.

`sbt --client "hearth/clean ; hearth3/clean ; quick-clean ; quick-test"` is green on both Scala 2.13 and Scala 3 (`ExprsSpec` 117/117 on each), including the sandwich cross-compilation tests.