### PR TITLE
Fix #334: cross-platform Expr.annotated API (@nowarn/@SuppressWarnings)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -339,7 +339,11 @@ val mimaSettings = Seq(
     ),
     exclude[ReversedMissingMethodProblem](
       "hearth.std.StdExtensions#ProvidedCompanion.hearth$std$StdExtensions$ProvidedCompanion$$lastMatchProvenanceValue_="
-    )
+    ),
+    // #334: `annotated` added to the NESTED trait `Exprs#ExprModule`. That trait is part of the MacroCommons cake and
+    // is implemented ONLY by Hearth's own `Expr` object (in ExprsScala2/ExprsScala3), so the interface and its
+    // implementation are always evicted together - no user has a standalone `ExprModule` implementation to break.
+    exclude[ReversedMissingMethodProblem]("hearth.typed.Exprs#ExprModule.annotated")
   )
 )
 

--- a/hearth-tests/src/main/scala-2/hearth/typed/AnnotatedExprFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/AnnotatedExprFixtures.scala
@@ -1,0 +1,19 @@
+package hearth
+package typed
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+final private class AnnotatedExprFixtures(val c: blackbox.Context)
+    extends MacroCommonsScala2
+    with AnnotatedExprFixturesImpl {
+
+  def testAnnotatedRoundtripImpl[A: c.WeakTypeTag](value: c.Expr[A]): c.Expr[A] = testAnnotatedRoundtrip[A](value)
+  def testAnnotatedRenderedImpl[A: c.WeakTypeTag](value: c.Expr[A]): c.Expr[String] = testAnnotatedRendered[A](value)
+}
+
+object AnnotatedExprFixtures {
+
+  def testAnnotatedRoundtrip[A](value: A): A = macro AnnotatedExprFixtures.testAnnotatedRoundtripImpl[A]
+  def testAnnotatedRendered[A](value: A): String = macro AnnotatedExprFixtures.testAnnotatedRenderedImpl[A]
+}

