### PR TITLE
Fix #331: keep value/implicit clauses that follow a type-parameter clause in Method.fold

### DIFF
--- a/hearth-better-printers/src/main/scala-2/hearth/treeprinter/ShowCodePrettyScala2.scala
+++ b/hearth-better-printers/src/main/scala-2/hearth/treeprinter/ShowCodePrettyScala2.scala
@@ -1167,7 +1167,12 @@ trait ShowCodePrettyScala2 {
           val weShouldSkipThisType = sym.isDeferred
           val preToUse = if (notRunnableExprResult && pre == NoPrefix) NoType else pre
 
-          printTypePrefix(preToUse, sym, printThisType = !weShouldSkipThisType)
+          // A free method type parameter (`def f[A](a: A)` reached as a standalone `A`, e.g. via `Method.fold` on a
+          // clause that follows the type-parameter clause) should print by its simple name — like a *bound* type
+          // parameter and like Scala 3 — not qualified by its enclosing class (`Owner.A`). See hearth#331.
+          val isMethodTypeParam =
+            sym.isType && sym.owner != null && sym.owner != NoSymbol && sym.owner.isMethod
+          if (!isMethodTypeParam) printTypePrefix(preToUse, sym, printThisType = !weShouldSkipThisType)
           printTypeNameFromSymbol(sym, isLastInChain)
           if (args.nonEmpty) {
             print("[")

--- a/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
@@ -10,6 +10,8 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
 
   // [hearth#176]
 
+  def testFoldSubstitutesTypeArgsImpl: c.Expr[Data] = testFoldSubstitutesTypeArgs
+
   def testConstructorsExtractionImpl[A: c.WeakTypeTag]: c.Expr[Data] =
     testConstructorsExtraction[A]
 
@@ -133,6 +135,8 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
 }
 
 object MethodsFixtures {
+
+  def testFoldSubstitutesTypeArgs: Data = macro MethodsFixtures.testFoldSubstitutesTypeArgsImpl
 
   def testConstructorsExtraction[A]: Data = macro MethodsFixtures.testConstructorsExtractionImpl[A]
 

--- a/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
@@ -9,6 +9,11 @@ final private class MethodsFixtures(q: Quotes) extends MacroCommonsScala3(using 
 
 object MethodsFixtures {
 
+  // [hearth#331]
+  inline def testFoldSubstitutesTypeArgs: Data = ${ testFoldSubstitutesTypeArgsImpl }
+  private def testFoldSubstitutesTypeArgsImpl(using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testFoldSubstitutesTypeArgs
+
   // [hearth#176]
 
   inline def testConstructorsExtraction[A]: Data = ${ testConstructorsExtractionImpl[A] }

--- a/hearth-tests/src/main/scala/hearth/examples/methods_overhaul.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/methods_overhaul.scala
@@ -54,6 +54,23 @@ class HigherKinded {
   def higherKinded[F[_]](a: F[String]): F[String] = a
 }
 
+// [hearth#331] a value/implicit clause that FOLLOWS a type-parameter clause: `Method.fold` used to hand `onValues`
+// an EMPTY clause here (the params were dropped), so there was no way to supply the `Sync[F]`.
+trait Sync[F[_]]
+class HigherKindedImplicit {
+  @scala.annotation.nowarn
+  def resource[F[_]](implicit ev: Sync[F]): F[Int] = null.asInstanceOf[F[Int]]
+  @scala.annotation.nowarn
+  def make[F[_]](config: String)(implicit ev: Sync[F]): F[Int] = null.asInstanceOf[F[Int]]
+}
+
+class ProperKindedImplicit {
+  // [hearth#331] value + implicit clauses that follow a `[T]` clause; used to check that applying `T := Int` in
+  // `onTypes` substitutes into the subsequent clauses (`(t: T)(implicit ord: Ordering[T])`).
+  @scala.annotation.nowarn
+  def pick[T](t: T)(implicit ord: Ordering[T]): T = t
+}
+
 class WithImplicitParam {
   @scala.annotation.nowarn
   def withImplicit(a: Int)(implicit b: String): String = s"$a $b"

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -485,6 +485,41 @@ trait MethodsFixturesImpl { this: MacroCommons =>
     }
   }
 
+  // [hearth#331] The applied type arguments must be SUBSTITUTED into a value/implicit clause that follows the
+  // type-parameter clause: applying `T := Int` to `pick[T](t: T)(implicit ord: Ordering[T])` should present
+  // `t: scala.Int` and `ord: scala.math.Ordering[scala.Int]` to `onValues` (not the abstract `T`/`Ordering[T]`).
+  def testFoldSubstitutesTypeArgs: Expr[Data] = {
+    implicit val IntType: Type[Int] = this.IntType
+    implicit val instanceType: Type[examples.methods.ProperKindedImplicit] =
+      Type.of[examples.methods.ProperKindedImplicit]
+    val method = Type[examples.methods.ProperKindedImplicit].methods
+      .find(_.name == "pick")
+      .getOrElse(Environment.reportErrorAndAbort("method `pick` not found"))
+    val captured = scala.collection.mutable.ListBuffer.empty[String]
+    val result = method.fold(
+      onInstance = _ => Expr.quote(new examples.methods.ProperKindedImplicit).as_??,
+      onTypes = at => at.typeParams.flatten.map(tp => tp -> Type.of[Int].as_??).toMap,
+      onValues = av =>
+        av.parameters.flatten.map { case (n, p) =>
+          captured += s"$n: ${p.tpe.plainPrint}"
+          import p.tpe.Underlying
+          val value: Expr_?? =
+            if (Underlying <:< Type.of[Int]) Expr(0).as_??
+            else
+              Expr
+                .summonImplicitByType(p.tpe.asUntyped)
+                .map(UntypedExpr.as_??(_))
+                .getOrElse(Environment.reportErrorAndAbort(s"cannot summon ${p.tpe.plainPrint}"))
+          n -> value
+        }.toMap
+    )
+    val built = result match {
+      case Right(_)    => "built"
+      case Left(error) => s"FAILED: $error"
+    }
+    Expr(Data.map("params" -> Data.list(captured.toList.map(Data(_))*), "result" -> Data(built)))
+  }
+
   def testCallConstructorViaFold[A: Type](params: VarArgs[Int]): Expr[Data] = {
     implicit val IntType: Type[Int] = this.IntType
     implicit val StringType: Type[String] = this.StringType

--- a/hearth-tests/src/test/scala-newest-3/hearth/typed/MethodsScala3NewestSpec.scala
+++ b/hearth-tests/src/test/scala-newest-3/hearth/typed/MethodsScala3NewestSpec.scala
@@ -107,9 +107,9 @@ final class MethodsScala3NewestSpec extends MacroSuite {
               "expectations" -> Data.list(
                 Data("NeedsInstance"),
                 Data("NeedsTypes[A]"),
-                Data("NeedsValues()"),
+                Data("NeedsValues(a: A)"),
                 Data("NeedsTypes[B]"),
-                Data("NeedsValues()")
+                Data("NeedsValues(b: B)")
               ),
               "knownReturning" -> Data("<none>"),
               "toString" -> Data(

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -2083,7 +2083,7 @@ final class MethodsSpec extends MacroSuite {
               "expectations" -> Data.list(
                 Data("NeedsInstance"),
                 Data("NeedsTypes[A]"),
-                Data("NeedsValues()")
+                Data("NeedsValues(a: A)")
               ),
               "knownReturning" -> Data("<none>"),
               "toString" -> Data(
@@ -2233,7 +2233,7 @@ final class MethodsSpec extends MacroSuite {
           Data.list(
             Data.map(
               "name" -> Data("parametric2"),
-              "expectations" -> Data.list(Data("NeedsInstance"), Data("NeedsTypes[A]"), Data("NeedsValues()")),
+              "expectations" -> Data.list(Data("NeedsInstance"), Data("NeedsTypes[A]"), Data("NeedsValues(a: A)")),
               "knownReturning" -> Data("<none>"),
               "toString" -> Data(
                 "hearth.examples.methods.Parametric: def parametric2[A]" +
@@ -2252,7 +2252,7 @@ final class MethodsSpec extends MacroSuite {
               "expectations" -> Data.list(
                 Data("NeedsInstance"),
                 Data("NeedsTypes[A <: java.lang.Comparable[A]]"),
-                Data("NeedsValues()")
+                Data("NeedsValues(a: A)")
               ),
               "knownReturning" -> Data("<none>"),
               "toString" -> Data(
@@ -2308,7 +2308,7 @@ final class MethodsSpec extends MacroSuite {
               "expectations" -> Data.list(
                 Data("NeedsInstance"),
                 Data("NeedsTypes[F]"),
-                Data("NeedsValues()")
+                Data("NeedsValues(a: F[java.lang.String])")
               ),
               "knownReturning" -> Data("<none>"),
               "toString" -> Data(
@@ -2338,9 +2338,60 @@ final class MethodsSpec extends MacroSuite {
             )
           )
       }
+
+      // [hearth#331] An implicit clause that FOLLOWS a type-parameter clause used to be dropped (`NeedsValues()`),
+      // so there was no way to supply the `Sync[F]`. It is now surfaced with the method's type parameter abstract.
+      test("resource[F[_]](implicit ev: Sync[F]): F[Int] — implicit clause after a type-param clause is kept") {
+        MethodsFixtures.testMethodExpectations[examples.methods.HigherKindedImplicit]("resource") <==>
+          Data.list(
+            Data.map(
+              "name" -> Data("resource"),
+              "expectations" -> Data.list(
+                Data("NeedsInstance"),
+                Data("NeedsTypes[F]"),
+                Data("NeedsValues(ev: hearth.examples.methods.Sync[F])")
+              ),
+              "knownReturning" -> Data("<none>"),
+              "toString" -> Data(
+                "hearth.examples.methods.HigherKindedImplicit: def resource[F](ev: hearth.examples.methods.Sync[F]): F[scala.Int]"
+              )
+            )
+          )
+      }
+
+      test(
+        "make[F[_]](config: String)(implicit ev: Sync[F]): F[Int] — value + implicit clause after a type-param clause"
+      ) {
+        MethodsFixtures.testMethodExpectations[examples.methods.HigherKindedImplicit]("make") <==>
+          Data.list(
+            Data.map(
+              "name" -> Data("make"),
+              "expectations" -> Data.list(
+                Data("NeedsInstance"),
+                Data("NeedsTypes[F]"),
+                Data("NeedsValues(config: java.lang.String)(ev: hearth.examples.methods.Sync[F])")
+              ),
+              "knownReturning" -> Data("<none>"),
+              "toString" -> Data(
+                "hearth.examples.methods.HigherKindedImplicit: def make[F](config: java.lang.String)(ev: hearth.examples.methods.Sync[F]): F[scala.Int]"
+              )
+            )
+          )
+      }
     }
 
     group("method calling via fold") {
+
+      // [hearth#331] applying `T := Int` in `onTypes` substitutes into the value/implicit clauses that follow.
+      test("fold substitutes applied type arguments into a following value/implicit clause") {
+        MethodsFixtures.testFoldSubstitutesTypeArgs <==> Data.map(
+          "params" -> Data.list(
+            Data("t: scala.Int"),
+            Data("ord: scala.math.Ordering[scala.Int]")
+          ),
+          "result" -> Data("built")
+        )
+      }
 
       test("nullary — nullaryNoParamList returns 42") {
         MethodsFixtures.testCallInstanceViaFold(new examples.methods.NullaryMethods)("nullaryNoParamList")() <==>

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
@@ -496,22 +496,59 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
 
       val untypedExpectations = untyped.methodExpectations(instanceTpe)
 
-      var seenTypeParams = false
-      val typedExpectations: List[MethodExpectation] = untypedExpectations.map {
-        case UntypedMethodExpectation.NeedsInstance   => MethodExpectation.NeedsInstance
-        case UntypedMethodExpectation.NeedsTypes(utp) =>
-          seenTypeParams = true
-          MethodExpectation.NeedsTypes(utp.map(_.map { sym =>
-            new TypeParameter(
-              asUntyped = sym,
-              upperBound = UntypedTypeParameter.upperBound(sym).as_??,
-              lowerBound = UntypedTypeParameter.lowerBound(sym).as_??
-            )
-          }))
-        case UntypedMethodExpectation.NeedsValues(up) =>
-          if (seenTypeParams) MethodExpectation.NeedsValues(List.empty)
-          else MethodExpectation.NeedsValues(up.asTyped[Instance])
+      // [hearth#331] A value/implicit clause that FOLLOWS a type-parameter clause references the method's own type
+      // parameters (`(implicit ev: Sync[F])`); resolving it against `Instance` conflates method and class type
+      // parameters, so it used to be dropped to `List.empty`. Instead read the parameter types straight from the
+      // member signature (class type parameters resolved as-seen-from `Instance`, method type parameters left
+      // abstract) and substitute the applied type arguments — abstract before `onTypes`, concrete after.
+      val methodTypeParamSyms: List[Symbol] = untyped.typeParameters.flatten
+      lazy val rawParamTypesByName: Map[String, c.universe.Type] = {
+        def collect(tpe: c.universe.Type): Map[String, c.universe.Type] = tpe match {
+          case MethodType(params, res) => params.map(p => symbolName(p) -> p.typeSignature).toMap ++ collect(res)
+          case NullaryMethodType(res)  => collect(res)
+          case PolyType(_, res)        => collect(res)
+          case _                       => Map.empty
+        }
+        collect(untyped.symbol.typeSignatureIn(instanceTpe))
       }
+      def resolveTypeParamClauseValues(up: UntypedParameters, typeArgs: UntypedTypeArguments): Parameters = {
+        // Unapplied method type parameters are kept abstract as a BARE `NoPrefix` ref: `internal.typeRef(NoPrefix, ...)`
+        // both avoids eta-applying a higher-kinded param (`tp.asType.toType` would turn `F` into `F[_$1]`) and prints
+        // without an owner prefix (`A`, not `Owner.A`), matching Scala 3's rendering.
+        val toReprs = methodTypeParamSyms.map(tp =>
+          typeArgs.get(tp).fold(internal.typeRef(NoPrefix, tp, Nil))(_.Underlying.asUntyped)
+        )
+        up.map(_.flatMap { case (name, param) =>
+          rawParamTypesByName.get(name).map { raw =>
+            val substituted =
+              if (methodTypeParamSyms.isEmpty) raw else raw.substituteTypes(methodTypeParamSyms, toReprs)
+            name -> new Parameter(
+              asUntyped = param,
+              untypedInstanceType = instanceTpe,
+              tpe = normalizeRepeatedParamType(substituted).as_??
+            )
+          }
+        })
+      }
+      def resolveExpectations(typeArgs: UntypedTypeArguments): List[MethodExpectation] = {
+        var seenTypeParams = false
+        untypedExpectations.map {
+          case UntypedMethodExpectation.NeedsInstance   => MethodExpectation.NeedsInstance
+          case UntypedMethodExpectation.NeedsTypes(utp) =>
+            seenTypeParams = true
+            MethodExpectation.NeedsTypes(utp.map(_.map { sym =>
+              new TypeParameter(
+                asUntyped = sym,
+                upperBound = UntypedTypeParameter.upperBound(sym).as_??,
+                lowerBound = UntypedTypeParameter.lowerBound(sym).as_??
+              )
+            }))
+          case UntypedMethodExpectation.NeedsValues(up) =>
+            if (seenTypeParams) MethodExpectation.NeedsValues(resolveTypeParamClauseValues(up, typeArgs))
+            else MethodExpectation.NeedsValues(up.asTyped[Instance])
+        }
+      }
+      val typedExpectations: List[MethodExpectation] = resolveExpectations(Map.empty)
 
       val hasUnresolvedTypeParams = untyped.hasTypeParameters && !untyped.isConstructor
       val totalParams: Parameters =
@@ -542,7 +579,8 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
         totalParameters = totalParams,
         returnType = returnType,
         buildExpr = buildExpr,
-        pathDepResolvers = Map.empty
+        pathDepResolvers = Map.empty,
+        resolveExpectationsForTypeArgs = resolveExpectations
       )
     }
 

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -766,22 +766,67 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
 
       val untypedExpectations = untyped.methodExpectations(instanceTpe)
 
-      var seenTypeParams = false
-      val typedExpectations: List[MethodExpectation] = untypedExpectations.map {
-        case UntypedMethodExpectation.NeedsInstance   => MethodExpectation.NeedsInstance
-        case UntypedMethodExpectation.NeedsTypes(utp) =>
-          seenTypeParams = true
-          MethodExpectation.NeedsTypes(utp.map(_.map { sym =>
-            new TypeParameter(
-              asUntyped = sym,
-              upperBound = UntypedTypeParameter.upperBound(sym).as_??,
-              lowerBound = UntypedTypeParameter.lowerBound(sym).as_??
+      // [hearth#331] A value/implicit clause that FOLLOWS a type-parameter clause references the method's own type
+      // parameters (`(implicit ev: Sync[F])`). `up.asTyped[Instance]` cannot resolve those against `Instance` (it
+      // conflates method and class type parameters and can even crash), so historically the clause was dropped to
+      // `List.empty`. Instead we read the parameter types straight from the member signature (class type parameters
+      // already resolved as-seen-from `Instance`, method type parameters left abstract) and substitute the applied
+      // type arguments for the method's type parameters — abstract when none are applied yet, concrete after `onTypes`.
+      val methodTypeParamSyms: List[Symbol] = untyped.typeParameters.flatten
+      // Resolve parameter types with the method's own type parameters instantiated to `typeArgs` — applied arguments
+      // become concrete, un-applied ones become the type parameter's own (bare) ref. We `appliedTo` the member
+      // `PolyType` rather than `substituteTypes` on its inner `MethodType`, because the parameter types reference the
+      // type parameters as PolyType-BOUND refs, which `substituteTypes(symbols, …)` would not touch.
+      def resolvedParamTypesByName(typeArgs: UntypedTypeArguments): Map[String, TypeRepr] = {
+        def collect(tpe: TypeRepr): Map[String, TypeRepr] = tpe match {
+          case mt: MethodType => mt.paramNames.zip(mt.paramTypes).toMap ++ collect(mt.resType)
+          case pt: PolyType   => collect(pt.resType)
+          case _              => Map.empty
+        }
+        // When nothing is applied yet, keep the `PolyType` untouched: its BOUND parameter refs print bare (`A`, `F`),
+        // matching Scala 2. Only instantiate once there are real arguments (then the applied slots become concrete).
+        val applied = safeMemberType(instanceTpe, untyped.symbol) match {
+          case pt: PolyType if methodTypeParamSyms.nonEmpty && typeArgs.nonEmpty =>
+            pt.appliedTo(
+              methodTypeParamSyms.map(tp => typeArgs.get(tp).fold(tp.typeRef: TypeRepr)(_.Underlying.asUntyped))
             )
-          }))
-        case UntypedMethodExpectation.NeedsValues(up) =>
-          if seenTypeParams then MethodExpectation.NeedsValues(List.empty)
-          else MethodExpectation.NeedsValues(up.asTyped[Instance])
+          case other => other
+        }
+        collect(applied)
       }
+      def resolveTypeParamClauseValues(up: UntypedParameters, typeArgs: UntypedTypeArguments): Parameters = {
+        val byName = resolvedParamTypesByName(typeArgs)
+        up.map(_.flatMap { case (name, param) =>
+          byName.get(name).map { tpe =>
+            name -> Parameter(
+              asUntyped = param,
+              untypedInstanceType = instanceTpe,
+              tpe = normalizeRepeatedParamType(tpe).as_??
+            )
+          }
+        })
+      }
+
+      def resolveExpectations(typeArgs: UntypedTypeArguments): List[MethodExpectation] = {
+        var seenTypeParams = false
+        untypedExpectations.map {
+          case UntypedMethodExpectation.NeedsInstance   => MethodExpectation.NeedsInstance
+          case UntypedMethodExpectation.NeedsTypes(utp) =>
+            seenTypeParams = true
+            MethodExpectation.NeedsTypes(utp.map(_.map { sym =>
+              new TypeParameter(
+                asUntyped = sym,
+                upperBound = UntypedTypeParameter.upperBound(sym).as_??,
+                lowerBound = UntypedTypeParameter.lowerBound(sym).as_??
+              )
+            }))
+          case UntypedMethodExpectation.NeedsValues(up) =>
+            if seenTypeParams then MethodExpectation.NeedsValues(resolveTypeParamClauseValues(up, typeArgs))
+            else MethodExpectation.NeedsValues(up.asTyped[Instance])
+        }
+      }
+
+      val typedExpectations: List[MethodExpectation] = resolveExpectations(Map.empty)
 
       val hasUnresolvedTypeParams = untyped.hasTypeParameters && !untyped.isConstructor
       val totalParams: Parameters =
@@ -814,7 +859,8 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
         totalParameters = totalParams,
         returnType = returnType,
         buildExpr = buildExpr,
-        pathDepResolvers = Map.empty
+        pathDepResolvers = Map.empty,
+        resolveExpectationsForTypeArgs = resolveExpectations
       )
     }
 

--- a/hearth/src/main/scala/hearth/typed/Methods.scala
+++ b/hearth/src/main/scala/hearth/typed/Methods.scala
@@ -406,7 +406,12 @@ trait Methods { this: MacroCommons =>
         totalParameters: Parameters,
         returnType: Option[??],
         buildExpr: (Option[UntypedExpr], UntypedTypeArguments, UntypedArguments) => Either[String, UntypedExpr],
-        pathDepResolvers: Map[Int, UntypedArguments => Parameters]
+        pathDepResolvers: Map[Int, UntypedArguments => Parameters],
+        // [hearth#331] Given ALL type arguments applied so far, re-resolve the (still-static) expectations so that a
+        // value/implicit clause following a type-parameter clause has the applied type arguments substituted into its
+        // parameter types (`(implicit ev: Sync[F])` -> `(implicit ev: Sync[SomeEffect])`). The platform builds this;
+        // the default is identity (used when there are no unresolved method type parameters).
+        resolveExpectationsForTypeArgs: UntypedTypeArguments => List[MethodExpectation]
     ): Method = {
       val initialState = AppliedState(hadKnownReturning = returnType.isDefined)
 
@@ -466,8 +471,12 @@ trait Methods { this: MacroCommons =>
                 totalParameters = totalParameters,
                 typeParams = asUntyped.typeParameters,
                 next = { typeArgs =>
+                  val allTypeArgs = accTypeArgs ++ typeArgs
                   val nextState = appliedState.copy(steps = appliedState.steps :+ AppliedStep.Types(typeArgs))
-                  buildFromStep(expectations, stepIndex + 1, accInstance, typeArgs, accArgs, nextState)
+                  // [hearth#331] Substitute the just-applied type arguments into the parameter types of any subsequent
+                  // value/implicit clauses, so `onValues` sees e.g. `Sync[SomeEffect]` rather than an empty clause.
+                  val resolvedExpectations = resolveExpectationsForTypeArgs(allTypeArgs)
+                  buildFromStep(resolvedExpectations, stepIndex + 1, accInstance, allTypeArgs, accArgs, nextState)
                 }
               )(instanceEvidence, appliedState)
             case MethodExpectation.NeedsValues(params) =>


### PR DESCRIPTION
Fixes #331.

## Problem
`Method.fold` dropped a value/implicit parameter clause when it **followed** a type-parameter clause. After applying type arguments via `onTypes`, the trailing clause reached `onValues` as an **empty** list, so a caller could not supply e.g. `implicit ev: Sync[F]` for `def resource[F[_]: Sync]`.

Root cause: `UntypedMethod.toTyped` collapsed such clauses to `List.empty` because resolving their parameter types against `Instance` conflates the method's own type parameters with the class's — and crashes outright on some shapes (an `IArray` extension method throws `substParams` IndexOutOfBounds).

## Fix
Resolve those clauses from the member signature — class type parameters resolved as-seen-from `Instance`, the method's own type parameters kept abstract — and substitute the applied type arguments at fold time:

- **`buildChain`** gains `resolveExpectationsForTypeArgs`: when `onTypes` supplies type arguments, subsequent value clauses are re-resolved with them substituted, so `onValues` sees `Sync[SomeEffect]`, not the abstract `Sync[F]` (nor an empty clause). `private[hearth]` → binary compatible.
- **Scala 3** uses `PolyType.appliedTo` (parameter refs are PolyType-bound, so `substituteTypes(symbols, …)` misses them); the `PolyType` is left untouched when nothing is applied yet so its bound refs still print bare. **Scala 2** uses `Type.substituteTypes` and keeps un-applied HK params as a bare `NoPrefix` ref (so `F` isn't eta-expanded to `F[_$1]`).
- **`ShowCodePrettyScala2`**: a *free* method type parameter now prints by simple name (`A`, not `Owner.A`) — matching Scala 3 and how a *bound* type parameter already prints.

## Tests
- `resource[F[_]](implicit ev: Sync[F])` / `make[F[_]](config)(implicit ev: Sync[F])` — the clause is kept (`NeedsValues(ev: …Sync[F])`), not dropped.
- `pick[T](t: T)(implicit ord: Ordering[T])` folded with `T := Int` — `onValues` sees `t: scala.Int` and `ord: scala.math.Ordering[scala.Int]` and the build succeeds.
- The four existing tests that encoded the bug as `NeedsValues()` are updated to the correct params.

`quick-test` green on 2.13.16 + 3.3.8 (1169 + 1302 + sandwich). MiMa and scalafmt clean.