### PR TITLE
Fix #307, #315, #327 (round 2): complete the incomplete batch-1 fixes

### DIFF
--- a/hearth-tests/src/main/scala-2/hearth/crossquotes/CrossTypesFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/crossquotes/CrossTypesFixtures.scala
@@ -12,6 +12,8 @@ final private class CrossTypesFixtures(val c: blackbox.Context) extends MacroCom
 
   def testTypeCtor1Impl[A: c.WeakTypeTag]: c.Expr[Data] = testTypeCtor1[A]
 
+  def testTypeCtorLiteralPreservationImpl: c.Expr[Data] = testTypeCtorLiteralPreservation
+
   def testTypeCtor2Impl[A: c.WeakTypeTag]: c.Expr[Data] = testTypeCtor2[A]
 
   def testTypeCtor3Impl[A: c.WeakTypeTag]: c.Expr[Data] = testTypeCtor3[A]
@@ -60,6 +62,8 @@ object CrossTypesFixtures {
   def testTypeOf[A]: Data = macro CrossTypesFixtures.testTypeOfImpl[A]
 
   def testTypeCtor1[A]: Data = macro CrossTypesFixtures.testTypeCtor1Impl[A]
+
+  def testTypeCtorLiteralPreservation: Data = macro CrossTypesFixtures.testTypeCtorLiteralPreservationImpl
 
   def testTypeCtor2[A]: Data = macro CrossTypesFixtures.testTypeCtor2Impl[A]
 

--- a/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
@@ -46,6 +46,9 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
   def testMethodPropertiesImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
     testMethodProperties[A](methodName)
 
+  def testAccessorMetadataImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
+    testAccessorMetadata[A](methodName)
+
   def testMethodVisibilityImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
     testMethodVisibility[A](methodName)
 
@@ -158,6 +161,9 @@ object MethodsFixtures {
 
   def testMethodProperties[A](methodName: String): Data =
     macro MethodsFixtures.testMethodPropertiesImpl[A]
+
+  def testAccessorMetadata[A](methodName: String): Data =
+    macro MethodsFixtures.testAccessorMetadataImpl[A]
 
   def testMethodVisibility[A](methodName: String): Data =
     macro MethodsFixtures.testMethodVisibilityImpl[A]

--- a/hearth-tests/src/main/scala-3/hearth/crossquotes/CrossTypesFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/crossquotes/CrossTypesFixtures.scala
@@ -17,6 +17,10 @@ object CrossTypesFixtures {
   inline def testTypeCtor1[A]: Data = ${ testTypeCtor1Impl[A] }
   private def testTypeCtor1Impl[A: Type](using q: Quotes): Expr[Data] = new CrossTypesFixtures(q).testTypeCtor1[A]
 
+  inline def testTypeCtorLiteralPreservation: Data = ${ testTypeCtorLiteralPreservationImpl }
+  private def testTypeCtorLiteralPreservationImpl(using q: Quotes): Expr[Data] =
+    new CrossTypesFixtures(q).testTypeCtorLiteralPreservation
+
   inline def testTypeCtor2[A]: Data = ${ testTypeCtor2Impl[A] }
   private def testTypeCtor2Impl[A: Type](using q: Quotes): Expr[Data] = new CrossTypesFixtures(q).testTypeCtor2[A]
 

--- a/hearth-tests/src/main/scala-3/hearth/examples/exports-s3.scala
+++ b/hearth-tests/src/main/scala-3/hearth/examples/exports-s3.scala
@@ -1,0 +1,14 @@
+package hearth
+package examples
+package exports
+
+// Scala 3-only fixtures for hearth#315: an `export`-created alias must classify the same as its underlying class
+// (its `typeSymbol` is the alias, which carries none of the class flags, so flag checks must `dealias`).
+
+object Inner {
+  case class Foo(a: Int, b: String)
+}
+
+object Exported {
+  export Inner.Foo
+}

--- a/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
@@ -93,6 +93,10 @@ object MethodsFixtures {
   private def testConstructVarargCtorImpl[A: Type](params: Expr[Seq[String]])(using q: Quotes): Expr[Data] =
     new MethodsFixtures(q).testConstructVarargCtor[A](params)
 
+  inline def testAccessorMetadata[A](inline methodName: String): Data = ${ testAccessorMetadataImpl[A]('methodName) }
+  private def testAccessorMetadataImpl[A: Type](methodName: Expr[String])(using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testAccessorMetadata[A](methodName)
+
   inline def testMethodProperties[A](inline methodName: String): Data = ${
     testMethodPropertiesImpl[A]('methodName)
   }

--- a/hearth-tests/src/main/scala/hearth/crossquotes/CrossTypesFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/crossquotes/CrossTypesFixturesImpl.scala
@@ -101,6 +101,28 @@ trait CrossTypesFixturesImpl { this: MacroTypedCommons =>
     case _ => None
   }
 
+  // [hearth#307] The Scala 2 `Type.CtorN` codegen used to `.widen` each extracted type argument, decaying a literal
+  // singleton (`ConstantType`, e.g. Chimney's `Path.Select["fieldName", _]`) to `java.lang.String`. Verify the
+  // extractor now hands the argument back as written (`dealias` only, no `widen`).
+  def testTypeCtorLiteralPreservation: Expr[Data] = {
+    val Ctor1 = Type.Ctor1.of[examples.kinds.Arity1]
+    val Ctor2 = Type.Ctor2.of[examples.kinds.Arity2]
+    val ctor1Literal = Type.of[examples.kinds.Arity1["fieldName"]] match {
+      case Ctor1(a) => a.Underlying.plainPrint
+      case _        => "<no match>"
+    }
+    val ctor2Literal = Type.of[examples.kinds.Arity2["fieldName", Int]] match {
+      case Ctor2(a, _) => a.Underlying.plainPrint
+      case _           => "<no match>"
+    }
+    Expr(
+      Data.map(
+        "ctor1Literal" -> Data(ctor1Literal),
+        "ctor2Literal" -> Data(ctor2Literal)
+      )
+    )
+  }
+
   def testTypeCtor1[In: Type]: Expr[Data] = {
     val classResult = try1(Type[In], Type.Ctor1.of[examples.kinds.Arity1]) match {
       case Some(data) => Seq("as class" -> data)

--- a/hearth-tests/src/main/scala/hearth/examples/methods.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/methods.scala
@@ -134,3 +134,9 @@ case class CaseClassWithVarCtorParam(var name: String)
 class WithRestrictedVar {
   private[examples] var counter: Int = 0
 }
+
+// [hearth#327] Inherited constructor-`val` fields: `id`/`status` are public vals declared in parent CLASSES; they must
+// be listed by `Type[IdStatusEntity].methods` with correct metadata (isAvailable=true, isInherited=true).
+abstract class StatusEntity(val status: String)
+abstract class AbstractIdStatusEntity(val id: Long, status: String) extends StatusEntity(status)
+class IdStatusEntity(id: Long, status: String) extends AbstractIdStatusEntity(id, status)

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -67,6 +67,22 @@ trait MethodsFixturesImpl { this: MacroCommons =>
       Environment.reportErrorAndAbort(s"Method name must be a string literal, got ${methodName.prettyPrint}")
   }
 
+  // [hearth#327] Focused report of the accessor metadata that matters for inherited constructor-`val` fields: an
+  // inherited public `val` must be listed as a usable, inherited accessor (isVal + isAvailable + isInherited), not the
+  // subclass's private param-accessor plumbing.
+  def testAccessorMetadata[A: Type](methodName: Expr[String]): Expr[Data] = methodName match {
+    case Expr(name) =>
+      Expr(Data(Type[A].methods.filter(_.name == name).map { m =>
+        Data.map(
+          "isVal" -> Data(m.isVal),
+          "isInherited" -> Data(m.isInherited),
+          "isAvailable(Everywhere)" -> Data(m.isAvailable(Everywhere))
+        )
+      }))
+    case _ =>
+      Environment.reportErrorAndAbort(s"Method name must be a string literal, got ${methodName.prettyPrint}")
+  }
+
   private def renderMethods(methods: List[Method]): Data =
     Data(
       methods

--- a/hearth-tests/src/test/scala-3/hearth/typed/MethodsScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/MethodsScala3Spec.scala
@@ -10,6 +10,25 @@ final class MethodsScala3Spec extends MacroSuite {
 
     group("type Method") {
 
+      group("methods: inherited constructor-val fields (issue #327)") {
+        import MethodsFixtures.testAccessorMetadata
+
+        test("are listed as available, inherited accessors (not the subclass's private param-accessor plumbing)") {
+          // `id` (from AbstractIdStatusEntity) and `status` (from StatusEntity) are public inherited vals; the subclass
+          // re-takes them as constructor params passed to super, which Scala 3 keeps as private[this] param accessors —
+          // those must not shadow the genuine public inherited accessors.
+          val expected = Data.list(
+            Data.map(
+              "isVal" -> Data(true),
+              "isInherited" -> Data(true),
+              "isAvailable(Everywhere)" -> Data(true)
+            )
+          )
+          testAccessorMetadata[examples.methods.IdStatusEntity]("id") <==> expected
+          testAccessorMetadata[examples.methods.IdStatusEntity]("status") <==> expected
+        }
+      }
+
       group(
         "constructors: Method.{primaryConstructorOf[A], defaultConstructorOf[A], constructorsOf[A]}, returns preprocessed constructors"
       ) {

--- a/hearth-tests/src/test/scala-3/hearth/typed/TypesScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/TypesScala3Spec.scala
@@ -203,6 +203,12 @@ final class TypesScala3Spec extends MacroSuite {
       ) {
         import TypesFixtures.{testFlags, testChildrenFlags}
 
+        test("an export-created alias classifies identically to its underlying class (issue #315)") {
+          // `Exported.Foo` is `export Inner.Foo`; its flags (isClass/isCase/isAbstract/...) must match `Inner.Foo`,
+          // not the (flag-less) alias symbol. Before the fix isClass/isCase were false for the export alias.
+          testFlags[examples.exports.Exported.Foo] <==> testFlags[examples.exports.Inner.Foo]
+        }
+
         test("for Scala 3 enums") {
           List(
             testFlags[examples.ExampleEnum],

--- a/hearth-tests/src/test/scala/hearth/crossquotes/CrossTypesSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/crossquotes/CrossTypesSpec.scala
@@ -48,6 +48,13 @@ final class CrossTypesSpec extends MacroSuite {
     group("for Type.Ctor[n].of") {
       import CrossTypesFixtures.*
 
+      test("Type.CtorN.unapply preserves literal type arguments and does not widen them (issue #307)") {
+        CrossTypesFixtures.testTypeCtorLiteralPreservation <==> Data.map(
+          "ctor1Literal" -> Data("\"fieldName\""),
+          "ctor2Literal" -> Data("\"fieldName\"")
+        )
+      }
+
       test(
         "should resolve types in the context of the macro compilation, and properly handle type aliases and kind projections for Type.Ctor1"
       ) {

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -863,16 +863,25 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
       // base classes and pick up their public, non-synthetic fields, deduplicating by name (closest class wins, since
       // `baseClasses` is ordered subclass-first) and never shadowing an own member. Scala 2's `.members` already sees
       // them. See issue #327. `UntypedType.baseClasses` is used explicitly to avoid the extension-shadowing footgun.
-      val ownMembers = symbol.methodMembers ++ symbol.fieldMembers
-      val seenNames = scala.collection.mutable.Set.from(ownMembers.iterator.map(_.name))
-      val inheritedFields = UntypedType
+      // [hearth#327] The genuine PUBLIC accessors inherited from parent CLASSES (candidates, closest class first).
+      val inheritedPublicFieldCandidates = UntypedType
         .baseClasses(instanceTpe)
         .iterator
         .flatMap(_.typeSymbol.fieldMembers)
-        .filter(f =>
-          !f.isNoSymbol && !f.flags.is(Flags.Private) && !f.flags.is(Flags.Synthetic) && seenNames.add(f.name)
-        )
+        .filter(f => !f.isNoSymbol && !f.flags.is(Flags.Private) && !f.flags.is(Flags.Synthetic))
         .toList
+      val inheritedPublicFieldNames = inheritedPublicFieldCandidates.iterator.map(_.name).toSet
+      // [hearth#327] When a subclass re-takes a constructor param and only passes it to `super` (e.g. `class
+      // IdStatusEntity(id: Long, ...) extends AbstractIdStatusEntity(id, ...)`), Scala 3 keeps it as a `private[this]`
+      // `ParamAccessor` field. Such a field would `seenNames`-shadow the genuine PUBLIC inherited accessor of the same
+      // name, leaving the listing with an unavailable, "declared" member (isAvailable=false, isInherited=false). Drop it
+      // ONLY in that shadowing case — a private param-accessor that is NOT hiding an inherited accessor (an ordinary
+      // constructor argument) must still be listed. Scala 2 never retains these, so this also aligns the platforms.
+      def shadowsInheritedAccessor(f: Symbol): Boolean =
+        f.flags.is(Flags.ParamAccessor) && f.flags.is(Flags.Private) && inheritedPublicFieldNames(f.name)
+      val ownMembers = symbol.methodMembers ++ symbol.fieldMembers.filterNot(shadowsInheritedAccessor)
+      val seenNames = scala.collection.mutable.Set.from(ownMembers.iterator.map(_.name))
+      val inheritedFields = inheritedPublicFieldCandidates.filter(f => seenNames.add(f.name))
       // Defined in the type or its parent, or synthetic
       val classMembers = ownMembers ++ inheritedFields
       // Defined exatcly in the type

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -217,8 +217,22 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
         case _         => false
       }
 
+    // [hearth#315] The symbol to classify a type by. For an `export`-created alias of a real CLASS (e.g.
+    // `export Inner.Foo`) the alias's own `typeSymbol` carries none of the class flags, so resolve through to the
+    // underlying class. But ONLY when the dealiased symbol is a non-module class: this leaves aliases of OBJECTS (e.g.
+    // `type EmptyTuple = EmptyTuple.type`, whose dealias is a module class and must stay `isClass=false`/non-final),
+    // direct object types (e.g. an `Enumeration` object, which classify as before), and ordinary aliases untouched —
+    // the change is purely additive (it only lets an export alias of a class see its class's flags).
+    private def classificationSymbol(instanceTpe: UntypedType): Symbol = {
+      val orig = instanceTpe.typeSymbol
+      val dealiased = instanceTpe.dealias.typeSymbol
+      if dealiased != orig && !dealiased.isNoSymbol && dealiased.isClassDef && !dealiased.flags.is(Flags.Module)
+      then dealiased
+      else orig
+    }
+
     override def isAbstract(instanceTpe: UntypedType): Boolean = {
-      val A = instanceTpe.typeSymbol
+      val A = classificationSymbol(instanceTpe)
       // We use =:= to check whether A is known to be exactly of the built-in type or is it some upper bound.
       // Also exclude enumeration Value types (they're not abstract)
       !A.isNoSymbol && (A.flags.is(Flags.Abstract) || A.flags.is(Flags.Trait)) &&
@@ -246,7 +260,7 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
       }
 
     override def isFinal(instanceTpe: UntypedType): Boolean = {
-      val A = instanceTpe.typeSymbol
+      val A = classificationSymbol(instanceTpe) // resolve `export`-created aliases of classes, see #315
       // String is not being detected as a final in Scala 3, so we need to check it manually.
       // TODO: check if it's not a general issue with Java classes in Scala 3
       !A.isNoSymbol && ((A.flags.is(Flags.Final) || instanceTpe.asTyped[Any] <:< Type.of[String]) || isArray(
@@ -255,12 +269,12 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
     }
 
     override def isTrait(instanceTpe: UntypedType): Boolean = {
-      val A = instanceTpe.typeSymbol
+      val A = classificationSymbol(instanceTpe) // resolve `export`-created aliases of classes, see #315
       !A.isNoSymbol && A.flags.is(Flags.Trait)
     }
 
     override def isClass(instanceTpe: UntypedType): Boolean = {
-      val A = instanceTpe.typeSymbol
+      val A = classificationSymbol(instanceTpe) // resolve `export`-created aliases of classes, see #315
       // String is not being detected as a class in Scala 3, so we need to check it manually.
       // TODO: check if it's not a general issue with Java classes in Scala 3
       !A.isNoSymbol && ((A.isClassDef || instanceTpe.asTyped[Any] <:< Type.of[String]) && !isArray(
@@ -269,7 +283,7 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
     }
 
     override def isSealed(instanceTpe: UntypedType): Boolean = {
-      val A = instanceTpe.typeSymbol
+      val A = classificationSymbol(instanceTpe) // resolve `export`-created aliases of classes, see #315
       !A.isNoSymbol && A.flags.is(Flags.Sealed)
     }
     override def isJavaEnum(instanceTpe: UntypedType): Boolean = {
@@ -340,7 +354,9 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
       // type symbol (no Case flag) while the `Case|Enum|StableRealizable` flags live on the TERM symbol - so we have to
       // inspect both, mirroring `isVal`. See issue #311.
       def hasCase(sym: Symbol): Boolean = !sym.isNoSymbol && sym.flags.is(Flags.Case)
-      hasCase(instanceTpe.typeSymbol) || hasCase(instanceTpe.termSymbol)
+      // Resolve `export`-created aliases of case classes (identity for non-alias/object types); the term symbol still
+      // carries the `Case` flag for parameterless enum cases / case objects. See #315 and #311.
+      hasCase(classificationSymbol(instanceTpe)) || hasCase(instanceTpe.termSymbol)
     }
     override def isObject(instanceTpe: UntypedType): Boolean = {
       val A = instanceTpe.typeSymbol

--- a/project/CrossQuotesMacrosGen.scala
+++ b/project/CrossQuotesMacrosGen.scala
@@ -402,14 +402,18 @@ object CrossQuotesMacrosGen {
     // Cast to `Type[U_i]` (the UPPER bound), not `Type[scala.Any]`: `as_<:??<:[L, U]` on a `Type[A]` requires `U >: A`,
     // so a `Type[scala.Any]` receiver would force `U >: Any` and reject any non-`Any` upper bound. For an unbounded
     // ctor `U_i` is `Any`, so this is unchanged there; for a bounded ctor it makes `U >: U` hold trivially. See #307.
+    //
+    // [hearth#307] `dealias` the extracted argument but do NOT `widen` it: widening decays a literal singleton
+    // (`ConstantType`, e.g. the `"fieldName"` in `Path.Select["fieldName", _]`) to `java.lang.String`, and a
+    // term singleton (`x.type`) to its widened type — an extractor must hand back the argument as written.
     if (n == 1) {
-      val expr = s"$$ctx.WeakTypeTag(tp1.dealias.widen).asInstanceOf[Type[$$${ArityGen.upper(1)}]].as_<:??<:[$$${ArityGen.lower(1)}, $$${ArityGen.upper(1)}]"
+      val expr = s"$$ctx.WeakTypeTag(tp1.dealias).asInstanceOf[Type[$$${ArityGen.upper(1)}]].as_<:??<:[$$${ArityGen.lower(1)}, $$${ArityGen.upper(1)}]"
       s"${indent}_root_.scala.Some($expr)\n"
     } else {
       val sb = new StringBuilder
       sb ++= s"${indent}_root_.scala.Some((\n"
       for (i <- 1 to n) {
-        val expr = s"$$ctx.WeakTypeTag(tp$i.dealias.widen).asInstanceOf[Type[$$${ArityGen.upper(i)}]].as_<:??<:[$$${ArityGen.lower(i)}, $$${ArityGen.upper(i)}]"
+        val expr = s"$$ctx.WeakTypeTag(tp$i.dealias).asInstanceOf[Type[$$${ArityGen.upper(i)}]].as_<:??<:[$$${ArityGen.lower(i)}, $$${ArityGen.upper(i)}]"
         if (i < n) sb ++= s"$exprIndent$expr,\n"
         else sb ++= s"$exprIndent$expr\n"
       }


### PR DESCRIPTION
Round-2 fixes for three issues that were closed in the first sweep but whose fixes turned out **incomplete** — verified against `0.4.0-9-g8153a5e-SNAPSHOT` from the Chimney migration, where each shim had to go back in. Each fix has a regression test verified to fail without it.

## #307 — Scala 2 `Type.CtorN` codegen decays literal type args
The generated `matchResult` called `.dealias.widen` on every **extracted** type argument. `widen` decays a literal singleton (`ConstantType`, e.g. the `"fieldName"` in Chimney's `Path.Select["fieldName", _]`) to `java.lang.String`, so `unapply` returned the wrong type and config parsing aborted with `Invalid string literal type: java.lang.String`.

**Fix:** `dealias` the extracted args (resolve aliases) but do **not** `widen` them — an extractor returns the argument as written. (`A0.dealias.widen`, which finds the scrutinee's base type, is unchanged.)
**Test:** `CrossTypesSpec` unapplies `Arity1["fieldName"]` / `Arity2["fieldName", Int]` and checks the literal survives.

## #315 — export-alias flag checks read the alias symbol (Scala 3)
Batch 1 dealiased the ctor lookups, but `isClass`/`isAbstract`/`isTrait`/`isFinal`/`isSealed`/`isCase` still read the alias `typeSymbol`, so `Type[Exported.Foo].isClass` (where `object Exported { export Inner.Foo }`) stayed `false` and Chimney's `isPOJO` rejected it.

**Fix:** a shared `classificationSymbol` that resolves through an alias **only when it dealiases to a non-module class** (an export alias of a real class); aliases of objects (`EmptyTuple`), direct object types (`Enumeration` objects) and ordinary types are untouched — purely additive.
**Test:** `TypesScala3Spec` asserts `testFlags[Exported.Foo]` equals `testFlags[Inner.Foo]`.

## #327 — inherited constructor-val fields have wrong metadata (Scala 3)
Batch 1 surfaced inherited `val` fields, but when a subclass re-takes an inherited val as a constructor param passed to `super`, Scala 3 keeps a `private[this]` `ParamAccessor` field that shadowed the parent's public accessor — so `id`/`status` reported `isAvailable=false`, `isInherited=false` and Chimney dropped them.

**Fix:** drop a private param-accessor field **only when it shadows a public inherited accessor** of the same name (an ordinary constructor arg shadowing nothing stays listed); the genuine inherited public accessor then surfaces with `isAvailable=true`/`isInherited=true`.
**Test:** `MethodsScala3Spec` checks `id`/`status` on `IdStatusEntity` are available, inherited accessors.

## Verification
`quick-clean ; quick-test` green on 2.13.16 + 3.3.8 (1166 + 1297 + sandwich). MiMa and scalafmt clean. Changes are internal / test-only — no public API break.