### PR TITLE
Fix #316, #320, #322: cross-quotes hygiene, EnumSet re-typecheck, sibling Type deadlock (0.4.1 followups)

### DIFF
--- a/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
+++ b/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
@@ -467,6 +467,44 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
     result
   } catch { case e: Throwable => reportIssue(e) }
 
+  /** [hearth#320] Scala 2 quasiquotes are not hygienic: Cross-Quotes reifies an `Expr.quote` body by printing it back
+    * to source and re-parsing it at the (possibly separately-compiled) expansion site. A reference to a top-level
+    * object printed by its SHORT name can there be captured by a same-named class/companion or be out of scope (e.g.
+    * `value wrap is not a member of ...Wrapper; did you mean unwrap?` for a companion call, or `not found: value
+    * support` for a plain object) — exactly what broke separately-compiled `StandardMacroExtension`s in the Chimney
+    * migration.
+    *
+    * By the time the body is printed it has already been untypechecked (symbols stripped), so we cannot qualify at
+    * print time. Instead, while `expr.tree` is still fully typed, we rewrite every reference to a
+    * statically-addressable public object into a fully-qualified, ROOTED `Select` chain (`_root_.a.b.C`). Being a
+    * structural rewrite (rather than a symbol on a bare `Ident`), it survives the later untypecheck and prints as the
+    * full path — the same hygiene treatment #300 gave to bare `scala.*` names, generalised to arbitrary objects.
+    *
+    * Statically-addressable public objects only: hearth API objects like `Expr`/`Type` are instance members (not
+    * reachable via `mirror.staticModule`) and are left untouched, so `Expr.splice`/`Expr.quote` detection downstream is
+    * unaffected; likewise locals, instance-nested objects and symbol-less stubs are never rewritten.
+    */
+  private def qualifyStaticModuleRefs(tree: c.Tree): c.Tree = {
+    def rootedSelect(fullName: String): c.Tree =
+      fullName.split('.').foldLeft(Ident(TermName("_root_")): c.Tree)((acc, part) => Select(acc, TermName(part)))
+    def qualifiedName(sym: Symbol): Option[String] =
+      if (sym == null || sym == NoSymbol || !sym.isTerm || !sym.asTerm.isModule || !sym.isPublic) None
+      else {
+        val full = sym.fullName
+        if (full.isEmpty || full.contains('$') || full.contains('<')) None
+        // `mirror.staticModule(full)` succeeds and returns THIS symbol iff `_root_.full` is a valid stable path to it
+        // (i.e. it is a genuinely static, top-level-reachable object) — the robust addressability check.
+        else scala.util.Try(c.mirror.staticModule(full)).toOption.filter(_ == sym).map(_ => full)
+      }
+    object transformer extends Transformer {
+      override def transform(t: Tree): Tree = t match {
+        case id: Ident => qualifiedName(id.symbol).fold(super.transform(t))(rootedSelect)
+        case _         => super.transform(t)
+      }
+    }
+    transformer.transform(tree)
+  }
+
   /* Replaces:
    *   Expr.quote[A](a)
    * with:
@@ -499,7 +537,9 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
           }
           resolved
       }
-    val quasiquote = convert(ctx)(expr.tree)
+    // [hearth#320] Fully-qualify statically-addressable object references while the tree is still typed (see
+    // `qualifyStaticModuleRefs`), so they survive convert's print-then-reparse at a separately-compiled expansion site.
+    val quasiquote = convert(ctx)(qualifyStaticModuleRefs(expr.tree))
 
     val quasiquoteFresh = freshName("Quasiquote")
     val unchecked = q"""

--- a/hearth-cross-quotes/src/main/scala-3/hearth/cq/CrossQuotesPlugin.scala
+++ b/hearth-cross-quotes/src/main/scala-3/hearth/cq/CrossQuotesPlugin.scala
@@ -265,6 +265,15 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
       // function body" / null self-assignment in class bodies). With the candidate excluded,
       // `scala.quoted.Type.of[A]` / `Type.CtorN.Bounded.Impl` materialize the type directly instead.
       private var selfDefNames = Set.empty[String]
+      // [hearth#316] Names of the sibling implicit `Type[_]`/`Type.CtorN[_]` val/def definitions declared in the
+      // enclosing TEMPLATE (class/trait/object body). Unlike a block, template members are mutually visible with no
+      // statement ordering, so injecting one sibling's `casted$name` given into another sibling's RHS forces it
+      // (via the `hearth.fp.ignore` suppression), and its RHS forces back — a mutual lazy-val init deadlock (hangs
+      // on the lazy-val CountDownLatch, no diagnostic). While initializing ANY such definition's RHS we therefore
+      // exclude ALL siblings (see the ValDef/DefDef cases): a concrete `Type.of[T]` RHS never legitimately needs a
+      // sibling `Type` given, because concrete types are materialized directly. Abstract-type givens come from
+      // context bounds / implicit params (`boundGivenCandidates`), which are NOT in this set and stay available.
+      private var enclosingTemplateTypeDefNames = Set.empty[String]
 
       private val ctorSize = (1 to 22).map(i => s"Ctor$i" -> i).toMap
       private val isCtor = ctorSize.keySet
@@ -481,6 +490,16 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
         TypeAppliedTypeTree.unapply(tpt).isDefined ||
           TypeCtorAppliedTypeTree.unapply(tpt).isDefined ||
           TypeCtorK1AppliedTypeTree.unapply(tpt).isDefined
+
+      // [hearth#316] Names of the implicit `Type[_]`/`Type.CtorN[_]` val/(parameterless) def members of a template
+      // body — i.e. the members that produce mutually-visible `casted$name` given candidates and could deadlock each
+      // other during initialization. See `enclosingTemplateTypeDefNames`.
+      private def templateTypeDefNames(body: List[untpd.Tree]): Set[String] = body.collect {
+        case vd: untpd.ValDef if vd.isImplicit && producesSelfGivenCandidate(vd.tpt) => vd.name.show
+        case dd @ untpd.DefDef(_, paramss, returnTpe, _)
+            if dd.isImplicit && paramss.flatten.isEmpty && producesSelfGivenCandidate(returnTpe) =>
+          dd.name.show
+      }.toSet
 
       private def blockGivenCandidates(trees: List[untpd.Tree]): List[untpd.ValDef] = trees.collect {
         // Handle imports with @ImportedCrossTypeImplicit (e.g. Underlying, Result, etc.)
@@ -932,7 +951,9 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
         case vd: untpd.ValDef if vd.isImplicit && producesSelfGivenCandidate(vd.tpt) =>
           val oldSelfDefNames = selfDefNames
           try {
-            selfDefNames = oldSelfDefNames + vd.name.show
+            // [hearth#316] Exclude self AND every sibling template-level implicit Type member: injecting a sibling's
+            // casted given here would force it (and it would force back) — a mutual lazy-val init deadlock.
+            selfDefNames = oldSelfDefNames + vd.name.show ++ enclosingTemplateTypeDefNames
             super.transform(vd)
           } finally
             selfDefNames = oldSelfDefNames
@@ -977,11 +998,17 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
         case tpl: Template =>
           val newGivenCandidates = blockGivenCandidates(tpl.body)
           val oldGivenCandidates = givenCandidates
+          val oldEnclosingTemplateTypeDefNames = enclosingTemplateTypeDefNames
           try {
             givenCandidates = oldGivenCandidates ++ newGivenCandidates
+            // [hearth#316] Record this template's mutually-visible implicit Type members so that each one's RHS can
+            // exclude its siblings (avoiding the mutual lazy-val init deadlock). Templates nest, so accumulate.
+            enclosingTemplateTypeDefNames = oldEnclosingTemplateTypeDefNames ++ templateTypeDefNames(tpl.body)
             super.transform(tpl)
-          } finally
+          } finally {
             givenCandidates = oldGivenCandidates
+            enclosingTemplateTypeDefNames = oldEnclosingTemplateTypeDefNames
+          }
 
         /* The cross-quotes code would have type bounds like:
          *  [A: Type, B: Type]
@@ -1019,7 +1046,11 @@ final class CrossQuotesPhase(loggingEnabled: (Option[JFile], Int, Int) => Boolea
           val oldSelfDefNames = selfDefNames
           try {
             givenCandidates = oldGivenCandidates ++ newGivenCandidates
-            selfDefNames = oldSelfDefNames ++ selfName
+            // [hearth#316] For an implicit parameterless Type def (selfName defined), also exclude sibling
+            // template-level implicit Type members to avoid the mutual init deadlock. Regular methods keep all
+            // sibling givens available (their bodies legitimately summon sibling Type[_]).
+            selfDefNames =
+              oldSelfDefNames ++ selfName ++ (if selfName.isDefined then enclosingTemplateTypeDefNames else Set.empty)
             // untpd.DefDef(methodName, paramss, returnTpe, transform(body)).withMods(dd.mods)
             super.transform(dd)
           } finally {

--- a/hearth-tests/src/main/scala-2/hearth/crossquotes/Issue316ReproFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/crossquotes/Issue316ReproFixtures.scala
@@ -1,0 +1,19 @@
+package hearth
+package crossquotes
+
+import hearth.data.Data
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+final private class Issue316ReproFixtures(val c: blackbox.Context)
+    extends MacroCommonsScala2
+    with Issue316ReproFixturesImpl {
+
+  def testSiblingImplicitTypesImpl: c.Expr[Data] = testSiblingImplicitTypes
+}
+
+object Issue316ReproFixtures {
+
+  def testSiblingImplicitTypes: Data = macro Issue316ReproFixtures.testSiblingImplicitTypesImpl
+}

--- a/hearth-tests/src/main/scala-2/hearth/crossquotes/Issue320ReproFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/crossquotes/Issue320ReproFixtures.scala
@@ -1,0 +1,17 @@
+package hearth
+package crossquotes
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+final private class Issue320ReproFixtures(val c: blackbox.Context)
+    extends MacroCommonsScala2
+    with Issue320ReproFixturesImpl {
+
+  def testCrossUnitQuoteImpl(value: c.Expr[String]): c.Expr[String] = testCrossUnitQuote(value)
+}
+
+object Issue320ReproFixtures {
+
+  def testCrossUnitQuote(value: String): String = macro Issue320ReproFixtures.testCrossUnitQuoteImpl
+}

--- a/hearth-tests/src/main/scala-3/hearth/crossquotes/Issue316ReproFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/crossquotes/Issue316ReproFixtures.scala
@@ -1,0 +1,15 @@
+package hearth
+package crossquotes
+
+import hearth.data.Data
+
+import scala.quoted.*
+
+final private class Issue316ReproFixtures(q: Quotes) extends MacroCommonsScala3(using q), Issue316ReproFixturesImpl
+
+object Issue316ReproFixtures {
+
+  inline def testSiblingImplicitTypes: Data = ${ testSiblingImplicitTypesImpl }
+  private def testSiblingImplicitTypesImpl(using q: Quotes): Expr[Data] =
+    new Issue316ReproFixtures(q).testSiblingImplicitTypes
+}

--- a/hearth-tests/src/main/scala-3/hearth/crossquotes/Issue320ReproFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/crossquotes/Issue320ReproFixtures.scala
@@ -1,0 +1,13 @@
+package hearth
+package crossquotes
+
+import scala.quoted.*
+
+final private class Issue320ReproFixtures(q: Quotes) extends MacroCommonsScala3(using q), Issue320ReproFixturesImpl
+
+object Issue320ReproFixtures {
+
+  inline def testCrossUnitQuote(inline value: String): String = ${ testCrossUnitQuoteImpl('value) }
+  private def testCrossUnitQuoteImpl(value: Expr[String])(using q: Quotes): Expr[String] =
+    new Issue320ReproFixtures(q).testCrossUnitQuote(value)
+}

--- a/hearth-tests/src/main/scala/hearth/crossquotes/CrossUnitQuoteHelpers.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/CrossUnitQuoteHelpers.scala
@@ -1,0 +1,24 @@
+package hearth
+package crossquotes
+
+// Support types for the hearth#320 regression (see Issue320ReproFixturesImpl / Issue320Spec).
+//
+// They live in package `hearth.crossquotes`, while the consuming spec lives in package `hearth`, so a quote that
+// references them by their SHORT names (as the fixture does) only resolves at the expansion site if the reified
+// Scala 2 source fully-qualifies them. This mirrors the Chimney migration scenario where a separately-compiled
+// extension quoted companion/object references that then failed to resolve downstream.
+
+/** Companion class + object sharing a name (issue #320 case 1: `CrossUnitWrapper.wrap` must not resolve its qualifier
+  * to the class at the expansion site).
+  */
+final class CrossUnitWrapper private (val unwrap: String)
+object CrossUnitWrapper {
+  def wrap(value: String): CrossUnitWrapper = new CrossUnitWrapper(value)
+}
+
+/** A plain object referenced unqualified (issue #320 case 2: `CrossUnitSupport` must not become `not found: value
+  * CrossUnitSupport` at the expansion site).
+  */
+object CrossUnitSupport {
+  def describe(wrapper: CrossUnitWrapper): String = "wrapped(" + wrapper.unwrap + ")"
+}

