### PR TITLE
Fix #307 (round 2): match wildcard existential args in Scala 2 CtorN.unapply

### DIFF
--- a/hearth-tests/src/main/scala-2/hearth/crossquotes/Issue307ReproFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/crossquotes/Issue307ReproFixtures.scala
@@ -1,0 +1,23 @@
+package hearth
+package crossquotes
+
+import hearth.data.Data
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+final private class Issue307ReproFixtures(val c: blackbox.Context)
+    extends MacroCommonsScala2
+    with Issue307ReproFixturesImpl {
+
+  def testCtor1UpperBoundedMatchImpl[In: c.WeakTypeTag]: c.Expr[Data] = testCtor1UpperBoundedMatch[In]
+  def testCtor2UpperBoundedMatchImpl[In: c.WeakTypeTag]: c.Expr[Data] = testCtor2UpperBoundedMatch[In]
+  def testCtor1BoundedMatchImpl[In: c.WeakTypeTag]: c.Expr[Data] = testCtor1BoundedMatch[In]
+}
+
+object Issue307ReproFixtures {
+
+  def testCtor1UpperBoundedMatch[In]: Data = macro Issue307ReproFixtures.testCtor1UpperBoundedMatchImpl[In]
+  def testCtor2UpperBoundedMatch[In]: Data = macro Issue307ReproFixtures.testCtor2UpperBoundedMatchImpl[In]
+  def testCtor1BoundedMatch[In]: Data = macro Issue307ReproFixtures.testCtor1BoundedMatchImpl[In]
+}

--- a/hearth-tests/src/main/scala-2/hearth/crossquotes/Issue307ReproFixturesImpl.scala
+++ b/hearth-tests/src/main/scala-2/hearth/crossquotes/Issue307ReproFixturesImpl.scala
@@ -1,6 +1,7 @@
 package hearth.crossquotes
 
 import hearth.*
+import hearth.data.Data
 
 // Regression for https://github.com/kubuszok/hearth/issues/307 (Scala 2 only).
 //
@@ -9,9 +10,14 @@ import hearth.*
 // `U >: Any`, so any real upper bound (e.g. `Marker`) made the generated code fail to typecheck with
 // `type arguments do not conform ... [L, U >: Any]`.
 //
+// Round 2: the generated `unapply` must also MATCH a WILDCARD type argument (`F1[_ <: Marker]`), which reaches
+// `baseType(HKT.typeSymbol)` as a PACKED `ExistentialType(_, TypeRef(...))` rather than a bare `TypeRef`. The
+// `test*Match` methods below exercise that path. (The full cross-compilation failure — where the constructor's prefix
+// is captured via an alias in a SEPARATE library so the structural-`==` fallback also misses — is validated by the
+// standalone repro linked from the issue; a single compilation unit cannot reproduce it.)
+//
 // Like the #300 repro this is a Scala 2 codegen bug (quasiquotes are not hygienic / typed), hence the fixture
