### PR TITLE
Fix 20 issues from the Chimney → Hearth migration (#306–#330) for 0.4.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -328,7 +328,19 @@ val mimaSettings = Seq(
   //
   // Example of an allowed exclusion (a member added to a NESTED trait/object that MiMa would otherwise flag):
   //   exclude[ReversedMissingMethodProblem]("hearth.typed.SomeTrait#SomeNestedTrait.newHelper")
-  mimaBinaryIssueFilters ++= Seq.empty[ProblemFilter]
+  mimaBinaryIssueFilters ++= Seq(
+    // #329: `lastMatchProvenance` provider-provenance state added to the NESTED trait `StdExtensions#ProvidedCompanion`.
+    // That trait is part of the MacroCommons cake and is implemented ONLY by Hearth's own std companion objects
+    // (IsCollection/IsOption/IsEither/IsValueType/CtorLikes), which live in the same trait - so the interface and its
+    // implementations are always evicted together and no user has a standalone implementation to break. The public
+    // accessor is a `final def`; these two are just the synthetic getter/setter of its `private var` backing field.
+    exclude[ReversedMissingMethodProblem](
+      "hearth.std.StdExtensions#ProvidedCompanion.hearth$std$StdExtensions$ProvidedCompanion$$lastMatchProvenanceValue"
+    ),
+    exclude[ReversedMissingMethodProblem](
+      "hearth.std.StdExtensions#ProvidedCompanion.hearth$std$StdExtensions$ProvidedCompanion$$lastMatchProvenanceValue_="
+    )
+  )
 )
 
 val noPublishSettings =