--- a/hearth-tests/src/main/scala/hearth/crossquotes/Issue316ReproFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/Issue316ReproFixturesImpl.scala
@@ -1,0 +1,31 @@
+package hearth
+package crossquotes
+
+import hearth.data.Data
+
+/** Fixtures for hearth#316: sibling `implicit lazy val`/`implicit val` `Type[_]` definitions declared in the same
+  * template must not force each other during their own initialization.
+  *
+  * On Scala 3 the Cross-Quotes plugin injects a `casted$name` given (referencing the sibling val) into each Type
+  * definition's RHS and force-evaluates it via the `hearth.fp.ignore` suppression. With two mutually-visible siblings
+  * that made each one's initializer force the other, whose initializer forced back — a mutual lazy-val init deadlock
+  * that hung the compiler on the lazy-val `CountDownLatch` with no diagnostic (in Chimney this hit `Unit`/`Null` and
+  * `AnyType`). The fix excludes sibling template-level Type givens while initializing any one of them.
+  */
+trait Issue316ReproFixturesImpl { this: MacroTypedCommons =>
+
+  implicit lazy val UnitT: Type[Unit] = Type.of[Unit]
+  implicit lazy val NullT: Type[Null] = Type.of[Null]
+  implicit lazy val AnyT: Type[Any] = Type.of[Any]
+
+  def testSiblingImplicitTypes: Expr[Data] = Expr(
+    Data.map(
+      // Touching each lazy val runs its (plugin-generated) initializer — the deadlock point.
+      "unit" -> Data(UnitT.plainPrint),
+      "null" -> Data(NullT.plainPrint),
+      "any" -> Data(AnyT.plainPrint),
+      // The siblings must remain usable as implicits for subsequent expansions.
+      "usable" -> Data(Type.of[Option[Unit]].plainPrint)
+    )
+  )
+}

