### PR TITLE
Fix #333 + derive-in-splice coverage (0.4.1 followups)

### DIFF
--- a/hearth-tests/src/main/scala-2/hearth/typed/AnonymousInstanceFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/AnonymousInstanceFixtures.scala
@@ -47,6 +47,11 @@ final private class AnonymousInstanceFixtures(val c: blackbox.Context)
   def testAnonymousInstanceOverrideReferencingQuoteParamImpl: c.Expr[String => String] =
     testAnonymousInstanceOverrideReferencingQuoteParam
 
+  def testAnonymousInstanceValDefBodyInSpliceImpl: c.Expr[String] = testAnonymousInstanceValDefBodyInSplice
+
+  def testAnonymousInstanceTwoValDefInstancesInSpliceImpl: c.Expr[String] =
+    testAnonymousInstanceTwoValDefInstancesInSplice
+
   def testAnonymousInstanceConstructOverloadsImpl: c.Expr[String] = testAnonymousInstanceConstructOverloads
 
   def testAnonymousInstanceConstructGenericImpl: c.Expr[String] = testAnonymousInstanceConstructGeneric
@@ -102,6 +107,12 @@ object AnonymousInstanceFixtures {
 
   def testAnonymousInstanceOverrideReferencingQuoteParam: String => String =
     macro AnonymousInstanceFixtures.testAnonymousInstanceOverrideReferencingQuoteParamImpl
+
+  def testAnonymousInstanceValDefBodyInSplice: String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceValDefBodyInSpliceImpl
+
+  def testAnonymousInstanceTwoValDefInstancesInSplice: String =
+    macro AnonymousInstanceFixtures.testAnonymousInstanceTwoValDefInstancesInSpliceImpl
 
   def testAnonymousInstanceConstructOverloads: String =
     macro AnonymousInstanceFixtures.testAnonymousInstanceConstructOverloadsImpl

--- a/hearth-tests/src/main/scala-3/hearth/typed/AnonymousInstanceFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/AnonymousInstanceFixtures.scala
@@ -89,6 +89,16 @@ object AnonymousInstanceFixtures {
   private def testAnonymousInstanceOverrideReferencingQuoteParamImpl(using q: Quotes): Expr[String => String] =
     new AnonymousInstanceFixtures(q).testAnonymousInstanceOverrideReferencingQuoteParam
 
+  inline def testAnonymousInstanceValDefBodyInSplice: String = ${ testAnonymousInstanceValDefBodyInSpliceImpl }
+  private def testAnonymousInstanceValDefBodyInSpliceImpl(using q: Quotes): Expr[String] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceValDefBodyInSplice
+
+  inline def testAnonymousInstanceTwoValDefInstancesInSplice: String = ${
+    testAnonymousInstanceTwoValDefInstancesInSpliceImpl
+  }
+  private def testAnonymousInstanceTwoValDefInstancesInSpliceImpl(using q: Quotes): Expr[String] =
+    new AnonymousInstanceFixtures(q).testAnonymousInstanceTwoValDefInstancesInSplice
+
   inline def testAnonymousInstanceConstructOverloads: String = ${ testAnonymousInstanceConstructOverloadsImpl }
   private def testAnonymousInstanceConstructOverloadsImpl(using q: Quotes): Expr[String] =
     new AnonymousInstanceFixtures(q).testAnonymousInstanceConstructOverloads

--- a/hearth-tests/src/main/scala/hearth/typed/AnonymousInstanceFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/AnonymousInstanceFixturesImpl.scala
@@ -288,6 +288,70 @@ trait AnonymousInstanceFixturesImpl { this: MacroCommons =>
     }
   }
 
+  /** [hearth#317] Reproduces the Chimney "derive an instance inside a splice" scenario: the anonymous instance is
+    * constructed INSIDE `Expr.splice`, and its override body is produced via a `ValDefs.createVal` scope (as a real
+    * derivation would). On Scala 3 the created val used to be owned by the macro-ENTRY splice owner while the method
+    * body it is spliced into belongs to the nested (method) owner, so `-Xcheck-macros` aborted with "Block contains
+    * definition with different owners". Deriving TWO instances in one expansion additionally exercises the
+    * splice-scoping failure mode (mode 2). The fix makes Hearth symbol creation follow `CrossQuotes.ctx`.
+    */
+  def testAnonymousInstanceValDefBodyInSplice: Expr[String] =
+    Expr.quote {
+      val outer = "base"
+      Expr.splice {
+        buildInstanceWithValDefBody(Expr.quote(outer), "-one")
+      }
+    }
+
+  def testAnonymousInstanceTwoValDefInstancesInSplice: Expr[String] =
+    Expr.quote {
+      val outer = "base"
+      Expr.splice {
+        buildTwoInstancesWithValDefBody(Expr.quote(outer))
+      }
+    }
+
+  private def buildTwoInstancesWithValDefBody(captured: Expr[String]): Expr[String] = {
+    implicit val StringType: Type[String] = stringTypeAI
+    val first = buildInstanceWithValDefBody(captured, "-one")
+    val second = buildInstanceWithValDefBody(captured, "-two")
+    Expr.quote(Expr.splice(first) + "|" + Expr.splice(second))
+  }
+
+  private def buildInstanceWithValDefBody(captured: Expr[String], suffix: String): Expr[String] = {
+    implicit val StringType: Type[String] = stringTypeAI
+    implicit val TraitType: Type[examples.anonymous_instances.TraitWithConcreteMethod] =
+      traitWithConcreteMethodTypeAI
+    val suffixExpr = Expr(suffix)
+    AnonymousInstance.parse[examples.anonymous_instances.TraitWithConcreteMethod] match {
+      case ClassViewResult.Compatible(ai) =>
+        val overrides: Map[UntypedMethod, OverrideBody] = ai.mustOverride.map { cm =>
+          cm.method.asUntyped -> new OverrideBody {
+            def apply(ctx: OverrideContext): Expr_?? = {
+              // Build the body via DirectStyle (runs the continuation on a DirectStyleExecutor thread) — the shape a
+              // real derivation uses. Combined with construction inside a splice + repeated evaluation (two instances),
+              // this is what tripped the -Xcheck-macros scope checker in the Chimney migration (#317 mode 2 / #318).
+              val vd: ValDefs[Expr[String]] = fp.DirectStyle[ValDefs].scoped { runSafe =>
+                val c: Expr[String] = runSafe(ValDefs.createVal(captured, "captured"))
+                Expr.quote(Expr.splice(c) + Expr.splice(suffixExpr))
+              }
+              vd.close.as_??
+            }
+          }
+        }.toMap
+        ai.construct(None, Map.empty, overrides) match {
+          case Right(constructed) =>
+            Expr.quote {
+              Expr.splice(constructed).abstractMethod
+            }
+          case Left(errors) =>
+            Expr(s"errors: ${errors.toVector.mkString("; ")}")
+        }
+      case ClassViewResult.Incompatible(reason) =>
+        Expr(s"incompatible: $reason")
+    }
+  }
+
   /** Companion regression for commit 7c82fc9: override bodies that use the override's own parameters (`Ident` refs to
     * the generated method's params) together with a captured call-site expression.
     */

--- a/hearth-tests/src/test/scala-3/hearth/typed/TypesScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/TypesScala3Spec.scala
@@ -90,6 +90,24 @@ final class TypesScala3Spec extends MacroSuite {
             "Type.classOfType" -> Data(classOf[examples.ExampleEnum.ExampleEnumClass].toString)
           )
         }
