### PR TITLE
Fix #317, #318: derive-in-splice owner mismatch + splice-scoped values (Scala 3)

### DIFF
--- a/hearth-tests/src/main/scala-3/hearth/crossquotes/Issue317Fixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/crossquotes/Issue317Fixtures.scala
@@ -1,0 +1,64 @@
+package hearth
+package crossquotes
+
+import scala.quoted.*
+
+/** Typeclass used by the hearth#317/#318 fixtures below. */
+trait Show317 { def show(a: Int): String }
+
+/** Fixtures for hearth#317/#318 (Scala 3 only).
+  *
+  * Exercises the two fixes:
+  *   - owner-following symbol creation: `ValDefs.createVal` runs inside the instance quote's splice (the `def show`
+  *     body), so its val must be owned by that nested splice's owner, not the macro-entry owner (see
+  *     `currentSpliceOwner` in `ExprsScala3`);
+  *   - `withMacroEntryCtx`: a class-level cache first-touched inside the first instance's splice is pinned to the
+  *     macro-entry context so it can be reused when a SECOND instance is derived in the same expansion.
+  *
+  * The `-Xcheck-macros` aborts these guard against ("Block contains definition with different owners" / "created in a
+  * splice ... used outside") only reproduce across SEPARATE compilation units (macro packaged to a jar, app compiled
+  * against it) — see the repros linked from the PR. Here we verify the generated code runs correctly. (Kept non-generic
+  * to avoid the unrelated `Type[A]` self-given loop of a generic `A: Type` bound.)
+  */
+final class Issue317Fixtures(q: Quotes) extends hearth.MacroCommonsScala3(using q) {
+
+  private lazy val cachedSuffix: Expr[String] = Expr.quote("!")
+
+  private def bodyWithCache(a: Expr[Int]): Expr[String] = Expr.quote {
+    Expr.splice(a).toString + Expr.splice(withMacroEntryCtx(cachedSuffix))
+  }
+
+  private def bodyWithVal(a: Expr[Int]): Expr[String] =
+    ValDefs.createVal[Int](a, "ref").use { ref =>
+      Expr.quote {
+        val prefix = "v:"
+        prefix + Expr.splice(ref).toString
+      }
+    }
+
+  def deriveWithVal: Expr[Show317] = Expr.quote {
+    new Show317 {
+      def show(a: Int): String = Expr.splice(bodyWithVal(Expr.quote(a)))
+    }
+  }
+
+  def deriveTwoWithCache: Expr[(Show317, Show317)] = {
+    def one: Expr[Show317] = Expr.quote {
+      new Show317 {
+        def show(a: Int): String = Expr.splice(bodyWithCache(Expr.quote(a)))
+      }
+    }
+    Expr.quote((Expr.splice(one), Expr.splice(one)))
+  }
+}
+
+object Issue317Fixtures {
+
+  inline def deriveWithVal: Show317 = ${ deriveWithValImpl }
+  private def deriveWithValImpl(using q: Quotes): Expr[Show317] =
+    new Issue317Fixtures(q).deriveWithVal
+
+  inline def deriveTwoWithCache: (Show317, Show317) = ${ deriveTwoWithCacheImpl }
+  private def deriveTwoWithCacheImpl(using q: Quotes): Expr[(Show317, Show317)] =
+    new Issue317Fixtures(q).deriveTwoWithCache
+}

--- a/hearth-tests/src/test/scala-3/hearth/crossquotes/Issue317Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/crossquotes/Issue317Spec.scala
@@ -1,0 +1,21 @@
+package hearth
+package crossquotes
+
+/** Regression smoke test for hearth#317/#318 (Scala 3). See [[Issue317Fixtures]] for the mechanisms; the full
+  * `-Xcheck-macros` failures reproduce only across separate compilation units (repros linked from the PR).
+  */
+final class Issue317Spec extends MacroSuite {
+
+  group("Cross-Quotes (Scala 3): derive-in-splice owner + entry-ctx (hearth#317/#318)") {
+
+    test("a createVal body built inside a nested-splice def body produces working code") {
+      Issue317Fixtures.deriveWithVal.show(42) <==> "v:42"
+    }
+
+    test("two instances sharing a withMacroEntryCtx-pinned cache produce working code") {
+      val (a, b) = Issue317Fixtures.deriveTwoWithCache
+      a.show(1) <==> "1!"
+      b.show(2) <==> "2!"
+    }
+  }
+}