--- a/hearth-tests/src/main/scala/hearth/crossquotes/Issue320ReproFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/Issue320ReproFixturesImpl.scala
@@ -4,8 +4,8 @@ package crossquotes
 /** Fixtures for the hearth#320 regression: Scala 2 cross-unit quote hygiene.
   *
   * The quote below references a companion-object method (`CrossUnitWrapper.wrap`) and a plain object
-  * (`CrossUnitSupport`) by their SHORT names. Because the fixture is compiled in package `hearth.crossquotes` while
-  * the spec that triggers the expansion lives in package `hearth`, the reified Scala 2 source must fully-qualify those
+  * (`CrossUnitSupport`) by their SHORT names. Because the fixture is compiled in package `hearth.crossquotes` while the
+  * spec that triggers the expansion lives in package `hearth`, the reified Scala 2 source must fully-qualify those
   * object references (`_root_.hearth.crossquotes.CrossUnitWrapper.wrap`, ...) or they fail to resolve at the expansion
   * site (`value wrap is not a member of ...CrossUnitWrapper` / `not found: value CrossUnitSupport`).
   *

--- a/hearth-tests/src/main/scala/hearth/crossquotes/Issue320ReproFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/Issue320ReproFixturesImpl.scala
@@ -1,0 +1,19 @@
+package hearth
+package crossquotes
+
+/** Fixtures for the hearth#320 regression: Scala 2 cross-unit quote hygiene.
+  *
+  * The quote below references a companion-object method (`CrossUnitWrapper.wrap`) and a plain object
+  * (`CrossUnitSupport`) by their SHORT names. Because the fixture is compiled in package `hearth.crossquotes` while
+  * the spec that triggers the expansion lives in package `hearth`, the reified Scala 2 source must fully-qualify those
+  * object references (`_root_.hearth.crossquotes.CrossUnitWrapper.wrap`, ...) or they fail to resolve at the expansion
+  * site (`value wrap is not a member of ...CrossUnitWrapper` / `not found: value CrossUnitSupport`).
+  *
+  * Scala 3 quotes are hygienic and already qualify these references, so the same test passes there unchanged.
+  */
+trait Issue320ReproFixturesImpl { this: MacroTypedCommons =>
+
+  def testCrossUnitQuote(value: Expr[String]): Expr[String] = Expr.quote {
+    CrossUnitSupport.describe(CrossUnitWrapper.wrap(Expr.splice(value)))
+  }
+}