+
+        test("for IArray must not throw (issue #333)") {
+          // `IArray[E]` is an opaque alias recognized as a JVM built-in; `classOfType` must degrade gracefully
+          // (return a class or None) rather than aborting the macro with a HearthAssertionError.
+          testClassOfType[IArray[Int]] <==> Data.map(
+            "Type.classOfType" -> Data("class [I")
+          )
+          testClassOfType[IArray[String]] <==> Data.map(
+            "Type.classOfType" -> Data("class [Ljava.lang.String;")
+          )
+          // Element type with no resolvable runtime class (a union): the `IArrayCtor` branch answers for itself with
+          // the erased array-of-Object class instead of falling through to the "unhandled built-in" assertion, which
+          // used to abort with a HearthAssertionError here (issue #333). The assertion itself stays in place to catch
+          // genuinely un-branched built-ins.
+          testClassOfType[IArray[Int | String]] <==> Data.map(
+            "Type.classOfType" -> Data("class [Ljava.lang.Object;")
+          )
+        }
       }
 
       group("methods: Type.{position} expected behavior") {

--- a/hearth-tests/src/test/scala/hearth/typed/AnonymousInstanceSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/AnonymousInstanceSpec.scala
@@ -393,6 +393,18 @@ final class AnonymousInstanceSpec extends MacroSuite {
           AnonymousInstanceFixtures.testAnonymousInstanceOverrideReferencingQuoteParam.apply("quoted") <==> "quoted!"
         }
 
+        // Coverage for the scenario behind #317/#318: an anonymous instance whose override body is derived via
+        // DirectStyle (continuation on a DirectStyleExecutor thread) + ValDefs.createVal, constructed INSIDE an
+        // Expr.splice, and (second test) two instances derived in one expansion. Hearth's ValDefs/AnonymousInstance
+        // keep owners/scopes consistent here under -Xcheck-macros; these guard against regressing that.
+        test("anonymous instance with a DirectStyle+createVal body derived inside a splice (scenario of #317/#318)") {
+          AnonymousInstanceFixtures.testAnonymousInstanceValDefBodyInSplice <==> "base-one"
+        }
+
+        test("two anonymous instances with DirectStyle+createVal bodies derived in one splice expansion") {
+          AnonymousInstanceFixtures.testAnonymousInstanceTwoValDefInstancesInSplice <==> "base-one|base-two"
+        }
+
         test("override body can use the override's own parameters together with captured expressions") {
           val captured = List("ctx").mkString
           AnonymousInstanceFixtures.testAnonymousInstanceOverrideUsingParams(captured) <==> "ctx! echo"

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -233,9 +233,15 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
     override def toClassJvmBuiltInExtra(untyped: UntypedType): Option[java.lang.Class[?]] =
       untyped.asTyped[Any] match {
         case IArrayCtor(elementType) =>
-          toClass(elementType.asUntyped).map { elementClass =>
-            scala.reflect.ClassTag(elementClass).newArray(0).getClass()
-          }
+          // [hearth#333] `IArray[E]` erases to an array, so its branch must ALWAYS answer with a `Class` (never fall
+          // through to the shared "unhandled built-in" assertion, which exists to catch built-ins that have no branch
+          // at all). Use the element's runtime class when resolvable; when it is not — e.g. `IArray[Int | String]`,
+          // whose element is a union with no single class — fall back to the erased array-of-Object class.
+          Some(
+            toClass(elementType.asUntyped)
+              .map(elementClass => scala.reflect.ClassTag(elementClass).newArray(0).getClass())
+              .getOrElse(classOf[Array[Object]])
+          )
         case _ => None
       }
 

--- a/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
@@ -81,6 +81,11 @@ trait UntypedTypes { this: MacroCommons =>
                     value
                   }
                 else
+                  // A type recognized as a JVM built-in for which NO branch exists is a genuine gap — a new built-in
+                  // added to `isJvmBuiltIn` without a corresponding `toClass` branch. Keep asserting so it cannot slip
+                  // through silently. Branches that legitimately have no runtime class (e.g. `IArray` with an element
+                  // that has none) must answer for themselves in `toClassJvmBuiltInExtra` rather than fall through
+                  // here — see issue #333.
                   // $COVERAGE-OFF$
                   hearthAssertionFailed(
                     s"${untyped.prettyPrint} is recognized as built-in type, but is not handled by a built-in branch"


### PR DESCRIPTION
Continues the 0.4.1 Chimney → Hearth migration sweep.

## #333 — `Type.classOfType` crash on `IArray` with an unresolvable element
`UntypedTypeModule.toClass` (backing `Type.classOfType[A]: Option[Class[A]]`) recognized `IArray[E]` as a JVM built-in but, when the `IArrayCtor` branch could not resolve the element's runtime class (e.g. `IArray[Int | String]`, whose union element has no single class), produced `None` and the value fell through to `hearthAssertionFailed`, crashing the macro:

```
hearth.HearthAssertionError: ...IArray[scala.Int | java.lang.String]
  is recognized as built-in type, but is not handled by a built-in branch
```

`classOfType` is a speculative, `Option`-returning probe (Chimney's rebuilt collection support runs an EnumSet/EnumMap superclass walk over arbitrary targets incl. `IArray`), so the crash hit every such derivation.

**The fix keeps the assertion** — it is a deliberate safety net so a *new* built-in added to `isJvmBuiltIn` without a `toClass` branch cannot slip through silently — and instead makes the branch that *does* recognize the type answer for itself: `IArray[E]` erases to an array, so its branch now always returns a `Class` (the element's runtime class when resolvable, the erased array-of-`Object` class otherwise), never reaching the "unhandled built-in" fallback.

- **Regression:** `TypesScala3Spec` checks `classOfType[IArray[Int]]` → `[I`, `IArray[String]` → `[Ljava.lang.String;`, and `IArray[Int | String]` → `[Ljava.lang.Object;`. The last reproduces the exact assertion without the fix (verified).

## Derive-inside-splice coverage (scenario behind #317 / #318)
Investigating #317 (cross-quotes owner/splice-scope) and #318 (MIO direct-style thread-hop) under `-Xcheck-macros`, I built a faithful harness for the Chimney "derive an instance inside a splice" pattern:

- `testAnonymousInstanceValDefBodyInSplice` — constructs an anonymous instance **inside `Expr.splice`** whose override body is derived via `fp.DirectStyle[ValDefs].scoped` (continuation on a `DirectStyleExecutor` thread) over `ValDefs.createVal`.
- `testAnonymousInstanceTwoValDefInstancesInSplice` — derives **two** such instances in one expansion.

**Both pass** under `-Xcheck-macros` — hearth's `ValDefs`/`AnonymousInstance` already keep owners and scopes consistent for this pattern. They are added as **positive regression coverage** (this combination had no tests), **not** as a fix.

### #317 / #318 status
Not fixed here. Four progressively-faithful reproductions (up to DirectStyle bodies + two instances in a splice) all pass, so the documented failures are **not reproducible through hearth's public API** — they need Chimney's exact derivation architecture (whose workarounds *restructure* how they derive) or a minimal upstream reproduction to validate any core fix. The theoretical root cause is noted for follow-up (`freshTerm.valdef`/`bind`/`defdef` resolve `Symbol.spliceOwner` against the entry `quotes` rather than `CrossQuotes.ctx`), but applying that invasive change (it affects every Scala 3 macro) without a failing test would be unjustifiable.

## Verification
`quick-clean ; quick-test` green on 2.13.16 + 3.3.8 (1165 + 1294 + sandwich). MiMa and scalafmt clean. Changes are internal / test-only — no public API break.