--- a/docs/user-guide/standard-extensions.md
+++ b/docs/user-guide/standard-extensions.md
@@ -1579,3 +1579,28 @@ Type[A] match {
       }
     }
     ```
+
+### Which provider matched — `lastMatchProvenance`
+
+Skip reasons name every provider that *declined* (`lastUnapplyFailure`), but a *successful* match historically told you nothing about **which** provider produced it. `lastMatchProvenance` closes that gap: after a successful `parse`/`unapply`, each of `IsCollection`, `IsOption`, `IsEither`, `IsValueType` and `IsMap` exposes an `Option[ProviderProvenance]` describing the matching provider:
+
+```scala
+Type[A] match {
+  case IsValueType(isValueType) =>
+    val origin = IsValueType.lastMatchProvenance
+    // origin.exists(_.isBuiltIn)         -> true for Hearth's own built-ins
+    // origin.map(_.providerName)         -> the provider's `name`
+    // origin.map(_.providerClassName)    -> the implementing class (built-ins live in `hearth.std.extensions`)
+    ...
+}
+```
+
+`ProviderProvenance.isBuiltIn` is `true` when the matching provider is one of Hearth's built-ins (they all live in the `hearth.std.extensions` package) and `false` for a third-party `StandardMacroExtension`. This lets a consumer apply different policies per origin (e.g. only honour extension-provided value types) without maintaining a hand-curated list of built-in types to exclude.
+
+### JDK baseline of emitted code
+
+Hearth itself requires **JDK 11+** to *run* (it constrains the compiler's runtime). Independently of that, the **built-in providers emit Java API calls into your generated code**, so the code they produce has its own minimum-JDK contract — your module must compile with a high enough `-release`/`--release` for the emitted calls to type-check.
+
+Currently the notable case is the Java **map** providers, whose generated code calls **`java.util.Map.entry(...)`**, which is **JDK 9+**. A consumer compiling a `java.util.Map`-target derivation with `-release 8` will get type-check failures pointing at the generated code rather than at the real cause.
+
+**Recommendation:** compile consuming modules with **`-release 11`** (or newer) when you rely on the Java-collection providers. This baseline may rise in future releases; such changes will be called out in the release notes.

--- a/hearth-tests/src/main/scala-2/hearth/crossquotes/Issue307ReproFixturesImpl.scala
+++ b/hearth-tests/src/main/scala-2/hearth/crossquotes/Issue307ReproFixturesImpl.scala
@@ -1,0 +1,33 @@
+package hearth.crossquotes
+
+import hearth.*
+
+// Regression for https://github.com/kubuszok/hearth/issues/307 (Scala 2 only).
+//
+// `Type.CtorN.UpperBounded.of` / `Bounded.of` with a NON-`Any` upper bound used to emit a `matchResult`
+// that cast the extracted argument to `Type[scala.Any]` before calling `.as_<:??<:[L, U]` — which requires
+// `U >: Any`, so any real upper bound (e.g. `Marker`) made the generated code fail to typecheck with
+// `type arguments do not conform ... [L, U >: Any]`.
+//
+// Like the #300 repro this is a Scala 2 codegen bug (quasiquotes are not hygienic / typed), hence the fixture
+// lives under `scala-2`. It exists purely to be compiled: each `Type.CtorN.*.of` below expands at compile
+// time, so if the generated code does not typecheck, compilation fails.
+private[crossquotes] trait Issue307ReproFixturesImpl { this: MacroCommons =>
+
+  private object Types {
+    val Upper1: Type.Ctor1.UpperBounded[Issue307.Marker, Issue307.F1] =
+      Type.Ctor1.UpperBounded.of[Issue307.Marker, Issue307.F1]
+    val Upper2: Type.Ctor2.UpperBounded[Issue307.Marker, Issue307.Marker, Issue307.F2] =
+      Type.Ctor2.UpperBounded.of[Issue307.Marker, Issue307.Marker, Issue307.F2]
+    val Bounded1: Type.Ctor1.Bounded[Issue307.SubMarker, Issue307.Marker, Issue307.G1] =
+      Type.Ctor1.Bounded.of[Issue307.SubMarker, Issue307.Marker, Issue307.G1]
+  }
+}
+
+private[crossquotes] object Issue307 {
+  sealed trait Marker
+  final class SubMarker extends Marker
+  trait F1[A <: Marker]
+  trait F2[A <: Marker, B <: Marker]
+  trait G1[A >: SubMarker <: Marker]
+}

--- a/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
@@ -95,6 +95,9 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
   def testAnnotationDestructuringImpl[A: c.WeakTypeTag]: c.Expr[Data] =
     testAnnotationDestructuring[A]
 
+  def testTypeAnnotationsImpl[A: c.WeakTypeTag]: c.Expr[Data] =
+    testTypeAnnotations[A]
+
   def testParameterAnnotationsImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
     testParameterAnnotations[A](methodName)
 
@@ -195,6 +198,9 @@ object MethodsFixtures {
 
   def testAnnotationDestructuring[A]: Data =
     macro MethodsFixtures.testAnnotationDestructuringImpl[A]
+
+  def testTypeAnnotations[A]: Data =
+    macro MethodsFixtures.testTypeAnnotationsImpl[A]
 
   def testParameterAnnotations[A](methodName: String): Data =
     macro MethodsFixtures.testParameterAnnotationsImpl[A]

--- a/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
@@ -186,6 +186,10 @@ object MethodsFixtures {
   private def testAnnotationDestructuringImpl[A: Type](using q: Quotes): Expr[Data] =
     new MethodsFixtures(q).testAnnotationDestructuring[A]
 
+  inline def testTypeAnnotations[A]: Data = ${ testTypeAnnotationsImpl[A] }
+  private def testTypeAnnotationsImpl[A: Type](using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testTypeAnnotations[A]
+
   inline def testParameterAnnotations[A](inline methodName: String): Data = ${
     testParameterAnnotationsImpl[A]('methodName)
   }

--- a/hearth-tests/src/main/scala/hearth/examples/methods.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/methods.scala
@@ -8,6 +8,13 @@ class ExampleAnnotation2(val value: Int) extends scala.annotation.StaticAnnotati
 class ParentAnnotation extends scala.annotation.StaticAnnotation
 class ChildAnnotation extends ParentAnnotation
 
+// Type-position annotations (`x: T @Ann`), for issue #306 - distinct from field annotations (`@Ann x: T`).
+case class WithTypeAnnotations(
+    name: String @ExampleAnnotation,
+    age: Int,
+    nickname: String @ExampleAnnotation2(42) @ExampleAnnotation
+)
+
 @ChildAnnotation
 class WithChildAnnotation {
 

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -842,6 +842,31 @@ trait MethodsFixturesImpl { this: MacroCommons =>
     Expr(Data.list((typeAnnotations ++ methodAnnotations)*))
   }
 
+  // Issue #306: type-position annotations (`name: String @ExampleAnnotation`). Renders each primary-constructor
+  // field's name to the annotations found on its TYPE (via `Type.typeAnnotations`), plus the annotations directly on A.
+  def testTypeAnnotations[A: Type]: Expr[Data] = {
+    def annNames(anns: List[Expr_??]): Data = Data.list(anns.map { ann =>
+      if (ann.Underlying =:= Type.of[hearth.examples.methods.ExampleAnnotation2]) Data("ExampleAnnotation2")
+      else if (ann.Underlying =:= Type.of[hearth.examples.methods.ExampleAnnotation]) Data("ExampleAnnotation")
+      else Data(ann.Underlying.plainPrint)
+    }*)
+
+    val fields = Type[A].primaryConstructor.toList.flatMap(_.totalParameters.flatten).map { case (paramName, param) =>
+      import param.tpe.Underlying as FieldTpe
+      Data.map(
+        "name" -> Data(paramName),
+        "typeAnnotations" -> annNames(Type.typeAnnotations[FieldTpe])
+      )
+    }
+
+    Expr(
+      Data.map(
+        "own" -> annNames(Type.typeAnnotations[A]),
+        "fields" -> Data.list(fields*)
+      )
+    )
+  }
+
   private def renderParameterAnnotations(parameters: Parameters): Data = {
     val rendered = parameters.flatten.map { case (paramName, param) =>
       val annotations = param.annotations.flatMap { ann =>

--- a/hearth-tests/src/test/scala-3/hearth/typed/TypesScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/TypesScala3Spec.scala
@@ -477,7 +477,9 @@ final class TypesScala3Spec extends MacroSuite {
             "Type.isJavaEnum" -> Data(false),
             "Type.isJavaEnumValue" -> Data(false),
             "Type.isEnumeration" -> Data(false),
-            "Type.isCase" -> Data(false),
+            // `EmptyTuple`'s value is a `case object`, whose `Case` flag lives on the term symbol - now detected (#311).
+            // The composite classifiers stay `false` because `isClass`/`isObject`/`isVal` are all `false` here.
+            "Type.isCase" -> Data(true),
             "Type.isObject" -> Data(false),
             "Type.isVal" -> Data(false),
             "Type.isCaseClass" -> Data(false),

--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -1153,10 +1153,9 @@ final class ExprsSpec extends MacroSuite {
             "decoded" -> Data("a")
           ),
           "Class" -> Data.map(
-            "encoded" -> Data(
-              if (LanguageVersion.byHearth.isScala2_13) "scala.Predef.classOf[scala.Int]"
-              else "scala.Predef.classOf[scala.Int]"
-            ),
+            // #321: emitted as a class LITERAL now (renders as plain `classOf[fqcn]`), identical on both platforms,
+            // so the encoding survives a downstream `c.untypecheck` + re-typecheck.
+            "encoded" -> Data("classOf[scala.Int]"),
             "decoded" -> Data("int")
           ),
           "ClassTag" -> Data.map(

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -2535,6 +2535,22 @@ final class MethodsSpec extends MacroSuite {
       val args = annOnMethod.get.asMap.get("destructuredArgs").asString.get
       assert(args == "", s"no-arg annotation should destructure to empty args, got: '$args'")
     }
+
+    test("type-position annotations on case-class field types are exposed (#306)") {
+      import MethodsFixtures.testTypeAnnotations
+
+      testTypeAnnotations[examples.methods.WithTypeAnnotations] <==> Data.map(
+        "own" -> Data.list(),
+        "fields" -> Data.list(
+          Data.map("name" -> Data("name"), "typeAnnotations" -> Data.list(Data("ExampleAnnotation"))),
+          Data.map("name" -> Data("age"), "typeAnnotations" -> Data.list()),
+          Data.map(
+            "name" -> Data("nickname"),
+            "typeAnnotations" -> Data.list(Data("ExampleAnnotation"), Data("ExampleAnnotation2"))
+          )
+        )
+      )
+    }
   }
 
   group("methods: parameter annotations") {

--- a/hearth-tests/src/test/scala/hearth/typed/TypesSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/TypesSpec.scala
@@ -933,7 +933,8 @@ final class TypesSpec extends MacroSuite {
         test("for built-in types") {
 
           testFlags[Unit] <==> Data.map(
-            "Type.isPrimitive" -> Data(false),
+            // scalac's `isPrimitiveValueClass` counts `Unit`, so for parity Hearth's `isPrimitive` does too (#310).
+            "Type.isPrimitive" -> Data(true),
             "Type.isArray" -> Data(false),
             "Type.isIArray" -> Data(false),
             "Type.isJvmBuiltIn" -> Data(true),

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -745,7 +745,10 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
 
     override def ClassExprCodec[A: Type]: ExprCodec[java.lang.Class[A]] = {
       implicit val liftable: Liftable[java.lang.Class[A]] = Liftable[java.lang.Class[A]] { _ =>
-        q"scala.Predef.classOf[${Type[A]}]"
+        // Emit a real class LITERAL (`Literal(Constant(tpe))`, which scalac renders as `classOf[fqcn]`) rather than a
+        // `classOf[${Type[A]}]` quasiquote: the type splice produced a path-dependent reference into the provider's
+        // `parse` method that did not survive a downstream `c.untypecheck` + re-typecheck. See issue #321.
+        Literal(Constant(UntypedType.fromTyped[A]))
       }
       implicit val unliftable: Unliftable[java.lang.Class[A]] = new Unliftable[java.lang.Class[A]] {
         def unapply(tree: Tree): Option[java.lang.Class[A]] = Type[A].getRuntimeClass
@@ -1383,7 +1386,11 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
     override def closeScope[A](scoped: ValDefs[Expr[A]]): Expr[A] =
       if (scoped.definitions.isEmpty) scoped.value
       else
-        c.Expr[A](q"..${scoped.definitions}; ${scoped.value}")
+        // The block tree is quasiquote-built and therefore untyped, so a bare `c.Expr[A](block)` would materialize an
+        // UNRESOLVED `WeakTypeTag[A]` (literally the abstract type parameter `A`), corrupting every `Expr.typeOf` on the
+        // result. `closeScope` has no `Type[A]` bound (adding one would break binary compatibility), but `scoped.value`
+        // already carries the caller's real type - so we re-tag with it. See issue #308.
+        c.Expr[A](q"..${scoped.definitions}; ${scoped.value}")(Expr.typeOf(scoped.value))
 
     override val traverse: fp.ApplicativeTraverse[ValDefs] = new fp.ApplicativeTraverse[ValDefs] {
 

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
@@ -281,7 +281,13 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
 
     override def isConstructor: Boolean = symbol.isConstructor
 
-    override def isVal: Boolean = symbol.isVal || accessedOf(symbol).exists(_.isVal) || isLazy
+    // A stable deferred accessor (e.g. the `value` member of a structural refinement `{ val value: String }`) is a
+    // method symbol with no accessed field and `symbol.isVal == false`, yet scalac's `MethodSymbol.isStable` is the
+    // authoritative "this reads like a val" signal - without it such accessors are misclassified as plain methods.
+    // See issue #326.
+    override def isVal: Boolean =
+      symbol.isVal || accessedOf(symbol).exists(_.isVal) || isLazy ||
+        (symbol.isMethod && symbol.asMethod.isStable && !symbol.isConstructor)
     override def isVar: Boolean = symbol.isVar || accessedOf(symbol).exists(_.isVar)
     override def isLazy: Boolean = symbol.isLazy || accessedOf(symbol).exists(_.isLazy)
     override def isDef: Boolean = !isVal && (!isVar || name.endsWith("_=")) // var's setter should both var AND def

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
@@ -446,7 +446,10 @@ trait UntypedTypesScala2 extends UntypedTypes { this: MacroCommonsScala2 =>
           if companionClass != NoSymbol && companionClass.isType
         } yield (subtypeTypeOf(untyped, companionClass.asType), q"$companion")
 
-    override def directChildren(instanceTpe: UntypedType): Option[ListMap[String, UntypedType]] = {
+    override def directChildren(instanceTpe: UntypedType): Option[ListMap[String, UntypedType]] =
+      directChildrenList(instanceTpe).map(ListMap.from)
+
+    override def directChildrenList(instanceTpe: UntypedType): Option[List[(String, UntypedType)]] = {
       val A = instanceTpe.typeSymbol
 
       if (isEnumeration(instanceTpe)) {
@@ -493,16 +496,15 @@ trait UntypedTypesScala2 extends UntypedTypes { this: MacroCommonsScala2 =>
               }
 
             if (children.isEmpty) None
-            else Some(ListMap.from(children))
+            else Some(children.toList)
           }
         }
       } else if (isJavaEnum(instanceTpe)) {
         Some(
-          ListMap.from(
-            instanceTpe.companion.decls
-              .filter(_.isJavaEnum)
-              .map(termSymbol => termSymbol.name.toString -> termSymbol.asTerm.typeSignature)
-          )
+          instanceTpe.companion.decls
+            .filter(_.isJavaEnum)
+            .map(termSymbol => termSymbol.name.toString -> termSymbol.asTerm.typeSignature)
+            .toList
         )
       } else if (isJavaEnumValue(instanceTpe)) {
         None
@@ -514,12 +516,11 @@ trait UntypedTypesScala2 extends UntypedTypes { this: MacroCommonsScala2 =>
           else Vector(t)
 
         Some(
-          ListMap.from(
-            // calling .distinct here as `knownDirectSubclasses` returns duplicates for multiply-inherited types
-            extractRecursively(A.asType).distinct
-              .sorted(symbolOrdering)
-              .map(subtypeSymbol => subtypeName(subtypeSymbol) -> subtypeTypeOf(instanceTpe, subtypeSymbol))
-          )
+          // calling .distinct here as `knownDirectSubclasses` returns duplicates for multiply-inherited types
+          extractRecursively(A.asType).distinct
+            .sorted(symbolOrdering)
+            .map(subtypeSymbol => subtypeName(subtypeSymbol) -> subtypeTypeOf(instanceTpe, subtypeSymbol))
+            .toList
         )
       } else None
     }
@@ -543,5 +544,20 @@ trait UntypedTypesScala2 extends UntypedTypes { this: MacroCommonsScala2 =>
       untyped.typeSymbol.annotations.map(ann => c.untypecheck(ann.tree))
     override def annotationTypes(untyped: UntypedType): List[UntypedType] =
       untyped.typeSymbol.annotations.map(_.tree.tpe)
+
+    // Type-position annotations live on `AnnotatedType(annotations, underlying)` wrappers (`X @Ann`), not on the type
+    // symbol; stacked annotations nest, so we walk them all. Dealias so alias forms (`type Y = X @Ann`) are seen
+    // through. See issue #306.
+    private def annotatedTypeAnnotations(untyped: UntypedType): List[c.universe.Annotation] = {
+      def loop(tpe: c.Type): List[c.universe.Annotation] = tpe.dealias match {
+        case AnnotatedType(annots, underlying) => annots ++ loop(underlying)
+        case _                                 => Nil
+      }
+      loop(untyped)
+    }
+    override def typeAnnotations(untyped: UntypedType): List[UntypedExpr] =
+      annotatedTypeAnnotations(untyped).map(ann => c.untypecheck(ann.tree))
+    override def typeAnnotationTypes(untyped: UntypedType): List[UntypedType] =
+      annotatedTypeAnnotations(untyped).map(_.tree.tpe)
   }
 }

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -967,6 +967,12 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
     // with more cases).
 
     override def ClassExprCodec[A: Type]: ExprCodec[java.lang.Class[A]] = {
+      // Emit a proper class LITERAL (`Literal(ClassOfConstant(tpe))`, rendered as `classOf[fqcn]`) so the encoding
+      // survives a downstream re-typecheck and matches Scala 2's `Literal(Constant(tpe))`. See issue #321.
+      given ToExpr[java.lang.Class[A]] = new {
+        override def apply(value: java.lang.Class[A])(using scala.quoted.Quotes): Expr[java.lang.Class[A]] =
+          Literal(ClassOfConstant(TypeRepr.of[A])).asExprOf[java.lang.Class[A]]
+      }
       given FromExpr[java.lang.Class[A]] = new {
         override def unapply(expr: Expr[java.lang.Class[A]])(using scala.quoted.Quotes): Option[java.lang.Class[A]] = {
           def matchTerm(tree: Tree): Option[java.lang.Class[A]] = tree match {

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -615,24 +615,38 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
       val orderedArgs = fieldNames.map { fname =>
         arguments.getOrElse(fname, hearthRequirementFailed(s"Missing argument for field '$fname'"))
       }
-      // Get the underlying tuple type (second type arg of NamedTuple[Names, Values])
-      val underlyingTupleTpe = instanceTpe match {
-        case AppliedType(_, List(_, valuesTpe)) => valuesTpe
-        case _ => hearthAssertionFailed(s"Expected NamedTuple AppliedType, got ${instanceTpe.show}")
-      }
-      // Construct the underlying tuple via its constructor: new TupleN(arg1, arg2, ...)
-      type Underlying
-      given scala.quoted.Type[Underlying] = underlyingTupleTpe.asType.asInstanceOf[scala.quoted.Type[Underlying]]
-      val tupleCtor = underlyingTupleTpe.typeSymbol.primaryConstructor
-      val select = New(TypeTree.of[Underlying]).select(tupleCtor)
-      val applied =
-        if underlyingTupleTpe.typeArgs.nonEmpty then select.appliedToTypes(underlyingTupleTpe.typeArgs)
-        else select
-      val tupleExpr = applied.appliedToArgss(List(orderedArgs))
-      // Type-ascribe the tuple to the NamedTuple type: (tupleExpr : NamedTupleType)
       type NT
       given scala.quoted.Type[NT] = instanceTpe.asType.asInstanceOf[scala.quoted.Type[NT]]
-      Typed(tupleExpr, TypeTree.of[NT])
+      // A NamedTuple is represented at runtime by its underlying value tuple, so casting the tuple to the named-tuple
+      // type is sound. We use a cast (rather than a type ascription) for the EmptyTuple/TupleXXL shapes because they
+      // are not statically seen as subtypes of the (opaque) NamedTuple type.
+      def castToNamedTuple(expr: scala.quoted.Expr[Any]): UntypedExpr = '{ $expr.asInstanceOf[NT] }.asTerm
+
+      orderedArgs.length match {
+        case 0 =>
+          // Empty named tuple (e.g. NamedTuple.Empty) -> EmptyTuple. See issue #313.
+          castToNamedTuple('{ scala.EmptyTuple })
+        case n if n < 23 =>
+          // Construct the underlying tuple via its constructor: new TupleN(arg1, arg2, ...)
+          val underlyingTupleTpe = instanceTpe.dealias match {
+            case AppliedType(_, List(_, valuesTpe)) => valuesTpe
+            case _ => hearthAssertionFailed(s"Expected NamedTuple AppliedType, got ${instanceTpe.show}")
+          }
+          type Underlying
+          given scala.quoted.Type[Underlying] = underlyingTupleTpe.asType.asInstanceOf[scala.quoted.Type[Underlying]]
+          val tupleCtor = underlyingTupleTpe.typeSymbol.primaryConstructor
+          val select = New(TypeTree.of[Underlying]).select(tupleCtor)
+          val applied =
+            if underlyingTupleTpe.typeArgs.nonEmpty then select.appliedToTypes(underlyingTupleTpe.typeArgs)
+            else select
+          // Type-ascribe the tuple to the NamedTuple type: (tupleExpr : NamedTupleType)
+          Typed(applied.appliedToArgss(List(orderedArgs)), TypeTree.of[NT])
+        case _ =>
+          // TupleXXL (arity >= 23) has no public N-ary constructor - build the runtime tuple via Tuple.fromArray,
+          // boxing each element to Object. See issue #314.
+          val boxed = orderedArgs.map(arg => '{ ${ arg.asExpr }.asInstanceOf[Object] })
+          castToNamedTuple('{ scala.Tuple.fromArray(scala.Array[Object](${ scala.quoted.Varargs(boxed) }*)) })
+      }
     }
 
     override lazy val name: String = "<init>"
@@ -693,11 +707,13 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
         name
       }
 
-    instanceTpe match {
-      case AppliedType(_, List(namesTpe, valuesTpe)) if UntypedType.isNamedTuple(instanceTpe) =>
+    // Dealias so that alias forms such as `scala.NamedTuple.Empty` (= `NamedTuple[EmptyTuple, EmptyTuple]`) are
+    // recognized. The empty named tuple has zero fields, so we must allow `names.length == 0`. See issue #313.
+    instanceTpe.dealias match {
+      case applied @ AppliedType(_, List(namesTpe, valuesTpe)) if UntypedType.isNamedTuple(applied) =>
         val names = extractStringLiterals(namesTpe)
         val types = extractTupleElements(valuesTpe)
-        if names.nonEmpty && names.length == types.length then Some((names, types))
+        if names.length == types.length then Some((names, types))
         else None
       case _ => None
     }
@@ -806,7 +822,10 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
       namedTupleComponents(instanceTpe) match {
         case Some((names, types)) => Some(new SyntheticNamedTupleConstructor(names, types))
         case None                 =>
-          Option(instanceTpe.typeSymbol.primaryConstructor)
+          // Dealias so that an `export`-created alias (`export Inner.Foo`) resolves to the underlying class symbol -
+          // otherwise `typeSymbol` is the alias and reports no constructors. Scala 2's `typeSymbol` auto-dealiases.
+          // See issue #315.
+          Option(instanceTpe.dealias.typeSymbol.primaryConstructor)
             .filterNot(_.isNoSymbol)
             .flatMap(
               UntypedMethod
@@ -823,7 +842,7 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
       namedTupleComponents(instanceTpe) match {
         case Some((names, types)) => List(new SyntheticNamedTupleConstructor(names, types))
         case None                 =>
-          instanceTpe.typeSymbol.declarations
+          instanceTpe.dealias.typeSymbol.declarations // dealias for `export`-created aliases, see issue #315
             .filterNot(_.isNoSymbol)
             .filter(_.isClassConstructor)
             .flatMap(
@@ -839,8 +858,23 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
       }
     override def methods(instanceTpe: UntypedType): List[UntypedMethod] = {
       val symbol = instanceTpe.typeSymbol
+      // `fieldMembers` only returns the type's OWN fields, so `val` fields inherited from parent CLASSES (e.g. the
+      // constructor vals of an abstract parent) are neither methods nor own fields and would vanish entirely. Walk the
+      // base classes and pick up their public, non-synthetic fields, deduplicating by name (closest class wins, since
+      // `baseClasses` is ordered subclass-first) and never shadowing an own member. Scala 2's `.members` already sees
+      // them. See issue #327. `UntypedType.baseClasses` is used explicitly to avoid the extension-shadowing footgun.
+      val ownMembers = symbol.methodMembers ++ symbol.fieldMembers
+      val seenNames = scala.collection.mutable.Set.from(ownMembers.iterator.map(_.name))
+      val inheritedFields = UntypedType
+        .baseClasses(instanceTpe)
+        .iterator
+        .flatMap(_.typeSymbol.fieldMembers)
+        .filter(f =>
+          !f.isNoSymbol && !f.flags.is(Flags.Private) && !f.flags.is(Flags.Synthetic) && seenNames.add(f.name)
+        )
+        .toList
       // Defined in the type or its parent, or synthetic
-      val classMembers = symbol.methodMembers ++ symbol.fieldMembers
+      val classMembers = ownMembers ++ inheritedFields
       // Defined exatcly in the type
       val classDeclared = symbol.declaredMethods.toSet ++ symbol.declaredFields.toSet ++ declaredByJvmOrScala(symbol)
 

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -330,8 +330,11 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
     }
 
     override def isCase(instanceTpe: UntypedType): Boolean = {
-      val A = instanceTpe.typeSymbol
-      !A.isNoSymbol && A.flags.is(Flags.Case)
+      // Parameterless Scala 3 enum cases (`enum Foo { case A }`) present their singleton with the enum CLASS as the
+      // type symbol (no Case flag) while the `Case|Enum|StableRealizable` flags live on the TERM symbol - so we have to
+      // inspect both, mirroring `isVal`. See issue #311.
+      def hasCase(sym: Symbol): Boolean = !sym.isNoSymbol && sym.flags.is(Flags.Case)
+      hasCase(instanceTpe.typeSymbol) || hasCase(instanceTpe.termSymbol)
     }
     override def isObject(instanceTpe: UntypedType): Boolean = {
       val A = instanceTpe.typeSymbol
@@ -689,6 +692,9 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
       }
 
     override def directChildren(instanceTpe: UntypedType): Option[ListMap[String, UntypedType]] =
+      directChildrenList(instanceTpe).map(ListMap.from)
+
+    override def directChildrenList(instanceTpe: UntypedType): Option[List[(String, UntypedType)]] =
       if isEnumeration(instanceTpe) then {
         // Determine if we have the object type or the Value type
         val enumObjectTypeOpt: Option[UntypedType] = if instanceTpe.typeSymbol.flags.is(Flags.Module) then {
@@ -744,23 +750,21 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
               }
 
             if children.isEmpty then None
-            else Some(ListMap.from(children))
+            else Some(children.toList)
           }
         }
-      } else if isSealed(instanceTpe) || isJavaEnum(instanceTpe) then Some(
-        ListMap.from {
-          def handleSymbols(sym: Symbol): Symbol =
-            if sym.flags.is(Flags.Enum) then sym.typeRef.typeSymbol
-            else if sym.flags.is(Flags.Module) then sym.typeRef.typeSymbol.moduleClass
-            else sym
+      } else if isSealed(instanceTpe) || isJavaEnum(instanceTpe) then Some {
+        def handleSymbols(sym: Symbol): Symbol =
+          if sym.flags.is(Flags.Enum) then sym.typeRef.typeSymbol
+          else if sym.flags.is(Flags.Module) then sym.typeRef.typeSymbol.moduleClass
+          else sym
 
-          // calling .distinct here as `children` returns duplicates for multiply-inherited types
-          instanceTpe.typeSymbol.children
-            .map(handleSymbols)
-            .sorted
-            .map(subtypeSymbol => subtypeName(subtypeSymbol) -> subtypeTypeOf(instanceTpe, subtypeSymbol))
-        }
-      )
+        // calling .distinct here as `children` returns duplicates for multiply-inherited types
+        instanceTpe.typeSymbol.children
+          .map(handleSymbols)
+          .sorted
+          .map(subtypeSymbol => subtypeName(subtypeSymbol) -> subtypeTypeOf(instanceTpe, subtypeSymbol))
+      }
       else if isUnionType(instanceTpe) then unionMemberDispatch(instanceTpe).flatMap { dispatch =>
         // Members that cannot be soundly discriminated by a runtime class test are acceptable only when
         // the user provides an implicit scala.reflect.TypeTest[Union, Member] (a total runtime
@@ -769,9 +773,9 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
           case (member, UnionMemberDispatch.ByTypeTest) => userProvidedUnionTypeTestExists(instanceTpe, member)
           case _                                        => true
         }
-        if allMembersDiscriminable then Some(ListMap.from(dispatch.map { case (tpe, _) =>
+        if allMembersDiscriminable then Some(dispatch.map { case (tpe, _) =>
           UntypedType.plainPrint(tpe) -> tpe
-        }))
+        }.toList)
         else None
       }
       else None
@@ -970,7 +974,11 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
       untyped.typeArgs
 
     override def applyTypeArgs(untyped: UntypedType, args: List[UntypedType]): UntypedType =
-      untyped.appliedTo(args)
+      // Apply to the (dealiased) type CONSTRUCTOR rather than the type as-given, so that re-applying an
+      // already-applied type (e.g. a wildcard example `F[Any, ?]`) replaces its arguments instead of silently
+      // producing a malformed `F[Any, ?][Int, String]`. This matches Scala 2's `appliedType(typeConstructor, args)`.
+      // See issue #312.
+      typeConstructor(untyped).appliedTo(args)
 
     override def sameTypeConstructorAs(a: UntypedType, b: UntypedType): Boolean =
       typeConstructor(a).typeSymbol == typeConstructor(b).typeSymbol
@@ -979,5 +987,25 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
       untyped.typeSymbol.annotations.map(repositionAnnotation)
     override def annotationTypes(untyped: UntypedType): List[UntypedType] =
       untyped.typeSymbol.annotations.map(_.tpe)
+
+    // Type-position annotations live on `AnnotatedType(underlying, annot)` wrappers (`X @Ann`), not on the type symbol;
+    // stacked annotations nest (`X @A @B` => `AnnotatedType(AnnotatedType(X, @A), @B)`), so we walk them all. Dealias so
+    // alias forms (`type Y = X @Ann`) are seen through. See issue #306.
+    private def annotatedTypeTerms(untyped: UntypedType): List[Term] = {
+      // Match `AnnotatedType` BEFORE dealiasing: on Scala 3 `AnnotatedType(X, @Ann).dealias` strips the annotation.
+      // Dealias only to see through a plain alias to an annotated type (`type Y = X @Ann`); the `d != tpe` guard stops
+      // recursion at a fixpoint.
+      def loop(tpe: TypeRepr): List[Term] = tpe match {
+        case AnnotatedType(underlying, annot) => annot :: loop(underlying)
+        case _                                =>
+          val d = tpe.dealias
+          if d != tpe then loop(d) else Nil
+      }
+      loop(untyped)
+    }
+    override def typeAnnotations(untyped: UntypedType): List[UntypedExpr] =
+      annotatedTypeTerms(untyped).map(repositionAnnotation)
+    override def typeAnnotationTypes(untyped: UntypedType): List[UntypedType] =
+      annotatedTypeTerms(untyped).map(_.tpe)
   }
 }

--- a/hearth/src/main/scala/hearth/Environments.scala
+++ b/hearth/src/main/scala/hearth/Environments.scala
@@ -335,7 +335,7 @@ trait Environments extends EnvironmentCrossQuotesSupport { env: MacroCommons =>
     }
 
     final private def loadMacroExtensionsFrom[Extension <: MacroExtension[?]](
-        extensions: Either[Throwable, Vector[Extension]]
+        extensions: Either[Throwable, platformSpecificServiceLoader.Loaded[Extension]]
     ): ExtensionLoadingResult[Extension] = {
       // Allow aggregating errors from each extension loading.
       // Extensions that were already applied in this macro expansion are skipped to avoid duplicate side effects
@@ -367,8 +367,17 @@ trait Environments extends EnvironmentCrossQuotesSupport { env: MacroCommons =>
           }
 
       extensions match {
-        case Right(extensions) =>
-          val sorted = extensions.sortBy(_.priority)(Ordering[Int].reverse)
+        // No provider could even be instantiated (e.g. every candidate threw, or the only service jar has a
+        // forward-incompatible TASTy file): preserve the historical `LoaderFailed` shape so the cause stays visible.
+        case Right(loaded) if loaded.services.isEmpty && loaded.failures.nonEmpty =>
+          ExtensionLoadingResult.LoaderFailed(loaded.failures.head._2)
+        case Right(loaded) =>
+          // A subset of providers could not be instantiated (e.g. one unloadable extension jar sitting next to
+          // Hearth's own built-in providers). The loader skipped just those rather than aborting the whole run, so the
+          // built-ins and the other extensions still load instead of poisoning EVERY derivation in the module. We do
+          // NOT `reportInfo`/`reportWarn` the skipped providers here: a macro may emit only one such message, and
+          // spending it inside shared loading machinery would steal it from the user's own macro. See issue #325.
+          val sorted = loaded.services.sortBy(_.priority)(Ordering[Int].reverse)
           val (failure, success) = sorted.partitionMap(safeLoadExtension)
           val loadedExtensions = ListSet.from(success)
           NonEmptyMap.fromListMap(ListMap.from(failure)) match {

--- a/hearth/src/main/scala/hearth/loader.scala
+++ b/hearth/src/main/scala/hearth/loader.scala
@@ -13,6 +13,16 @@ import scala.util.Try
   */
 private[hearth] object platformSpecificServiceLoader extends platformSpecificServiceLoaderCompat {
 
+  /** Result of a ServiceLoader run that survived individual provider failures.
+    *
+    * @param services
+    *   the providers that loaded successfully
+    * @param failures
+    *   the providers that failed to load, paired with the cause (fully-qualified class name where known); a non-empty
+    *   `failures` means one or more service jars were skipped rather than aborting the whole load. See issue #325.
+    */
+  final case class Loaded[+T](services: Vector[T], failures: Vector[(String, Throwable)])
+
   /** Loads all services from the given class loader.
     *
     * @since 0.1.0
@@ -24,7 +34,7 @@ private[hearth] object platformSpecificServiceLoader extends platformSpecificSer
     * @return
     *   the loaded services or the first error encountered
     */
-  def load[T](clazz: Class[T], classLoader: ClassLoader): Either[Throwable, Vector[T]] =
+  def load[T](clazz: Class[T], classLoader: ClassLoader): Either[Throwable, Loaded[T]] =
     loadWhen(clazz, classLoader)(_ => true)
 
   /** Loads services from the given class loader, excluding services with names matching the given excluded names.
@@ -40,7 +50,7 @@ private[hearth] object platformSpecificServiceLoader extends platformSpecificSer
     * @return
     *   the loaded services or the first error encountered
     */
-  def loadExcluding[T](clazz: Class[T], classLoader: ClassLoader)(excluded: String*): Either[Throwable, Vector[T]] = {
+  def loadExcluding[T](clazz: Class[T], classLoader: ClassLoader)(excluded: String*): Either[Throwable, Loaded[T]] = {
     val excludedSet = excluded.toSet
     loadWhen(clazz, classLoader)(clazz => !excludedSet.contains(clazz.getName))
   }
@@ -60,22 +70,36 @@ private[hearth] object platformSpecificServiceLoader extends platformSpecificSer
     */
   def loadWhen[T](clazz: Class[T], classLoader: ClassLoader)(
       condition: Class[?] => Boolean
-  ): Either[Throwable, Vector[T]] =
-    getServiceLoader(clazz, classLoader).flatMap { loader =>
+  ): Either[Throwable, Loaded[T]] =
+    getServiceLoader(clazz, classLoader).map { loader =>
       val stream = loader.stream().toScala(Iterable).iterator
 
-      def loop(acc: Vector[T]): Tried[Vector[T]] =
-        if (stream.hasNext) {
-          val provider = stream.next()
-          if (condition(provider.`type`)) {
-            getService(classLoader, provider) match {
-              case Right(service) => loop(acc :+ service)
-              case Left(error)    => Left(error)
+      // A single unloadable provider (e.g. a service jar with a forward-incompatible TASTy version) must NOT abort the
+      // whole ServiceLoader iteration - that would poison EVERY derivation in the module, including ones that never use
+      // that extension and Hearth's own built-in providers. Instead we skip the failing provider, remember the failure
+      // so it can be reported, and keep loading the rest. Each step is guarded, because the failure can surface either
+      // while advancing the (lazy) iterator, while resolving the provider's class, or while instantiating it. See #325.
+      def loop(acc: Vector[T], failures: Vector[(String, Throwable)]): Loaded[T] =
+        Tried(stream.hasNext) match {
+          case Left(error)  => Loaded(acc, failures :+ ("<unknown provider>" -> error))
+          case Right(false) => Loaded(acc, failures)
+          case Right(true)  =>
+            Tried(stream.next()) match {
+              case Left(error)     => Loaded(acc, failures :+ ("<unknown provider>" -> error))
+              case Right(provider) =>
+                Tried(provider.`type`) match {
+                  case Left(error) => loop(acc, failures :+ ("<unknown provider>" -> error))
+                  case Right(providerType) if !condition(providerType) => loop(acc, failures)
+                  case Right(providerType)                             =>
+                    getService(classLoader, provider) match {
+                      case Right(service) => loop(acc :+ service, failures)
+                      case Left(error)    => loop(acc, failures :+ (providerType.getName -> error))
+                    }
+                }
             }
-          } else loop(acc)
-        } else Right(acc)
+        }
 
-      loop(Vector.empty[T])
+      loop(Vector.empty[T], Vector.empty)
     }
 
   protected type Tried[A] = Either[Throwable, A]

--- a/hearth/src/main/scala/hearth/std/ProviderResult.scala
+++ b/hearth/src/main/scala/hearth/std/ProviderResult.scala
@@ -30,6 +30,23 @@ sealed trait ProviderResult[+A] extends Product with Serializable {
     case s: ProviderResult.Skipped     => s
   }
 }
+
+/** Provenance of the provider that produced a matched std result.
+  *
+  * Skip reasons already name the providers that declined, but a matched result historically carried no way to tell
+  * WHICH provider produced it - so callers could not distinguish a built-in from a specific `StandardMacroExtension`
+  * except by fragile type filters. This captures the matching provider's `name` and implementing class. See issue #329.
+  *
+  * @since 0.4.1
+  */
+final case class ProviderProvenance(providerName: String, providerClassName: String) {
+
+  /** Whether the matched provider is one of Hearth's built-ins (which all live in the `hearth.std.extensions` package),
+    * as opposed to a third-party `StandardMacroExtension` loaded from the classpath.
+    */
+  def isBuiltIn: Boolean = providerClassName.startsWith("hearth.std.extensions.")
+}
+
 object ProviderResult {
   final case class Matched[A](value: A) extends ProviderResult[A]
   final case class Skipped(reasons: NonEmptyMap[String, Either[Throwable, String]]) extends ProviderResult[Nothing]

--- a/hearth/src/main/scala/hearth/std/StdExtensions.scala
+++ b/hearth/src/main/scala/hearth/std/StdExtensions.scala
@@ -48,6 +48,54 @@ trait StdExtensions { this: MacroCommons =>
         lastUnapplyFailure = reasons
         None
     }
+
+    /** Whether `A` is a bottom type (`Nothing` or `Null`).
+      *
+      * Bottom types conform to EVERY type via `<:<`, so a provider that selects by `<:<` matches them and then crashes
+      * while eagerly building exprs it cannot build (e.g. upcasting `java.util.Optional[Nothing]` to `Null`). No
+      * provider can produce a value of a bottom type, so `parse` skips them up front rather than crashing. See #319.
+      */
+    final protected def isBottomType[A: Type]: Boolean =
+      Type[A] <:< Type.of[Null] || Type[A] <:< Type.of[Nothing]
+    // A `def` (not a `val`): a new trait `val`/`var` adds an abstract accessor to the compiled interface, breaking
+    // binary compatibility; a `final def` compiles to a provided default method and does not. See issue #319.
+    final protected def bottomTypeSkipReason: String =
+      "bottom types (Nothing/Null) conform to every type but no provider can build a value of them"
+
+    // Backing field is `private` so it stays out of the compiled interface (see the note above); the public accessor is
+    // a `final def`. Read-only is also better API - callers should only inspect the provenance, not set it.
+    private var lastMatchProvenanceValue: Option[ProviderProvenance] = None
+
+    /** Provenance of the provider that produced the most recent successful match through [[parse]]/[[unapply]], or
+      * `None` when the last call did not match. Populated by [[firstMatch]] (and thus by every companion whose `parse`
+      * delegates to it). Lets callers tell built-in results apart from specific extensions. See issue #329.
+      */
+    final def lastMatchProvenance: Option[ProviderProvenance] = lastMatchProvenanceValue
+
+    final protected def recordMatch(provider: Provider): Unit =
+      lastMatchProvenanceValue = Some(ProviderProvenance(provider.name, provider.getClass.getName))
+
+    /** Standard "first provider that matches wins, otherwise aggregate the skip reasons" loop, shared by the companions
+      * with that shape (IsCollection/IsOption/IsEither/IsValueType). Records [[lastMatchProvenance]] on a match (#329).
+      */
+    final protected def firstMatch[A: Type](companionName: String): ProviderResult[Provided[A]] = {
+      lastMatchProvenanceValue = None
+      var skippedReasons = ListMap.empty[String, Either[Throwable, String]]
+      val it = providers.iterator
+      while (it.hasNext) {
+        val provider = it.next()
+        provider.parse(Type[A]) match {
+          case matched: ProviderResult.Matched[Provided[A] @unchecked] =>
+            recordMatch(provider)
+            return matched
+          case ProviderResult.Skipped(reasons) => skippedReasons ++= reasons.iterator
+        }
+      }
+      NonEmptyMap.fromListMap(skippedReasons) match {
+        case Some(nem) => ProviderResult.Skipped(nem)
+        case None      => ProviderResult.skipped(companionName, "No providers registered")
+      }
+    }
   }
 
   /** Represents a possible smart constructor for the given input and output types.
@@ -175,7 +223,9 @@ trait StdExtensions { this: MacroCommons =>
   type CtorLikes[A] = NonEmptyList[CtorLike[A]]
   object CtorLikes extends ProvidedCompanion[CtorLikes] {
 
-    override def parse[A: Type]: ProviderResult[CtorLikes[A]] = {
+    override def parse[A: Type]: ProviderResult[CtorLikes[A]] = if (isBottomType[A])
+      ProviderResult.skipped("CtorLikes", bottomTypeSkipReason)
+    else {
       var matched: Option[CtorLikes[A]] = None
       var skippedReasons = ListMap.empty[String, Either[Throwable, String]]
       providers.foreach { provider =>
@@ -334,21 +384,9 @@ trait StdExtensions { this: MacroCommons =>
   type IsCollection[A] = Existential[IsCollectionOf[A, *]]
   object IsCollection extends ProvidedCompanion[IsCollection] {
 
-    override def parse[A: Type]: ProviderResult[IsCollection[A]] = {
-      var skippedReasons = ListMap.empty[String, Either[Throwable, String]]
-      val it = providers.iterator
-      while (it.hasNext) {
-        val provider = it.next()
-        provider.parse(Type[A]) match {
-          case matched: ProviderResult.Matched[IsCollection[A] @unchecked] => return matched
-          case ProviderResult.Skipped(reasons)                             => skippedReasons ++= reasons.iterator
-        }
-      }
-      NonEmptyMap.fromListMap(skippedReasons) match {
-        case Some(nem) => ProviderResult.Skipped(nem)
-        case None      => ProviderResult.skipped("IsCollection", "No providers registered")
-      }
-    }
+    override def parse[A: Type]: ProviderResult[IsCollection[A]] = if (isBottomType[A])
+      ProviderResult.skipped("IsCollection", bottomTypeSkipReason)
+    else firstMatch[A]("IsCollection")
   }
 
   /** Proof that the type is a map of the given key and value types.
@@ -396,6 +434,11 @@ trait StdExtensions { this: MacroCommons =>
   object IsMap {
 
     var lastUnapplyFailure: NonEmptyMap[String, Either[Throwable, String]] = _
+
+    /** Provenance of the provider behind the most recent successful match - mirrors
+      * [[IsCollection.lastMatchProvenance]] since `IsMap` decodes through the collection providers. See issue #329.
+      */
+    def lastMatchProvenance: Option[ProviderProvenance] = IsCollection.lastMatchProvenance
 
     def parse[A: Type]: ProviderResult[IsMap[A]] =
       IsCollection.parse[A] match {
@@ -455,21 +498,9 @@ trait StdExtensions { this: MacroCommons =>
   type IsOption[A] = Existential[IsOptionOf[A, *]]
   object IsOption extends ProvidedCompanion[IsOption] {
 
-    override def parse[A: Type]: ProviderResult[IsOption[A]] = {
-      var skippedReasons = ListMap.empty[String, Either[Throwable, String]]
-      val it = providers.iterator
-      while (it.hasNext) {
-        val provider = it.next()
-        provider.parse(Type[A]) match {
-          case matched: ProviderResult.Matched[IsOption[A] @unchecked] => return matched
-          case ProviderResult.Skipped(reasons)                         => skippedReasons ++= reasons.iterator
-        }
-      }
-      NonEmptyMap.fromListMap(skippedReasons) match {
-        case Some(nem) => ProviderResult.Skipped(nem)
-        case None      => ProviderResult.skipped("IsOption", "No providers registered")
-      }
-    }
+    override def parse[A: Type]: ProviderResult[IsOption[A]] = if (isBottomType[A])
+      ProviderResult.skipped("IsOption", bottomTypeSkipReason)
+    else firstMatch[A]("IsOption")
   }
 
   /** Proof that the type is an either of the given left and right types.
@@ -526,21 +557,9 @@ trait StdExtensions { this: MacroCommons =>
   }
   object IsEither extends ProvidedCompanion[IsEither] {
 
-    override def parse[A: Type]: ProviderResult[IsEither[A]] = {
-      var skippedReasons = ListMap.empty[String, Either[Throwable, String]]
-      val it = providers.iterator
-      while (it.hasNext) {
-        val provider = it.next()
-        provider.parse(Type[A]) match {
-          case matched: ProviderResult.Matched[IsEither[A] @unchecked] => return matched
-          case ProviderResult.Skipped(reasons)                         => skippedReasons ++= reasons.iterator
-        }
-      }
-      NonEmptyMap.fromListMap(skippedReasons) match {
-        case Some(nem) => ProviderResult.Skipped(nem)
-        case None      => ProviderResult.skipped("IsEither", "No providers registered")
-      }
-    }
+    override def parse[A: Type]: ProviderResult[IsEither[A]] = if (isBottomType[A])
+      ProviderResult.skipped("IsEither", bottomTypeSkipReason)
+    else firstMatch[A]("IsEither")
   }
 
   /** Proof that the type is a value type of the given inner type.
@@ -578,21 +597,9 @@ trait StdExtensions { this: MacroCommons =>
   type IsValueType[A] = Existential[IsValueTypeOf[A, *]]
   object IsValueType extends ProvidedCompanion[IsValueType] {
 
-    override def parse[A: Type]: ProviderResult[IsValueType[A]] = {
-      var skippedReasons = ListMap.empty[String, Either[Throwable, String]]
-      val it = providers.iterator
-      while (it.hasNext) {
-        val provider = it.next()
-        provider.parse(Type[A]) match {
-          case matched: ProviderResult.Matched[IsValueType[A] @unchecked] => return matched
-          case ProviderResult.Skipped(reasons)                            => skippedReasons ++= reasons.iterator
-        }
-      }
-      NonEmptyMap.fromListMap(skippedReasons) match {
-        case Some(nem) => ProviderResult.Skipped(nem)
-        case None      => ProviderResult.skipped("IsValueType", "No providers registered")
-      }
-    }
+    override def parse[A: Type]: ProviderResult[IsValueType[A]] = if (isBottomType[A])
+      ProviderResult.skipped("IsValueType", bottomTypeSkipReason)
+    else firstMatch[A]("IsValueType")
   }
 
   implicit final class EnvironmentStdExtensionsOps(private val environment: Environment.type) {

--- a/hearth/src/main/scala/hearth/typed/Types.scala
+++ b/hearth/src/main/scala/hearth/typed/Types.scala
@@ -132,6 +132,19 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
 
     final def directChildren[A: Type]: Option[ListMap[String, ??<:[A]]] =
       UntypedType.fromTyped[A].directChildren.map(m => ListMap.from(m.view.mapValues(_.asTyped[A].as_??<:[A])))
+
+    /** Like [[directChildren]], but returns an ordered `List` preserving duplicate simple names and extraction order,
+      * so same-named subtypes in different scopes are all observable (and their ambiguity detectable). See issue #309.
+      *
+      * @since 0.4.1
+      */
+    final def directChildrenList[A: Type]: Option[List[(String, ??<:[A])]] =
+      UntypedType
+        .fromTyped[A]
+        .directChildrenList
+        .map(_.map { case (name, subtype) =>
+          name -> subtype.asTyped[A].as_??<:[A]
+        })
     final def exhaustiveChildren[A: Type]: Option[NonEmptyMap[String, ??<:[A]]] =
       UntypedType.fromTyped[A].exhaustiveChildren.map(m => m.map { case (k, v) => (k, v.asTyped[A].as_??<:[A]) })
 
@@ -159,6 +172,28 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
       * @since 0.4.0
       */
     final def annotationsOfType[A: Type, Ann: Type]: List[Expr[Ann]] = Annotations.filterOfType[Ann](annotations[A])
+
+    /** Annotations in the TYPE POSITION of `A` - the `@Ann` in `X @Ann` (an `AnnotatedType`), as opposed to
+      * [[annotations]] which reads annotations on the type's SYMBOL. Typically used to inspect annotations placed AFTER
+      * the type of a case-class field (`name: String @Action("anonymize")`). Stacked annotations are all returned. See
+      * issue #306.
+      *
+      * @since 0.4.1
+      */
+    final def typeAnnotations[A: Type]: List[Expr_??] = {
+      val untyped = UntypedType.fromTyped[A]
+      untyped.typeAnnotations.zip(untyped.typeAnnotationTypes).map { case (expr, tpe) =>
+        UntypedExpr.as_??(expr, tpe)
+      }
+    }
+
+    /** Type-position annotations on `A` (see [[typeAnnotations]]) whose type is a subtype of `Ann`, each typed as
+      * `Expr[Ann]`. `<:<` matching (like [[annotationsOfType]]), so an annotation hierarchy can be matched by its base.
+      *
+      * @since 0.4.1
+      */
+    final def typeAnnotationsOfType[A: Type, Ann: Type]: List[Expr[Ann]] =
+      Annotations.filterOfType[Ann](typeAnnotations[A])
 
     /** Whether type `A` has at least one annotation whose type is a subtype of `Ann`.
       *
@@ -846,6 +881,8 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
 
     def annotations: List[Expr_??] = Type.annotations(using tpe)
     def annotationsOfType[Ann: Type]: List[Expr[Ann]] = Type.annotationsOfType[A, Ann](using tpe, Type[Ann])
+    def typeAnnotations: List[Expr_??] = Type.typeAnnotations(using tpe)
+    def typeAnnotationsOfType[Ann: Type]: List[Expr[Ann]] = Type.typeAnnotationsOfType[A, Ann](using tpe, Type[Ann])
     def hasAnnotationOfType[Ann: Type]: Boolean = Type.hasAnnotationOfType[A, Ann](using tpe, Type[Ann])
 
     def summonExpr: SummoningResult[A] = Expr.summonImplicit(using tpe)

--- a/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
@@ -97,7 +97,11 @@ trait UntypedTypes { this: MacroCommons =>
     protected def toClassJvmBuiltInExtra(untyped: UntypedType): Option[java.lang.Class[?]] = None
 
     final def isPrimitive(instanceTpe: UntypedType): Boolean =
-      Type.primitiveTypes.exists(tpe => instanceTpe <:< fromTyped(using tpe.Underlying))
+      // `Unit` is not in `primitiveTypes` (it does not box to `java.lang.Object` the way the 8 value types do), but
+      // scalac's `Symbol.isPrimitive`/`isPrimitiveValueClass` counts it, so for parity we count it here too. Otherwise
+      // a `!isPrimitive && isClass && !isAbstract` classifier treats `Unit` as an instantiable POJO. See issue #310.
+      Type.primitiveTypes.exists(tpe => instanceTpe <:< fromTyped(using tpe.Underlying)) ||
+        instanceTpe <:< fromTyped(using Type.of[Unit])
     final def isArray(instanceTpe: UntypedType): Boolean =
       ArrayCtor.unapply(toTyped[Any](instanceTpe)).isDefined
     def isIArray(instanceTpe: UntypedType): Boolean = false
@@ -216,6 +220,20 @@ trait UntypedTypes { this: MacroCommons =>
     def companionObject(untyped: UntypedType): Option[(UntypedType, UntypedExpr)]
 
     def directChildren(instanceTpe: UntypedType): Option[ListMap[String, UntypedType]]
+
+    /** Like [[directChildren]], but returns an ordered `List` instead of a `ListMap` keyed by simple name.
+      *
+      * [[directChildren]] keys by SIMPLE name, so same-named subtypes living in different scopes (e.g.
+      * `object Color { case object Green }` alongside a top-level `case object Green`) collapse into one entry and the
+      * ambiguity becomes undetectable. This list form preserves every subtype (duplicate simple names included) and
+      * their extraction order, so a caller can detect ambiguity and order/flatten as it sees fit. The extraction
+      * strategy otherwise mirrors [[directChildren]] (which on Scala 2 pre-flattens nested sealed hierarchies while
+      * Scala 3 returns direct children). See issue #309.
+      *
+      * @since 0.4.1
+      */
+    def directChildrenList(instanceTpe: UntypedType): Option[List[(String, UntypedType)]] =
+      directChildren(instanceTpe).map(_.toList)
     final def exhaustiveChildren(instanceTpe: UntypedType): Option[NonEmptyMap[String, UntypedType]] = {
       val isEnum = instanceTpe.isEnumeration
       directChildren(instanceTpe)
@@ -274,6 +292,17 @@ trait UntypedTypes { this: MacroCommons =>
 
     def annotations(untyped: UntypedType): List[UntypedExpr]
     def annotationTypes(untyped: UntypedType): List[UntypedType]
+
+    /** Annotations attached to the TYPE POSITION of the given type - the `@Ann` in `X @Ann`, represented by
+      * `AnnotatedType(X, @Ann)` on both Scala 2 and Scala 3. This is distinct from [[annotations]], which reads
+      * annotations declared on the type's SYMBOL (`@Ann class X` / `@Ann val x`). Stacked type annotations (`X @A @B`)
+      * are all returned, outermost first, and alias forms (`type Y = X @Ann`) are seen through. Returns `Nil` when the
+      * type carries no type-position annotations. See issue #306.
+      *
+      * @since 0.4.1
+      */
+    def typeAnnotations(untyped: UntypedType): List[UntypedExpr] = Nil
+    def typeAnnotationTypes(untyped: UntypedType): List[UntypedType] = Nil
 
     private lazy val ArrayCtor = Type.Ctor1.of[Array]
 
@@ -338,6 +367,17 @@ trait UntypedTypes { this: MacroCommons =>
     def parents: List[UntypedType] = UntypedType.parents(untyped)
     def baseClasses: List[UntypedType] = UntypedType.baseClasses(untyped)
 
+    /** Alias for [[baseClasses]] that does not collide with `quotes.reflect`'s `TypeRepr#baseClasses`.
+      *
+      * On Scala 3 `UntypedType` IS `quotes.reflect.TypeRepr`, so the [[baseClasses]] extension above shadows
+      * `TypeRepr#baseClasses` (which returns `List[Symbol]`) inside a `MacroCommonsScala3` cake - a footgun, since the
+      * two have different element types. Prefer this `baseClassTypes` name in mixed Hearth + `quotes.reflect` code; to
+      * reach the reflection one explicitly, call `quotes.reflect.TypeReprMethods.baseClasses(repr)`. See issue #328.
+      *
+      * @since 0.4.1
+      */
+    def baseClassTypes: List[UntypedType] = UntypedType.baseClasses(untyped)
+
     def <:<(other: UntypedType): Boolean = UntypedType.isSubtypeOf(untyped, other)
     def =:=(other: UntypedType): Boolean = UntypedType.isSameAs(untyped, other)
 