--- a/hearth-tests/src/main/scala/hearth/std/StdExtensionsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/std/StdExtensionsFixturesImpl.scala
@@ -78,15 +78,11 @@ trait StdExtensionsFixturesImpl { this: MacroCommons & StdExtensions =>
       implicit val builderType: Type[scala.collection.mutable.Builder[Elem, CtorResult]] =
         BuilderType[Elem, CtorResult]
 
-      // Build iteration without calling provider for Option/Optional (ctx capture) or EnumSet (pattern var "item" capture) in Scala 2.
+      // Build iteration without calling provider for Option/Optional (ctx capture) in Scala 2.
+      // EnumSet now routes through the provider's `asIterable` like every other collection: issue #322
+      // extracted its quotes into the `isEnumSet` helper so the trees no longer capture the local `item`.
       val iteration =
-        if (Type[A].plainPrint.startsWith("java.util.EnumSet["))
-          Expr.quote {
-            val set = Expr.splice(value).asInstanceOf[java.util.Set[Any]]
-            val lst = scala.jdk.javaapi.CollectionConverters.asScala(set).toList
-            Data(lst.map(elem => Data(elem.toString)).toList)
-          }
-        else if (Type[A].plainPrint.startsWith("scala.Option["))
+        if (Type[A].plainPrint.startsWith("scala.Option["))
           Expr.quote {
             val lst = Expr.splice(value).asInstanceOf[scala.Option[Any]].toList
             Data(lst.map(elem => Data(elem.toString)).toList)
@@ -113,11 +109,10 @@ trait StdExtensionsFixturesImpl { this: MacroCommons & StdExtensions =>
           Expr.quote(Data(Expr.splice(a).toString.takeWhile(c => c != ';' && c != '@' && c != '$')))
         else Expr.quote(Data(Expr.splice(a).toString))
       }
-      // For Option/Optional/EnumSet, build without using provider's factory/build to avoid free term capture in Scala 2.
+      // For Option/Optional, build without using provider's factory/build to avoid free term capture in Scala 2.
+      // (EnumSet has a non-String element, so it falls through to the final "<not a collection of string>" branch.)
       val building =
-        if (Type[A].plainPrint.startsWith("java.util.EnumSet["))
-          Expr(Data("<not a collection of string>"))
-        else if (Type[A].plainPrint.startsWith("scala.Option[") && Elem <:< StringType)
+        if (Type[A].plainPrint.startsWith("scala.Option[") && Elem <:< StringType)
           Expr.quote(Data(Option(Expr.splice(Expr("one"))).toString))
         else if (Type[A].plainPrint.startsWith("java.util.Optional[") && Elem <:< StringType)
           Expr.quote(Data(java.util.Optional.of(Expr.splice(Expr("one"))).toString))

--- a/hearth-tests/src/test/scala/hearth/Issue320Spec.scala
+++ b/hearth-tests/src/test/scala/hearth/Issue320Spec.scala
@@ -2,8 +2,8 @@ package hearth
 
 import hearth.crossquotes.Issue320ReproFixtures
 
-/** Regression for hearth#320: on Scala 2, object/companion references inside an `Expr.quote` from one compilation
-  * scope must survive being re-materialized at a foreign expansion site.
+/** Regression for hearth#320: on Scala 2, object/companion references inside an `Expr.quote` from one compilation scope
+  * must survive being re-materialized at a foreign expansion site.
   *
   * This spec lives in package `hearth` while the quoted `CrossUnitWrapper`/`CrossUnitSupport` objects (and the fixture
   * that quotes them) live in package `hearth.crossquotes`, and only the fixture object is imported here — so the quoted

--- a/hearth-tests/src/test/scala/hearth/Issue320Spec.scala
+++ b/hearth-tests/src/test/scala/hearth/Issue320Spec.scala
@@ -1,0 +1,22 @@
+package hearth
+
+import hearth.crossquotes.Issue320ReproFixtures
+
+/** Regression for hearth#320: on Scala 2, object/companion references inside an `Expr.quote` from one compilation
+  * scope must survive being re-materialized at a foreign expansion site.
+  *
+  * This spec lives in package `hearth` while the quoted `CrossUnitWrapper`/`CrossUnitSupport` objects (and the fixture
+  * that quotes them) live in package `hearth.crossquotes`, and only the fixture object is imported here — so the quoted
+  * short names (`CrossUnitWrapper.wrap`, `CrossUnitSupport.describe`) are NOT in scope at this expansion site. Before
+  * the fix the reified Scala 2 source used those short names and failed to compile here; the fix fully-qualifies them
+  * as `_root_.hearth.crossquotes.…`. Scala 3 quotes are hygienic and already pass.
+  */
+final class Issue320Spec extends MacroSuite {
+
+  group("Cross-Quotes (Scala 2 cross-unit hygiene, hearth#320)") {
+
+    test("object/companion references in a quote resolve at a foreign-package expansion site") {
+      Issue320ReproFixtures.testCrossUnitQuote("hi") <==> "wrapped(hi)"
+    }
+  }
+}

--- a/hearth-tests/src/test/scala/hearth/crossquotes/Issue316Spec.scala
+++ b/hearth-tests/src/test/scala/hearth/crossquotes/Issue316Spec.scala
@@ -1,0 +1,25 @@
+package hearth
+package crossquotes
+
+import hearth.data.Data
+
+/** Regression for hearth#316: sibling implicit `Type[_]` definitions in one template must not deadlock forcing each
+  * other during initialization.
+  *
+  * Macro implementation is in [[hearth.cq.CrossQuotesPlugin]] (Scala 3, where the deadlock occurred) and
+  * [[hearth.cq.CrossQuotesMacros]] (Scala 2). Fixtures are in [[Issue316ReproFixturesImpl]].
+  */
+final class Issue316Spec extends MacroSuite {
+
+  group("Cross-Quotes plugin: sibling implicit Type vals (hearth#316)") {
+
+    test("sibling implicit lazy val Type definitions do not force each other into a deadlock") {
+      Issue316ReproFixtures.testSiblingImplicitTypes <==> Data.map(
+        "unit" -> Data("scala.Unit"),
+        "null" -> Data("scala.Null"),
+        "any" -> Data("scala.Any"),
+        "usable" -> Data("scala.Option[scala.Unit]")
+      )
+    }
+  }
+}

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
@@ -100,6 +100,62 @@ final class IsCollectionProviderForJavaCollection extends StandardMacroExtension
           }
         })
 