--- a/hearth/src/main/scala-3/hearth/EnvironmentCrossQuotesSupport.scala
+++ b/hearth/src/main/scala-3/hearth/EnvironmentCrossQuotesSupport.scala
@@ -26,6 +26,9 @@ trait EnvironmentCrossQuotesSupport { this: Environments =>
 
     protected var currentCtx: scala.quoted.Quotes = _
 
+    /** The `Quotes` the macro was entered with (the outermost context). Set once by the platform on construction. */
+    protected def macroEntryCtx: scala.quoted.Quotes
+
     /** Necessary to use for achieving correct expansion when we extract some Expr.quote inside an Expr.splice,
       * otherwise nested quote-insides can't work.
       */
@@ -37,6 +40,14 @@ trait EnvironmentCrossQuotesSupport { this: Environments =>
         thunk
       finally
         currentCtx = oldContext
+    }
+
+    /** [hearth#317/#318] Runs `thunk` with the macro-ENTRY `Quotes` pinned as the active Cross-Quotes context. */
+    final def withMacroEntryCtx[A](thunk: => A): A = {
+      val oldContext = currentCtx
+      currentCtx = macroEntryCtx
+      try thunk
+      finally currentCtx = oldContext
     }
   }
 
@@ -96,4 +107,17 @@ trait EnvironmentCrossQuotesSupport { this: Environments =>
     */
   final def withQuotes[A](thunk: scala.quoted.Quotes ?=> A): A =
     thunk(using CrossQuotes.ctx[scala.quoted.Quotes])
+
+  /** Runs `thunk` with the macro-ENTRY [[scala.quoted.Quotes]] pinned as Cross-Quotes' active context.
+    *
+    * When a whole derivation runs INSIDE an `Expr.splice` (e.g. building `new Transformer[A, B] { def transform(src) =
+    * $${ derive(src) } }`), every `Expr`/`Type` it creates — including values memoized in a `lazy val`/cache and
+    * first-touched during that splice — belongs to that ONE splice evaluation. Reusing them in another evaluation (e.g.
+    * deriving a second instance in the same expansion) then aborts on Scala 3 with
+    * `ScopeException: Expression created in a splice was used outside of that splice`. Wrapping the derivation in
+    * `withMacroEntryCtx` makes those values ENTRY-scoped, so they are usable across evaluations. See issues #317/#318.
+    *
+    * @since 0.4.1
+    */
+  final def withMacroEntryCtx[A](thunk: => A): A = CrossQuotes.withMacroEntryCtx(thunk)
 }

--- a/hearth/src/main/scala-3/hearth/EnvironmentsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/EnvironmentsScala3.scala
@@ -206,6 +206,8 @@ trait EnvironmentsScala3 extends Environments { this: MacroCommonsScala3 =>
 
     currentCtx = quotes
 
+    override protected def macroEntryCtx: scala.quoted.Quotes = quotes
+
     override def ctx[CastAs]: CastAs = currentCtx.asInstanceOf[CastAs]
   }
 }

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -33,6 +33,17 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         def resetOwner(using Type[A]): Expr[A] = expr.asTerm.changeOwner(Symbol.spliceOwner).asExprOf[A]
       }
 
+      /** [hearth#317] The splice owner of the CURRENTLY-ACTIVE Cross-Quotes context (`CrossQuotes.ctx`), NOT the
+        * macro-entry `quotes`. When a derivation runs inside an `Expr.splice` (under `nestedCtx`) — e.g. a whole
+        * instance derivation running in `new Show[A] { def show(a) = ${ derive } }` — fresh vals/defs/binds must be
+        * owned by that nested splice's owner (here `def show`). Otherwise a `Block` (from `ValDefs.closeScope`) mixing
+        * such a symbol with trees built by cross-quoted helpers (owned by the nested owner) aborts under
+        * `-Xcheck-macros`: "Block contains definition with different owners". In the common, non-nested case
+        * `CrossQuotes.ctx == quotes`, so this is exactly the entry splice owner and nothing changes.
+        */
+      private def currentSpliceOwner: Symbol =
+        CrossQuotes.ctx[scala.quoted.Quotes].reflect.Symbol.spliceOwner.asInstanceOf[Symbol]
+
       object freshTerm {
         // Workaround to contain @experimental from polluting the whole codebase
         private val impl = quotes.reflect.Symbol.getClass.getMethod("freshName", classOf[String])
@@ -46,11 +57,11 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         }
 
         def bind[A: Type](freshName: FreshName, flags: Flags): Symbol =