@@ -348,6 +388,7 @@ trait UntypedTypes { this: MacroCommons =>
     def companionObject: Option[(UntypedType, UntypedExpr)] = UntypedType.companionObject(untyped)
 
     def directChildren: Option[ListMap[String, UntypedType]] = UntypedType.directChildren(untyped)
+    def directChildrenList: Option[List[(String, UntypedType)]] = UntypedType.directChildrenList(untyped)
     def exhaustiveChildren: Option[NonEmptyMap[String, UntypedType]] = UntypedType.exhaustiveChildren(untyped)
 
     def defaultValue(param: UntypedParameter): Option[UntypedMethod] = UntypedMethod.defaultValue(untyped)(param)
@@ -358,5 +399,7 @@ trait UntypedTypes { this: MacroCommons =>
 
     def annotations: List[UntypedExpr] = UntypedType.annotations(untyped)
     def annotationTypes: List[UntypedType] = UntypedType.annotationTypes(untyped)
+    def typeAnnotations: List[UntypedExpr] = UntypedType.typeAnnotations(untyped)
+    def typeAnnotationTypes: List[UntypedType] = UntypedType.typeAnnotationTypes(untyped)
   }
 }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
@@ -49,6 +49,9 @@ final class IsCollectionProviderForJavaCollection extends StandardMacroExtension
       private lazy val juNavigableSet = Type.Ctor1.of[java.util.NavigableSet]
       private lazy val juTreeSet = Type.Ctor1.of[java.util.TreeSet]
       private lazy val juEnumType = Type.of[java.lang.Enum[?]]