--- a/hearth-tests/src/main/scala-3/hearth/typed/AnnotatedExprFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/AnnotatedExprFixtures.scala
@@ -1,0 +1,17 @@
+package hearth
+package typed
+
+import scala.quoted.*
+
+final private class AnnotatedExprFixtures(q: Quotes) extends MacroCommonsScala3(using q), AnnotatedExprFixturesImpl
+
+object AnnotatedExprFixtures {
+
+  inline def testAnnotatedRoundtrip[A](inline value: A): A = ${ testAnnotatedRoundtripImpl[A]('value) }
+  private def testAnnotatedRoundtripImpl[A: Type](value: Expr[A])(using q: Quotes): Expr[A] =
+    new AnnotatedExprFixtures(q).testAnnotatedRoundtrip[A](value)
+
+  inline def testAnnotatedRendered[A](inline value: A): String = ${ testAnnotatedRenderedImpl[A]('value) }
+  private def testAnnotatedRenderedImpl[A: Type](value: Expr[A])(using q: Quotes): Expr[String] =
+    new AnnotatedExprFixtures(q).testAnnotatedRendered[A](value)
+}

--- a/hearth-tests/src/main/scala/hearth/typed/AnnotatedExprFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/AnnotatedExprFixturesImpl.scala
@@ -1,0 +1,14 @@
+package hearth
+package typed
+
+/** Fixtures for [[AnnotatedExprSpec]] — exercising `Expr.annotated` (hearth#334). */
+trait AnnotatedExprFixturesImpl { this: MacroCommons =>
+
+  // Wraps `value` in `@nowarn` and returns it: proves the annotated val compiles and the value passes through.
+  def testAnnotatedRoundtrip[A: Type](value: Expr[A]): Expr[A] =
+    Expr.annotated(value, Expr.quote(new scala.annotation.nowarn()))
+
+  // Renders the annotated block so the test can assert the annotation is present in the generated code.
+  def testAnnotatedRendered[A: Type](value: Expr[A]): Expr[String] =
+    Expr(Expr.annotated(value, Expr.quote(new scala.annotation.nowarn("msg"))).prettyPrint)
+}

--- a/hearth-tests/src/test/scala/hearth/typed/AnnotatedExprSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/AnnotatedExprSpec.scala
@@ -1,0 +1,20 @@
+package hearth
+package typed
+
+/** Cross-platform tests for `Expr.annotated` (hearth#334). */
+final class AnnotatedExprSpec extends MacroSuite {
+
+  group("Expr.annotated") {
+
+    test("an annotated value round-trips at runtime (the annotated val compiles and passes the value through)") {
+      AnnotatedExprFixtures.testAnnotatedRoundtrip(42) ==> 42
+      AnnotatedExprFixtures.testAnnotatedRoundtrip("hello") ==> "hello"
+      AnnotatedExprFixtures.testAnnotatedRoundtrip(List(1, 2, 3)) ==> List(1, 2, 3)
+    }
+
+    test("the annotation is attached to the generated code") {
+      val rendered = AnnotatedExprFixtures.testAnnotatedRendered(42)
+      assert(rendered.contains("nowarn"), s"expected the rendered code to mention `nowarn`, but was:\n$rendered")
+    }
+  }
+}

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -145,6 +145,16 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
 
     override def suppressUnused[A: Type](expr: Expr[A]): Expr[Unit] = c.Expr[Unit](q"val _ = $expr; ()")
 
+    // [hearth#334] `{ @annotation val fresh = expr; fresh }`. Quasiquotes are not typed, so the annotation instance
+    // tree (`new Ann(args)`) must be `untypecheck`ed before it is spliced as a `val` modifier annotation (mixing typed
+    // and untyped trees crashes the compiler — the same reason annotation trees are untypechecked elsewhere).
+    override def annotated[A: Type, Ann](expr: Expr[A], annotation: Expr[Ann]): Expr[A] = {
+      val name = c.internal.reificationSupport.freshTermName("annotated$macro$")
+      val annotationTree = c.untypecheck(annotation.tree.duplicate)
+      c.Expr[A](q"""@$annotationTree val $name = $expr
+      $name""")
+    }
+
     override def singletonOf[A: Type]: Option[Expr[A]] = {
       val tpe = Type[A].tpe
       val sym = tpe.typeSymbol

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -41,7 +41,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         * `-Xcheck-macros`: "Block contains definition with different owners". In the common, non-nested case
         * `CrossQuotes.ctx == quotes`, so this is exactly the entry splice owner and nothing changes.
         */
-      private def currentSpliceOwner: Symbol =
+      private[Expr] def currentSpliceOwner: Symbol =
         CrossQuotes.ctx[scala.quoted.Quotes].reflect.Symbol.spliceOwner.asInstanceOf[Symbol]
 
       object freshTerm {
@@ -174,6 +174,27 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
 
     override def suppressUnused[A: Type](expr: Expr[A]): Expr[Unit] =
       Block(List(expr.asTerm), Literal(UnitConstant())).asExprOf[Unit]
+
+    // [hearth#334] `{ @annotation val fresh = expr; fresh }`. The annotation is carried as an `AnnotatedType` on the
+    // fresh `val`'s type. `currentSpliceOwner`/`freshTerm` are the owner-following, `@experimental`-free helpers used
+    // by `ValDefs` (see the #317 note above); `changeOwner` reparents the bound expression onto the fresh symbol so
+    // `-Xcheck-macros` accepts the block.
+    override def annotated[A: Type, Ann](expr: Expr[A], annotation: Expr[Ann]): Expr[A] = {
+      // Cross-Quotes' `Expr.quote` wraps the annotation instance in `Inlined(...)`; `AnnotatedType` wants the bare
+      // constructor call (an `Inlined` annotation also crashes the source printer), so strip the wrappers.
+      def stripInlined(t: Term): Term = t match {
+        case Inlined(_, Nil, inner) => stripInlined(inner)
+        case other                  => other
+      }
+      val name = Symbol.newVal(
+        platformSpecific.currentSpliceOwner,
+        platformSpecific.freshTerm("annotated"),
+        AnnotatedType(TypeRepr.of[A], stripInlined(annotation.asTerm)),
+        Flags.EmptyFlags,
+        Symbol.noSymbol
+      )
+      Block(List(ValDef(name, Some(expr.asTerm.changeOwner(name)))), Ref(name)).asExprOf[A]
+    }
 
     override def singletonOf[A: Type]: Option[Expr[A]] = {
       import quotes.reflect.*

--- a/hearth/src/main/scala/hearth/typed/Exprs.scala
+++ b/hearth/src/main/scala/hearth/typed/Exprs.scala
@@ -48,6 +48,17 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
 
     def suppressUnused[A: Type](expr: Expr[A]): Expr[Unit]
 
+    /** Attaches an annotation to `expr` by binding it to a fresh, annotated `val`, producing the equivalent of
+      * `{ @annotation val fresh = expr; fresh }`.
+      *
+      * `annotation` is the annotation INSTANCE expression (e.g. `Expr.quote(new scala.annotation.nowarn("msg"))` or
+      * `Expr.quote(new SuppressWarnings(Array("...")))`). Use this to wrap generated code in a user-supplied
+      * `@nowarn`/`@SuppressWarnings` (or any annotation), which is otherwise not expressible cross-platform.
+      *
+      * @since 0.4.1
+      */
+    def annotated[A: Type, Ann](expr: Expr[A], annotation: Expr[Ann]): Expr[A]
+
     def singletonOf[A: Type]: Option[Expr[A]]
 
     /** Returns the type of an expression as seen by the compiler.
@@ -167,6 +178,12 @@ trait Exprs extends ExprsCrossQuotes with ExprsCompat { this: MacroCommons =>
 
     def upcast[B](implicit A: Type[A], B: Type[B]): Expr[B] = Expr.upcast(expr)
     def suppressUnused(implicit A: Type[A]): Expr[Unit] = Expr.suppressUnused(expr)
+
+    /** Attaches an annotation to this expression — see [[ExprModule.annotated]].
+      *
+      * @since 0.4.1
+      */
+    def annotated[Ann](annotation: Expr[Ann])(implicit A: Type[A]): Expr[A] = Expr.annotated(expr, annotation)
 
     /** Returns the type of this expression as seen by the compiler.
       *


### PR DESCRIPTION
Fixes #334.

## What
Adds `Expr.annotated[A, Ann](expr, annotation)` and the `expr.annotated(annotation)` extension, producing the equivalent of `{ @annotation val fresh = expr; fresh }` cross-platform. `annotation` is the annotation **instance** expression:

```scala
expr.annotated(Expr.quote(new scala.annotation.nowarn("msg")))
expr.annotated(Expr.quote(new SuppressWarnings(Array("..."))))
```

This lets a macro wrap generated code in a user-supplied `@nowarn`/`@SuppressWarnings` (or any annotation) — previously not expressible cross-platform, so Chimney kept per-platform `nowarnExpr`/`suppressWarningsExpr` bridges it can now drop.

## How
- **Scala 3**: annotation carried as an `AnnotatedType` on a fresh, owner-following `val` (`currentSpliceOwner`/`freshTerm` — the same `@experimental`-free helpers `ValDefs` uses), `changeOwner`-ing the bound expression so `-Xcheck-macros` accepts the block. Cross-Quotes wraps the quoted annotation in `Inlined(...)` (which `AnnotatedType` rejects and the source printer crashes on), so it is stripped.
- **Scala 2**: quasiquotes the annotated `val`; the annotation instance tree is `untypecheck`ed before splicing (mixing typed and untyped trees crashes the compiler).

## Binary compatibility
`ExprModule.annotated` is a new abstract method on the **nested** trait `Exprs#ExprModule`, implemented only by Hearth's own `Expr` object (interface + implementation evict in lockstep, no user has a standalone implementation). Per `docs/contributing/binary-compatibility-and-mixins.md` this is not user-observable — MiMa filter added with that rationale (same shape as the #329 filter).

## Tests
`AnnotatedExprSpec` (cross-platform): the annotated value round-trips at runtime (the annotated `val` compiles and passes the value through), and the annotation is present in the generated code.

`quick-test` green on 2.13.16 + 3.3.8 (1168 + 1301 + sandwich). MiMa and scalafmt clean.