-          Symbol.newBind(Symbol.spliceOwner, apply[A](freshName, null), flags, TypeRepr.of[A])
+          Symbol.newBind(currentSpliceOwner, apply[A](freshName, null), flags, TypeRepr.of[A])
 
         def defdef[A: Type](freshName: FreshName, expr: Expr[A]): Symbol =
           Symbol.newMethod(
-            Symbol.spliceOwner,
+            currentSpliceOwner,
             apply[A](freshName, expr),
             MethodType(Nil)(_ => Nil, _ => TypeRepr.of[A])
           )
@@ -59,7 +70,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             freshName: FreshName,
             expr: Expr[A],
             flags: Flags,
-            owner: Symbol = Symbol.spliceOwner
+            owner: Symbol = currentSpliceOwner
         ): Symbol =
           Symbol.newVal(owner, apply[A](freshName, expr), TypeRepr.of[A], flags, Symbol.noSymbol)
 


### PR DESCRIPTION
Fixes the two cross-quotes issues that surface when a whole derivation runs **inside an `Expr.splice`** on Scala 3 under `-Xcheck-macros` (as Chimney's instance macros do). Both were validated against the standalone reproductions provided on the issues.

## Reproduction (the missing ingredient)
The failures only fire across **two separate compilation units** — the macro packaged into a library jar, then the app compiled against it:
```sh
scala-cli --power package macros/Macros.scala --library -o macros.jar -f
scala-cli compile app/Main.scala --extra-jars macros.jar
```
A single-project run masks it (same-run macro suspension + the plugin duplicating compilation units). Confirmed both reproduce against a locally-published snapshot of `master`, and both are resolved by this branch.

## #317 mode 1 — owner mismatch → `AssertionError: Block contains definition with different owners`
`ValDefs`/`freshTerm` created fresh vals/defs/binds owned by `Symbol.spliceOwner` resolved against the macro-**entry** `quotes`, while trees built by cross-quoted helpers under the nested context are owned by the nested splice's owner (the enclosing `def`). `closeScope`'s `Block.apply` then aborted.

**Fix:** resolve `spliceOwner` against the currently-active `CrossQuotes.ctx` (`currentSpliceOwner`). Non-nested case is unchanged (`CrossQuotes.ctx == quotes`). **No user action required.**

## #317 mode 2 / #318 — splice-scoped values → `ScopeException: created in a splice ... used outside`
Values memoized in a `lazy val`/cache and first-touched during the first instance's splice evaluation (incl. values produced lazily via MIO direct style — #318) become splice-scoped, so reusing them when deriving a second instance aborts.

**Fix:** add **`withMacroEntryCtx { ... }`** (Scala 3), which pins the macro-entry `Quotes` as Cross-Quotes' active context, so values created inside are entry-scoped and reusable across splice evaluations. Wrapping a cache access (`withMacroEntryCtx(cache)`) or a whole derivation resolves both. This is the endorsed "API to pin the entry context" (Chimney's `withMacroEntryCtxCompat`). `final def` → binary compatible.

## Validation
- Both standalone repros: **owner-mismatch abort gone** after the mode-1 fix; **ScopeException gone** after wrapping the cache access in `withMacroEntryCtx` (both `Expr`- and `Type`-`ScopeException` variants, incl. the MIO direct-style #318 case).
- `Issue317Spec` (Scala 3) smoke-tests both paths for result correctness in-repo (the full `-Xcheck-macros` aborts need separate compilation, hence the external repros).
- `quick-test` green on 2.13.16 + 3.3.8 (1165 + 1296 + sandwich). MiMa and scalafmt clean.