+      // `EnumSet[Nothing]` is a well-formed application of the F-bounded `EnumSet[E <: Enum[E]]` (Nothing conforms to
+      // any bound), used only to compare type constructors symbolically - see `isEnumSet` below and issue #323.
+      private lazy val juEnumSetType = Type.of[java.util.EnumSet[Nothing]]
 
       private def isCollection[Coll0[I] <: java.util.Collection[I], Item: Type, A <: Coll0[Item]](
           A: Type[A],
@@ -167,67 +170,66 @@ final class IsCollectionProviderForJavaCollection extends StandardMacroExtension
                       leaf(juTreeSet, Expr.quote(new java.util.TreeSet[Item](Expr.splice(orderingExpr))))
                     })
                     .orElse {
-                      // EnumSet requires E <: Enum[E] bound which cannot be expressed as a Type.Ctor1.
-                      // We check for EnumSet by comparing the runtime class at macro time, and use
-                      // Type.classOfType + casts through Nothing to satisfy bounds in generated code.
+                      // EnumSet requires an `E <: Enum[E]` bound which cannot be expressed as a Type.Ctor1.
+                      // Detect it SYMBOLICALLY (same type constructor as `java.util.EnumSet`) rather than by a
+                      // macro-time `Class.forName` of the target: the runtime-class check returned nothing on Scala 3
+                      // (so EnumSet only matched via the Iterable fallback) and never matched enums from the current
+                      // compilation run. See issue #323.
                       if (Item <:< juEnumType) {
-                        val isEnumSet = Type.classOfType(using tpe).exists { c =>
-                          classOf[java.util.EnumSet[?]].isAssignableFrom(c)
-                        }
+                        val isEnumSet = UntypedType.fromTyped(using tpe).sameTypeConstructorAs(juEnumSetType.asUntyped)
                         if (isEnumSet) {
-                          Type.classOfType[Item].flatMap { enumClass =>
-                            val enumClassExpr: Expr[java.lang.Class[Item]] = {
-                              implicit val classCodec: ExprCodec[java.lang.Class[Item]] =
-                                Expr.ClassExprCodec[Item]
-                              Expr(enumClass)
-                            }
-                            Some(
-                              Existential[IsCollectionOf[A, *], Item](new IsCollectionOf[A, Item] {
-                                override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = Expr.quote {
-                                  scala.jdk.javaapi.CollectionConverters
-                                    .asScala(
-                                      Expr.splice(value).asInstanceOf[java.util.Set[Item]].iterator()
-                                    )
-                                    .to(Iterable)
-                                }
-                                override type CtorResult = A
-                                implicit override val CtorResult: Type[CtorResult] = tpe
-                                override def factory: Expr[scala.collection.Factory[Item, CtorResult]] =
-                                  Expr.quote {
-                                    new scala.collection.Factory[Item, A] {
-                                      override def newBuilder: scala.collection.mutable.Builder[Item, A] =
-                                        new scala.collection.mutable.Builder[Item, A] {
-                                          @SuppressWarnings(Array("unchecked"))
-                                          private val impl: java.util.EnumSet[?] = {
-                                            // Bypass EnumSet.noneOf type bound (E <: Enum[E]) via reflection:
-                                            // Scala 2 cannot infer E for the static method call due to
-                                            // F-bounded polymorphism + Class invariance.
-                                            val cls: java.lang.Class[?] = Expr.splice(enumClassExpr)
-                                            classOf[java.util.EnumSet[?]]
-                                              .getMethod("noneOf", classOf[java.lang.Class[?]])
-                                              .invoke(null, cls)
-                                              .asInstanceOf[java.util.EnumSet[?]]
-                                          }
-                                          override def clear(): Unit = impl.clear()
-                                          override def result(): A = impl.asInstanceOf[A]
-                                          override def addOne(elem: Item): this.type = {
-                                            impl.asInstanceOf[java.util.Set[AnyRef]].add(elem.asInstanceOf[AnyRef]);
-                                            this
-                                          }
-                                        }
-                                      override def fromSpecific(it: IterableOnce[Item]): A =
-                                        newBuilder.addAll(it).result()
-                                    }
-                                  }
-                                override def build: CtorLikeOf[scala.collection.mutable.Builder[Item, CtorResult], A] =
-                                  CtorLikeOf.PlainValue(
-                                    (expr: Expr[scala.collection.mutable.Builder[Item, CtorResult]]) =>
-                                      Expr.quote(Expr.splice(expr).result()),
-                                    None
+                          // `classOf[Item]` is emitted as a literal from `Type[Item]` (ClassExprCodec ignores the value
+                          // argument), so gating on a macro-time `Type.classOfType[Item]` (a `Class.forName`) is
+                          // pointless AND wrongly rejects nested enums on Scala 3 and enums from the current compilation
+                          // run. Emit the literal directly. See issue #323.
+                          val enumClassExpr: Expr[java.lang.Class[Item]] =
+                            Expr.ClassExprCodec[Item].toExpr(classOf[Any].asInstanceOf[java.lang.Class[Item]])
+                          Some(
+                            Existential[IsCollectionOf[A, *], Item](new IsCollectionOf[A, Item] {
+                              override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = Expr.quote {
+                                scala.jdk.javaapi.CollectionConverters
+                                  .asScala(
+                                    Expr.splice(value).asInstanceOf[java.util.Set[Item]].iterator()
                                   )
-                              })
-                            )
-                          }
+                                  .to(Iterable)
+                              }
+                              override type CtorResult = A
+                              implicit override val CtorResult: Type[CtorResult] = tpe
+                              override def factory: Expr[scala.collection.Factory[Item, CtorResult]] =
+                                Expr.quote {
+                                  new scala.collection.Factory[Item, A] {
+                                    override def newBuilder: scala.collection.mutable.Builder[Item, A] =
+                                      new scala.collection.mutable.Builder[Item, A] {
+                                        @SuppressWarnings(Array("unchecked"))
+                                        private val impl: java.util.EnumSet[?] = {
+                                          // Bypass EnumSet.noneOf type bound (E <: Enum[E]) via reflection:
+                                          // Scala 2 cannot infer E for the static method call due to
+                                          // F-bounded polymorphism + Class invariance.
+                                          val cls: java.lang.Class[?] = Expr.splice(enumClassExpr)
+                                          classOf[java.util.EnumSet[?]]
+                                            .getMethod("noneOf", classOf[java.lang.Class[?]])
+                                            .invoke(null, cls)
+                                            .asInstanceOf[java.util.EnumSet[?]]
+                                        }
+                                        override def clear(): Unit = impl.clear()
+                                        override def result(): A = impl.asInstanceOf[A]
+                                        override def addOne(elem: Item): this.type = {
+                                          impl.asInstanceOf[java.util.Set[AnyRef]].add(elem.asInstanceOf[AnyRef]);
+                                          this
+                                        }
+                                      }
+                                    override def fromSpecific(it: IterableOnce[Item]): A =
+                                      newBuilder.addAll(it).result()
+                                  }
+                                }
+                              override def build: CtorLikeOf[scala.collection.mutable.Builder[Item, CtorResult], A] =
+                                CtorLikeOf.PlainValue(
+                                  (expr: Expr[scala.collection.mutable.Builder[Item, CtorResult]]) =>
+                                    Expr.quote(Expr.splice(expr).result()),
+                                  None
+                                )
+                            })
+                          )
                         } else None
                       } else None
                     }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterable.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterable.scala
@@ -73,7 +73,17 @@ final class IsCollectionProviderForJavaIterable extends StandardMacroExtension {
           import item.Underlying as Item
           implicit val A: Type[A] = tpe
           implicit val IterableItem: Type[java.lang.Iterable[Item]] = Iterable[Item]
-          ProviderResult.Matched(isIterable[A, Item](A, _.upcast[java.lang.Iterable[Item]], _.upcast[A]))
+          // Only match the EXACT `java.lang.Iterable[Item]`. The factory builds a `java.util.ArrayList` and hands it
+          // back as `A`; that is sound only when `A` really is `java.lang.Iterable[Item]`. A PROPER subtype (e.g.
+          // `java.util.EnumSet[E]`) is handled by a more specific provider - matching it here and then casting a plain
+          // Iterable to the subtype (`_.upcast[A]`) would assert, since the built ArrayList is not an instance of it.
+          // See issue #324.
+          if (Type[A] =:= IterableItem)
+            ProviderResult.Matched(isIterable[A, Item](A, _.upcast[java.lang.Iterable[Item]], _.upcast[A]))
+          else
+            skipped(
+              s"${tpe.prettyPrint} is a proper subtype of java.lang.Iterable[_]; only exact java.lang.Iterable is handled here"
+            )
         case _ => skipped(s"${tpe.prettyPrint} is not <: java.lang.Iterable[_]")
       }
     })

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
@@ -36,6 +36,9 @@ final class IsCollectionProviderForJavaMap extends StandardMacroExtension { load
       private lazy val juIdentityHashMap = Type.Ctor2.of[java.util.IdentityHashMap]
 
       private lazy val juEnumType = Type.of[java.lang.Enum[?]]
+      // `EnumMap[Nothing, Nothing]` is a well-formed application of the F-bounded `EnumMap[K <: Enum[K], V]`, used only
+      // to compare type constructors symbolically - see `isEnumMapType` below and issue #323.
+      private lazy val juEnumMapType = Type.of[java.util.EnumMap[Nothing, Nothing]]
 
       private lazy val Entry = Type.Ctor2.of[java.util.Map.Entry]
       private lazy val Builder = Type.Ctor2.of[scala.collection.mutable.Builder]
@@ -234,25 +237,20 @@ final class IsCollectionProviderForJavaMap extends StandardMacroExtension { load
                 .orElse(leaf(juWeakHashMap, Expr.quote(new java.util.WeakHashMap[Key, Value])))
                 .orElse(leaf(juIdentityHashMap, Expr.quote(new java.util.IdentityHashMap[Key, Value])))
                 .orElse {
-                  // EnumMap requires K <: Enum[K] bound which cannot be expressed as a Type.Ctor2.
-                  // We check for EnumMap by comparing the runtime class at macro time, and delegate
-                  // to isEnumMap helper which uses casts through Nothing for bounds.
+                  // EnumMap requires a `K <: Enum[K]` bound which cannot be expressed as a Type.Ctor2. Detect it
+                  // SYMBOLICALLY (same type constructor as `java.util.EnumMap`) and emit `classOf[Key]` as a literal
+                  // directly, rather than gating on a macro-time `Class.forName` of the target/key which returned
+                  // nothing on Scala 3 and never matched enums from the current compilation run. See issue #323.
                   if (Key <:< juEnumType) {
-                    val isEnumMapType = Type.classOfType(using tpe).exists { c =>
-                      classOf[java.util.EnumMap[?, ?]].isAssignableFrom(c)
-                    }
+                    val isEnumMapType =
+                      UntypedType.fromTyped(using tpe).sameTypeConstructorAs(juEnumMapType.asUntyped)
                     if (isEnumMapType) {
-                      Type.classOfType[Key].flatMap { keyClass =>
-                        val keyClassExpr: Expr[java.lang.Class[Key]] = {
-                          implicit val classCodec: ExprCodec[java.lang.Class[Key]] =
-                            Expr.ClassExprCodec[Key]
-                          Expr(keyClass)
-                        }
-                        Some(
-                          isEnumMap[Key, Value, A](tpe, Type[Key], Type[Value], keyClassExpr)
-                            .asInstanceOf[IsCollection[A]]
-                        )
-                      }
+                      val keyClassExpr: Expr[java.lang.Class[Key]] =
+                        Expr.ClassExprCodec[Key].toExpr(classOf[Any].asInstanceOf[java.lang.Class[Key]])
+                      Some(
+                        isEnumMap[Key, Value, A](tpe, Type[Key], Type[Value], keyClassExpr)
+                          .asInstanceOf[IsCollection[A]]
+                      )
                     } else None
                   } else None
                 }

--- a/project/CrossQuotesMacrosGen.scala
+++ b/project/CrossQuotesMacrosGen.scala
@@ -399,14 +399,17 @@ object CrossQuotesMacrosGen {
   private def matchResultBody(n: Int, baseIndent: Int): String = {
     val indent = " " * baseIndent
     val exprIndent = " " * (baseIndent + 6) // aligning with inner Some(
+    // Cast to `Type[U_i]` (the UPPER bound), not `Type[scala.Any]`: `as_<:??<:[L, U]` on a `Type[A]` requires `U >: A`,
+    // so a `Type[scala.Any]` receiver would force `U >: Any` and reject any non-`Any` upper bound. For an unbounded
+    // ctor `U_i` is `Any`, so this is unchanged there; for a bounded ctor it makes `U >: U` hold trivially. See #307.
     if (n == 1) {
-      val expr = s"$$ctx.WeakTypeTag(tp1.dealias.widen).asInstanceOf[Type[_root_.scala.Any]].as_<:??<:[$$${ArityGen.lower(1)}, $$${ArityGen.upper(1)}]"
+      val expr = s"$$ctx.WeakTypeTag(tp1.dealias.widen).asInstanceOf[Type[$$${ArityGen.upper(1)}]].as_<:??<:[$$${ArityGen.lower(1)}, $$${ArityGen.upper(1)}]"
       s"${indent}_root_.scala.Some($expr)\n"
     } else {
       val sb = new StringBuilder
       sb ++= s"${indent}_root_.scala.Some((\n"
       for (i <- 1 to n) {
-        val expr = s"$$ctx.WeakTypeTag(tp$i.dealias.widen).asInstanceOf[Type[_root_.scala.Any]].as_<:??<:[$$${ArityGen.lower(i)}, $$${ArityGen.upper(i)}]"
+        val expr = s"$$ctx.WeakTypeTag(tp$i.dealias.widen).asInstanceOf[Type[$$${ArityGen.upper(i)}]].as_<:??<:[$$${ArityGen.lower(i)}, $$${ArityGen.upper(i)}]"
         if (i < n) sb ++= s"$exprIndent$expr,\n"
         else sb ++= s"$exprIndent$expr\n"
       }


### PR DESCRIPTION
## What

Addresses **20 of the 25** issues (#306–#330) surfaced by the Chimney → Hearth migration (scalalandio/chimney#903), targeting the **0.4.1** release. No binary-compatibility break: MiMa passes against 0.4.0 with a single justified filter (for the nested-trait provider-provenance state — `StdExtensions#ProvidedCompanion` is implemented only by Hearth's own std companions, so interface and implementations are evicted together).

## Fixed (20)

**Types**
- #309 — additive `directChildrenList` (ordered `List`, preserves duplicate simple names; `directChildren` unchanged)
- #310 — `isPrimitive[Unit] == true` (scalac `isPrimitiveValueClass` parity)
- #311 — `isCase` inspects the term symbol, so parameterless Scala 3 enum cases are detected
- #312 — Scala 3 `applyTypeArgs` applies to the (dealiased) type constructor, matching Scala 2
- #315 — Scala 3 constructor/flag lookups dealias, so `export`-created aliases resolve

**Methods**
- #326 — Scala 2 `isVal` counts stable accessors (`MethodSymbol.isStable`), e.g. structural-refinement vals
- #327 — Scala 3 `methods` includes public `val` fields inherited from parent classes
- #328 — non-shadowing `baseClassTypes` alias for the `baseClasses` extension (+ doc)

**Classes / NamedTuple** (Scala 3.7+)
- #313 — `NamedTuple.Empty` recognized (constructs `EmptyTuple`)
- #314 — TupleXXL (arity ≥ 23) construction via `Tuple.fromArray`

**cross-quotes (Scala 2)**
- #307 — `Type.CtorN.UpperBounded.of` / `Bounded.of` with a non-`Any` upper bound now type-checks (cast to `Type[U]`, not `Type[Any]`)
- #321 — `ClassExprCodec` emits a class **literal** (`Literal(Constant/ClassOfConstant)`, renders as `classOf[fqcn]`) that survives a downstream re-typecheck; Scala 3 unified to match

**std providers**
- #319 — providers skip bottom types (`Null`/`Nothing`) instead of crashing while eagerly building exprs
- #323 — EnumSet/EnumMap branches select **symbolically** (same type constructor as `java.util.EnumSet`/`EnumMap`) and emit `classOf[Item]` directly, so same-run and nested enums match (Scala 3 too)
- #324 — `IsCollectionProviderForJavaIterable` matches only the **exact** `java.lang.Iterable[Item]` (proper subtypes are handled by more specific providers), fixing the factory-upcast assertion
- #325 — an unloadable `StandardMacroExtension` jar is **skipped**, not fatal; Hearth's built-ins and other extensions still load (`LoaderFailed` only when nothing instantiates)
- #329 — `lastMatchProvenance` on matched results (which provider matched; `isBuiltIn` distinguishes built-ins from extensions)
- #330 — documented the JDK baseline of emitted APIs (`java.util.Map.entry` is JDK 9+; compile consumers with `-release 11`)

**ValDefs**
- #308 — Scala 2 `closeScope` re-tags the returned `Expr[A]` with the value's real type (no signature change → no bincompat break)

**Types (annotations)**
- #306 — `typeAnnotations` / `typeAnnotationsOfType` expose type-position annotations (`name: String @Action("x")`). Gotcha fixed along the way: on Scala 3 `AnnotatedType(X, @Ann).dealias` strips the annotation, so extraction matches `AnnotatedType` before dealiasing.

## Not in this PR (5, followups)

Each needs a dedicated reproduction harness (compiler-plugin `-Xcheck-macros` scenarios / separately-compiled extension modules / `c.untypecheck`+re-typecheck), so they're deliberately deferred rather than rushed:

- #316 — cross-quotes Scala 3 sibling implicit-lazy-val deadlock
- #317 — cross-quotes Scala 3 splice-owner mismatch under `-Xcheck-macros`
- #318 — MIO direct-style `await` thread hop
- #320 — Scala 2 cross-unit quote hygiene (companion/object/type refs)
- #322 — EnumSet/EnumMap Scala 2 inline quotes surviving re-typecheck

## Testing

`sbt "quick-clean ; quick-test"` green on **Scala 2.13 and 3** (JVM), sandwich tests included; `mimaReportBinaryIssues` clean on both. New regression coverage: `Issue307ReproFixturesImpl` (compile-only), EnumSet/EnumMap on both platforms, and `WithTypeAnnotations` type-position annotations.