+      // Helper for EnumSet: mirrors `isCollection` but without requiring a `Type.Ctor1` (which cannot express the
+      // `E <: Enum[E]` bound). Written as a method with a regular `Item` type parameter (and an implicit `Type[Item]`)
+      // so the emitted quotes reference `Item` through its reified type - NOT the provider's local existential `item`
+      // path - and therefore survive a downstream `c.untypecheck` + re-typecheck on Scala 2. See issue #322.
+      private def isEnumSet[Item, A](
+          A: Type[A],
+          itemType: Type[Item],
+          enumClassExpr: Expr[java.lang.Class[Item]]
+      ): IsCollection[A] = {
+        implicit val Item: Type[Item] = itemType
+        Existential[IsCollectionOf[A, *], Item](new IsCollectionOf[A, Item] {
+          override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = Expr.quote {
+            scala.jdk.javaapi.CollectionConverters
+              .asScala(
+                Expr.splice(value).asInstanceOf[java.util.Set[Item]].iterator()
+              )
+              .to(Iterable)
+          }
+          override type CtorResult = A
+          implicit override val CtorResult: Type[CtorResult] = A
+          override def factory: Expr[scala.collection.Factory[Item, CtorResult]] =
+            Expr.quote {
+              new scala.collection.Factory[Item, A] {
+                override def newBuilder: scala.collection.mutable.Builder[Item, A] =
+                  new scala.collection.mutable.Builder[Item, A] {
+                    @SuppressWarnings(Array("unchecked"))
+                    private val impl: java.util.EnumSet[?] = {
+                      // Bypass EnumSet.noneOf type bound (E <: Enum[E]) via reflection:
+                      // Scala 2 cannot infer E for the static method call due to
+                      // F-bounded polymorphism + Class invariance.
+                      val cls: java.lang.Class[?] = Expr.splice(enumClassExpr)
+                      classOf[java.util.EnumSet[?]]
+                        .getMethod("noneOf", classOf[java.lang.Class[?]])
+                        .invoke(null, cls)
+                        .asInstanceOf[java.util.EnumSet[?]]
+                    }
+                    override def clear(): Unit = impl.clear()
+                    override def result(): A = impl.asInstanceOf[A]
+                    override def addOne(elem: Item): this.type = {
+                      impl.asInstanceOf[java.util.Set[AnyRef]].add(elem.asInstanceOf[AnyRef]);
+                      this
+                    }
+                  }
+                override def fromSpecific(it: IterableOnce[Item]): A =
+                  newBuilder.addAll(it).result()
+              }
+            }
+          override def build: CtorLikeOf[scala.collection.mutable.Builder[Item, CtorResult], A] =
+            CtorLikeOf.PlainValue(
+              (expr: Expr[scala.collection.mutable.Builder[Item, CtorResult]]) =>
+                Expr.quote(Expr.splice(expr).result()),
+              None
+            )
+        })
+      }
+
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = {
         def isCollectionOf[Coll[I] <: java.util.Collection[I], Item: Type, Coll2[I] <: Coll[I]](
             coll: Type.Ctor1[Coll],
@@ -176,60 +232,19 @@ final class IsCollectionProviderForJavaCollection extends StandardMacroExtension
                       // (so EnumSet only matched via the Iterable fallback) and never matched enums from the current
                       // compilation run. See issue #323.
                       if (Item <:< juEnumType) {
-                        val isEnumSet = UntypedType.fromTyped(using tpe).sameTypeConstructorAs(juEnumSetType.asUntyped)
-                        if (isEnumSet) {
+                        val isEnumSetType =
+                          UntypedType.fromTyped(using tpe).sameTypeConstructorAs(juEnumSetType.asUntyped)
+                        if (isEnumSetType) {
                           // `classOf[Item]` is emitted as a literal from `Type[Item]` (ClassExprCodec ignores the value
                           // argument), so gating on a macro-time `Type.classOfType[Item]` (a `Class.forName`) is
                           // pointless AND wrongly rejects nested enums on Scala 3 and enums from the current compilation
                           // run. Emit the literal directly. See issue #323.
                           val enumClassExpr: Expr[java.lang.Class[Item]] =
                             Expr.ClassExprCodec[Item].toExpr(classOf[Any].asInstanceOf[java.lang.Class[Item]])
-                          Some(
-                            Existential[IsCollectionOf[A, *], Item](new IsCollectionOf[A, Item] {
-                              override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = Expr.quote {
-                                scala.jdk.javaapi.CollectionConverters
-                                  .asScala(
-                                    Expr.splice(value).asInstanceOf[java.util.Set[Item]].iterator()
-                                  )
-                                  .to(Iterable)
-                              }
-                              override type CtorResult = A
-                              implicit override val CtorResult: Type[CtorResult] = tpe
-                              override def factory: Expr[scala.collection.Factory[Item, CtorResult]] =
-                                Expr.quote {
-                                  new scala.collection.Factory[Item, A] {
-                                    override def newBuilder: scala.collection.mutable.Builder[Item, A] =
-                                      new scala.collection.mutable.Builder[Item, A] {
-                                        @SuppressWarnings(Array("unchecked"))
-                                        private val impl: java.util.EnumSet[?] = {
-                                          // Bypass EnumSet.noneOf type bound (E <: Enum[E]) via reflection:
-                                          // Scala 2 cannot infer E for the static method call due to
-                                          // F-bounded polymorphism + Class invariance.
-                                          val cls: java.lang.Class[?] = Expr.splice(enumClassExpr)
-                                          classOf[java.util.EnumSet[?]]
-                                            .getMethod("noneOf", classOf[java.lang.Class[?]])
-                                            .invoke(null, cls)
-                                            .asInstanceOf[java.util.EnumSet[?]]
-                                        }
-                                        override def clear(): Unit = impl.clear()
-                                        override def result(): A = impl.asInstanceOf[A]
-                                        override def addOne(elem: Item): this.type = {
-                                          impl.asInstanceOf[java.util.Set[AnyRef]].add(elem.asInstanceOf[AnyRef]);
-                                          this
-                                        }
-                                      }
-                                    override def fromSpecific(it: IterableOnce[Item]): A =
-                                      newBuilder.addAll(it).result()
-                                  }
-                                }
-                              override def build: CtorLikeOf[scala.collection.mutable.Builder[Item, CtorResult], A] =
-                                CtorLikeOf.PlainValue(
-                                  (expr: Expr[scala.collection.mutable.Builder[Item, CtorResult]]) =>
-                                    Expr.quote(Expr.splice(expr).result()),
-                                  None
-                                )
-                            })
-                          )
+                          // Route through the `isEnumSet` helper (regular `Item` type parameter) so the emitted quotes
+                          // do not reference the provider's local existential `item` path - required for downstream
+                          // re-typecheck on Scala 2. See issue #322.
+                          Some(isEnumSet[Item, A](tpe, Type[Item], enumClassExpr).asInstanceOf[IsCollection[A]])
                         } else None
                       } else None
                     }


### PR DESCRIPTION
Follow-up fixes for the **0.4.1** release, continuing the Chimney → Hearth migration sweep (after #332 landed the first 20). Each fix is validated with a real before/after regression test.

## #322 — EnumSet (Scala 2) quotes survive downstream re-typecheck
The `EnumSet` branch of `IsCollectionProviderForJavaCollection` built its `asIterable`/`factory` quotes **inline** in `parse`, closing over the local existential `item` (imported as `Item = item.Underlying`). On Scala 2 the emitted trees referenced the provider's local `item`, so any consumer that `c.untypecheck`s + re-typechecks the expansion (Chimney does) failed with `not found: value item`.

- Extracted the branch into a `private def isEnumSet[Item, A]` helper mirroring the already-clean `isEnumMap` (regular `Item` type param + implicit `Type[Item]`), so quotes reify the concrete enum type instead of the `item.Underlying` projection.
- **Regression:** removed the `StdExtensionsFixturesImpl` workaround that deliberately avoided the provider's `asIterable`/`factory` for EnumSet "to avoid item capture in Scala 2"; the existing `StdExtensionsJvmSpec` EnumSet test now exercises the real path on Scala 2.

## #320 — Scala 2 cross-unit quote hygiene (object/companion references)
Scala 2 quasiquotes aren't hygienic: Cross-Quotes reifies an `Expr.quote` body by printing it back to source and re-parsing it at the (possibly separately-compiled) expansion site. A bare object reference (`CrossUnitWrapper.wrap`, `CrossUnitSupport`) printed by its **short name** could be captured by a same-named class/companion or be out of scope downstream — `value wrap is not a member of ...Wrapper; did you mean unwrap?` / `not found: value support`. #300 handled only the `scala.*` subset.

- By print time the tree is already untypechecked (symbols stripped), so `qualifyStaticModuleRefs` rewrites bare module `Ident`s into rooted `Select` chains (`_root_.a.b.C`) **while the tree is still typed**, before `convert`. Structural, so it survives untypecheck and prints as the full path. Addressability verified via `mirror.staticModule`. hearth API objects (`Expr`/`Type`) are instance members → untouched, so splice/quote detection is unaffected.
- **Regression:** `Issue320ReproFixtures` quotes those objects in package `hearth.crossquotes`; `Issue320Spec` triggers the expansion from package `hearth` where the short names aren't in scope. Witnessed failing (`not found: value CrossUnitSupport`) before the fix. Scala 3 quotes are hygienic and pass unchanged.

## #316 — sibling implicit `Type` val deadlock (Scala 3 plugin)
The plugin injects each implicit `Type[_]` val/def's `casted$name` given into siblings' RHS and force-evaluates it via the `hearth.fp.ignore` suppression. In a **template** (class/trait body, no statement ordering unlike a block) two siblings forced each other into a **mutual lazy-val init deadlock** on the `-Yfuture-lazy-vals` CountDownLatch (no diagnostic; hit `Unit`/`Null`/`AnyType` in Chimney). #285 fixed only the self-referential case.

- Generalised the `#285` `selfDefNames` exclusion: while transforming ANY implicit Type member's RHS, exclude **all** sibling template-level Type givens (`enclosingTemplateTypeDefNames`), not just self. Safe — a concrete `Type.of[T]` RHS never needs a sibling Type given; abstract-type givens come from context bounds (untouched). Regular methods keep all sibling givens.
- **Validation:** the deadlock is specific to Scala 3.8.4 (`scala-newest`). `Issue316ReproFixtures` declares sibling `implicit lazy val UnitT/NullT/AnyT: Type[_]` + a macro touching them; on 3.8.4, `hearthTests3/Test/compile` **hangs** at `Issue316Spec`'s expansion without the fix (stuck 60s+ vs an 86s full build with it) and compiles clean with it.

## Verification
- `sbt --client "quick-clean ; quick-test"` green on **2.13.16 + 3.3.8** (1163 + 1291 + sandwich).
- #316 fix additionally validated on **3.8.4** (`NEWEST_SCALA_TESTS=true`): deadlock without the fix, clean with it.
- MiMa clean; scalafmt clean. Changes are additive / internal — no public API break.

## Not included (deferred)
#317 (entry-Quotes vs `nestedCtx` owner/splice-scope under `-Xcheck-macros`) and #318 (MIO direct-style thread-hop) remain open — their fixes touch core cross-quotes ctx/owner/scope semantics and need a Chimney-mirroring multi-instance-derivation harness; better handled in a dedicated PR.