-// lives under `scala-2`. It exists purely to be compiled: each `Type.CtorN.*.of` below expands at compile
-// time, so if the generated code does not typecheck, compilation fails.
+// lives under `scala-2`.
 private[crossquotes] trait Issue307ReproFixturesImpl { this: MacroCommons =>
 
   private object Types {
@@ -22,6 +28,24 @@ private[crossquotes] trait Issue307ReproFixturesImpl { this: MacroCommons =>
     val Bounded1: Type.Ctor1.Bounded[Issue307.SubMarker, Issue307.Marker, Issue307.G1] =
       Type.Ctor1.Bounded.of[Issue307.SubMarker, Issue307.Marker, Issue307.G1]
   }
+
+  // A wildcard argument is extracted as a fresh existential skolem (`_$N`) whose printed name is callsite- and
+  // compiler-version-dependent, so we only report WHETHER the constructor matched (the point of the #307 round-2 fix).
+
+  def testCtor1UpperBoundedMatch[In: Type]: Expr[Data] = Expr(Data(Type[In] match {
+    case Types.Upper1(_) => true
+    case _               => false
+  }))
+
+  def testCtor2UpperBoundedMatch[In: Type]: Expr[Data] = Expr(Data(Type[In] match {
+    case Types.Upper2(_, _) => true
+    case _                  => false
+  }))
+
+  def testCtor1BoundedMatch[In: Type]: Expr[Data] = Expr(Data(Type[In] match {
+    case Types.Bounded1(_) => true
+    case _                 => false
+  }))
 }
 
 private[crossquotes] object Issue307 {

--- a/hearth-tests/src/test/scala-2/hearth/crossquotes/Issue307MatchSpec.scala
+++ b/hearth-tests/src/test/scala-2/hearth/crossquotes/Issue307MatchSpec.scala
@@ -1,0 +1,33 @@
+package hearth
+package crossquotes
+
+import hearth.data.Data
+
+/** Regression for https://github.com/kubuszok/hearth/issues/307 (Scala 2 only), round 2: the generated
+  * `Type.CtorN.UpperBounded/Bounded.unapply` must MATCH a WILDCARD type argument (`F1[_ <: Marker]`), which reaches
+  * `baseType` as a packed `ExistentialType` rather than a bare `TypeRef`. See [[Issue307ReproFixturesImpl]] — the full
+  * cross-compilation failure is validated by the standalone repro linked from the issue.
+  */
+final class Issue307MatchSpec extends MacroSuite {
+
+  group("Cross-Quotes (Scala 2): CtorN.UpperBounded/Bounded.unapply matches wildcard existential args (#307)") {
+
+    test("Ctor1.UpperBounded matches a concrete application") {
+      Issue307ReproFixtures.testCtor1UpperBoundedMatch[Issue307.F1[Issue307.SubMarker]] <==> Data(true)
+    }
+
+    test("Ctor1.UpperBounded matches a wildcard application (F1[_ <: Marker])") {
+      Issue307ReproFixtures.testCtor1UpperBoundedMatch[Issue307.F1[? <: Issue307.Marker]] <==> Data(true)
+    }
+
+    test("Ctor2.UpperBounded matches a wildcard application (F2[_ <: Marker, _ <: Marker])") {
+      Issue307ReproFixtures
+        .testCtor2UpperBoundedMatch[Issue307.F2[? <: Issue307.Marker, ? <: Issue307.Marker]] <==> Data(true)
+    }
+
+    test("Ctor1.Bounded matches a wildcard application (G1[_ >: SubMarker <: Marker])") {
+      Issue307ReproFixtures
+        .testCtor1BoundedMatch[Issue307.G1[? >: Issue307.SubMarker <: Issue307.Marker]] <==> Data(true)
+    }
+  }
+}

--- a/project/CrossQuotesMacrosGen.scala
+++ b/project/CrossQuotesMacrosGen.scala
@@ -147,7 +147,7 @@ object CrossQuotesMacrosGen {
     val stubTypeArgs = (1 to n).flatMap(i => Seq(s"$$${ArityGen.lower(i)}", s"$$${ArityGen.upper(i)}")).mkString(", ")
     sb ++= s"""      val ctxVal = q${tq}private val $$ctx = CrossQuotes.ctx[_root_.scala.reflect.macros.blackbox.Context]${tq}\n"""
     sb ++= s"""      val convertDef = q${tq}private implicit def $$convertProvidedTypesForCrossQuotes[$$typeInner](implicit $$termInner: Type[$$typeInner]): $$ctx.WeakTypeTag[$$typeInner] = $$termInner.asInstanceOf[$$ctx.WeakTypeTag[$$typeInner]]${tq}\n"""
-    sb ++= s"""      val ctxImport = q${tq}import $$ctx.universe.{ TypeRef, TypeRefTag }${tq}\n"""
+    sb ++= s"""      val ctxImport = q${tq}import $$ctx.universe.{ TypeRef, TypeRefTag, ExistentialType, ExistentialTypeTag }${tq}\n"""
     sb ++= s"""      val hktVal = q${tq}private val HKT = $$ctx.weakTypeTag[Type.$cn.Stub[$stubTypeArgs, $$HKT]].tpe.typeArgs.last${tq}\n"""
     sb ++= s"      List(ctxVal, convertDef, ctxImport, hktVal)\n"
     sb ++= s"    }\n"
@@ -188,6 +188,12 @@ object CrossQuotesMacrosGen {
     sb ++= s"        A0.dealias.widen.baseType(HKT.typeSymbol) match {\n"
     val tpList = (1 to n).map(i => s"tp$i").mkString(", ")
     sb ++= s"          case TypeRef(_, _, _root_.scala.List($tpList)) =>\n"
+    sb ++= s"            matchResult($tpList)\n"
+    // [hearth#307] A WILDCARD type argument (`HKT[?]`, e.g. a `SomeFlag[?]` DSL member) makes `baseType` return a
+    // PACKED `ExistentialType(_, TypeRef(...))` instead of a bare `TypeRef`, so the case above misses. Unwrap it here
+    // (still `baseType`-symbol-based, so prefix-representation-independent) rather than falling through to the
+    // structural-`==` fallback, which additionally misses when the constructor's prefix is captured via an alias.
+    sb ++= s"          case ExistentialType(_, TypeRef(_, _, _root_.scala.List($tpList))) =>\n"
     sb ++= s"            matchResult($tpList)\n"
     sb ++= s"          case _ =>\n"
     sb ++= s"            if (A0.typeConstructor == HKT && A0.typeArgs.size == $n) {\n"
@@ -278,7 +284,7 @@ object CrossQuotesMacrosGen {
     sb ++= s"    def buildPreamble(): List[c.Tree] = {\n"
     sb ++= s"""      val ctxVal = q${tq}private val $$ctx = CrossQuotes.ctx[_root_.scala.reflect.macros.blackbox.Context]${tq}\n"""
     sb ++= s"""      val convertDef = q${tq}private implicit def $$convertProvidedTypesForCrossQuotes[$$typeInner](implicit $$termInner: Type[$$typeInner]): $$ctx.WeakTypeTag[$$typeInner] = $$termInner.asInstanceOf[$$ctx.WeakTypeTag[$$typeInner]]${tq}\n"""
-    sb ++= s"""      val ctxImport = q${tq}import $$ctx.universe.{ TypeRef, TypeRefTag }${tq}\n"""
+    sb ++= s"""      val ctxImport = q${tq}import $$ctx.universe.{ TypeRef, TypeRefTag, ExistentialType, ExistentialTypeTag }${tq}\n"""
     sb ++= s"""      val hktVal = q${tq}private val HKT = $${untyped.tree}.asInstanceOf[$$ctx.Type]${tq}\n"""
     sb ++= s"      List(ctxVal, convertDef, ctxImport, hktVal)\n"
     sb ++= s"    }\n"
@@ -319,6 +325,12 @@ object CrossQuotesMacrosGen {
     sb ++= s"        A0.dealias.widen.baseType(HKT.typeSymbol) match {\n"
     val tpList = (1 to n).map(i => s"tp$i").mkString(", ")
     sb ++= s"          case TypeRef(_, _, _root_.scala.List($tpList)) =>\n"
+    sb ++= s"            matchResult($tpList)\n"
+    // [hearth#307] A WILDCARD type argument (`HKT[?]`, e.g. a `SomeFlag[?]` DSL member) makes `baseType` return a
+    // PACKED `ExistentialType(_, TypeRef(...))` instead of a bare `TypeRef`, so the case above misses. Unwrap it here
+    // (still `baseType`-symbol-based, so prefix-representation-independent) rather than falling through to the
+    // structural-`==` fallback, which additionally misses when the constructor's prefix is captured via an alias.
+    sb ++= s"          case ExistentialType(_, TypeRef(_, _, _root_.scala.List($tpList))) =>\n"
     sb ++= s"            matchResult($tpList)\n"
     sb ++= s"          case _ =>\n"
     sb ++= s"            if (A0.typeConstructor == HKT && A0.typeArgs.size == $n) {\n"


### PR DESCRIPTION
Fixes #307 (the third, wildcard-argument signature — thanks to the Chimney agent for the precise root-cause + standalone repro).

## Problem
The generated Scala 2 `Type.CtorN.UpperBounded/Bounded.unapply` failed to **match** a flag type with a **wildcard** argument (`SomeFlag[?]` from a DSL member declared with `[?]`), aborting Chimney config parsing with:

```
Invalid internal TransformerFlag type: ...TransformerFlags#OptionFallbackMerge[...?$N]!
```

## Root cause (two independent misses that coincide)
- **Path 1** (`baseType(sym) match { case TypeRef(_, _, List(tp)) }`) misses because a wildcard arg makes `baseType` return a **packed `ExistentialType(_, TypeRef(…))`**, not a bare `TypeRef`. (A concrete arg → `TypeRef` → path 1 fires; that's why only `SomeFlag[?]` members failed.)
- **Path 2** (`A0.typeConstructor == HKT`) then misses because structural `==` is prefix-representation-sensitive: when the constructor is captured through an alias in a **separate library**, the prefix (root-anchored `SingleType` chain from the use-site vs compact `ThisType` from the aliased capture) is *symbol*-equal but *structurally* unequal.

The maintainer's earlier self-contained fixtures masked it: same-compilation-unit prefixes render identically, so path 2 succeeds and hides path 1's miss.

## Fix
Add to path 1 a `case ExistentialType(_, TypeRef(_, _, List(tp))) => matchResult(tp)` that unwraps the packed existential. Still `baseType`-symbol-based (prefix-representation-independent), and firing here means the structural-`==` fallback is never reached for the wildcard case — so the delicate `FixedFront1`/`FixedBack1` alias matching (path 2) is untouched. Additive: a concrete argument still yields a `TypeRef` and takes the existing case.

## Validation
- **Standalone repro** (3-stage build — flags + macro in separate libraries, aliased capture, kind-projector): the abort is **gone**; both controls (direct-import capture; concrete arg) still match; the wildcard control now extracts the skolem instead of `scala.Any`.
- `Issue307MatchSpec` smoke-tests wildcard matching (`F1[_ <: Marker]`, `F2[_, _]`, `G1[_ >: _ <: _]`) in-suite. The full failure needs the separate-compilation + aliased-capture combination a single unit cannot reproduce, so the repro is the authoritative regression check.
- `quick-test` green on 2.13.16 + 3.3.8 (1170 + 1299 + sandwich); `CrossTypesSpec` (the alias-matching suite) intact. scalafmt clean; no ABI change (body-only edit to generated code).