### PR TITLE
Fix #321 + compilation perf: EnumSet re-typecheck fix, Type.Cache / lazy ClassViewResult / MIO logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -343,7 +343,40 @@ val mimaSettings = Seq(
     // #334: `annotated` added to the NESTED trait `Exprs#ExprModule`. That trait is part of the MacroCommons cake and
     // is implemented ONLY by Hearth's own `Expr` object (in ExprsScala2/ExprsScala3), so the interface and its
     // implementation are always evicted together - no user has a standalone `ExprModule` implementation to break.
-    exclude[ReversedMissingMethodProblem]("hearth.typed.Exprs#ExprModule.annotated")
+    exclude[ReversedMissingMethodProblem]("hearth.typed.Exprs#ExprModule.annotated"),
+    // Perf: `ClassViewResult.Incompatible` changed from a `case class` to a plain class so its `reason` (an
+    // expensive `Type.prettyPrint`, discarded by most callers) can be computed lazily. The former binary surface is
+    // preserved as far as shims can reach: `apply(String)`, the primary constructor `this(String)`, and
+    // `copy(String)` / `copy$default$1()` are all reintroduced as `private[ClassViewResult]` members, which Scala
+    // emits as PUBLIC bytecode (so 0.4.0-compiled callers still link) while hiding them from new source (so new call
+    // sites resolve to the lazy `apply(=> String)` and `reason` stays lazy). Those therefore need NO filter.
+    //
+    // What remains below is STRUCTURAL - a plain class simply cannot carry it, and no shim can restore it without
+    // either undoing the laziness or making it a `case class` again:
+    //   * `unapply` returns `Some` instead of `Option`, so `case Incompatible(reason)` stays irrefutable and sealed
+    //     matches stay exhaustive (returning `Option` would emit non-exhaustiveness warnings in downstream `-Werror`
+    //     builds - a worse regression than this filter). Return-type overloading cannot provide both.
+    //   * the companion loses its `AbstractFunction1[String, Incompatible]` parent (restoring it would force a PUBLIC
+    //     `apply(String)`, reintroducing the overload ambiguity the shim exists to avoid).
+    //   * Scala 3 `Mirror.Sum` (+`ordinal`) on `ClassViewResult` and `Mirror.Product` (`_1`, `fromProduct`) on
+    //     `Incompatible` - case-class/Mirror machinery a plain class does not generate.
+    // `ClassViewResult` is an internal parsing-result type that ONLY Hearth constructs; no user builds one via the
+    // synthesized `Function1`/`Mirror`, so none of the below is user-observable.
+    exclude[MissingTypesProblem]("hearth.typed.Classes$ClassViewResult$Incompatible$"),
+    exclude[IncompatibleResultTypeProblem]("hearth.typed.Classes#ClassViewResult#Incompatible.unapply"),
+    exclude[MissingTypesProblem]("hearth.typed.Classes$ClassViewResult$"),
+    exclude[DirectMissingMethodProblem]("hearth.typed.Classes#ClassViewResult.ordinal"),
+    exclude[DirectMissingMethodProblem]("hearth.typed.Classes#ClassViewResult#Incompatible._1"),
+    exclude[DirectMissingMethodProblem]("hearth.typed.Classes#ClassViewResult#Incompatible.fromProduct"),
+    // Perf: `Type.Cache` (a type-keyed memo) added to the NESTED trait `Types#TypeModule`, which is part of the
+    // MacroCommons cake and implemented ONLY by Hearth's own platform `Type` object (TypesScala2/TypesScala3), so
+    // interface and implementation are always evicted together - no user has a standalone `TypeModule` to break.
+    exclude[ReversedMissingMethodProblem]("hearth.typed.Types#TypeModule.Cache"),
+    // Perf: `unsortedMethods` (methods without the expensive position-resolving `sortMethods` pass) added to the
+    // NESTED trait `UntypedMethods#UntypedMethodModule`, part of the MacroCommons cake and implemented ONLY by
+    // Hearth's own platform `UntypedMethod` object (UntypedMethodsScala2/Scala3) - interface and implementation are
+    // always evicted together, so no user has a standalone implementation to break.
+    exclude[ReversedMissingMethodProblem]("hearth.untyped.UntypedMethods#UntypedMethodModule.unsortedMethods")
   )
 )
 

--- a/hearth-better-printers/src/main/scala-2/hearth/treeprinter/ShowCodePrettyScala2.scala
+++ b/hearth-better-printers/src/main/scala-2/hearth/treeprinter/ShowCodePrettyScala2.scala
@@ -1238,7 +1238,7 @@ trait ShowCodePrettyScala2 {
                   val dealiased = tpe.dealias
                   val naiveAttempt = dealiased.toString.takeWhile(_ != '[') // does not work for e.g. primitive types
                   def typeSymbolAttempt = dealiased.typeSymbol.fullName // does not work for e.g. path-dependent types
-                  val fullName = if (naiveAttempt.exists(_ == '.')) naiveAttempt else typeSymbolAttempt
+                  val fullName = if (naiveAttempt.contains('.')) naiveAttempt else typeSymbolAttempt
                   highlightTypeDef(fullName) + tpeArgs
               }
             print(helper(tpe)) // TODO: is this even printed?

--- a/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
+++ b/hearth-cross-quotes/src/main/scala-2/hearth/cq/CrossQuotesMacros.scala
@@ -397,7 +397,7 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
         case TypeRef(_, _, _root_.scala.List(g)) =>
           _root_.scala.Some(g.asInstanceOf[UntypedType])
         case _ =>
-          if (A0.typeConstructor == HKT && A0.typeArgs.size == 1) {
+          if (A0.typeConstructor == HKT && A0.typeArgs.sizeIs == 1) {
             val _root_.scala.Seq(g) = A0.typeArgs
             _root_.scala.Some(g.asInstanceOf[UntypedType])
           }
@@ -445,7 +445,7 @@ final class CrossQuotesMacros(val c: blackbox.Context) extends ShowCodePrettySca
         case TypeRef(_, _, _root_.scala.List(g)) =>
           _root_.scala.Some(g.asInstanceOf[UntypedType])
         case _ =>
-          if (A0.typeConstructor == HKT && A0.typeArgs.size == 1) {
+          if (A0.typeConstructor == HKT && A0.typeArgs.sizeIs == 1) {
             val _root_.scala.Seq(g) = A0.typeArgs
             _root_.scala.Some(g.asInstanceOf[UntypedType])
           }

--- a/hearth-micro-fp/src/main/scala/hearth/fp/effect/MIO.scala
+++ b/hearth-micro-fp/src/main/scala/hearth/fp/effect/MIO.scala
@@ -444,6 +444,17 @@ object MIO {
   /** Whether each Log.scoped should also benchmark the scope duration. */
   var benchmarkScopes: Boolean = false
 
+  /** When `true`, [[log]] and [[nameLogsScope]] become no-ops, skipping the per-entry / per-scope allocations.
+    *
+    * UNSAFE: while set, no `Log` entries or scopes are recorded, so any later log rendering is empty. Only enable when
+    * all logs are guaranteed to be discarded. Set (save/restore) via
+    * [[hearth.Environments.EnvironmentModule.withMioLoggingDisabled]], which `runToExprOrFail` turns on automatically
+    * when every rendering knob is `DontRender`.
+    *
+    * @since 0.4.1
+    */
+  var disableLogging: Boolean = false
+
   /** Reference timestamp captured at the start of macro expansion. Used to convert absolute nanoTime values to
     * relative-to-start values for flame graph rendering.
     */
@@ -495,20 +506,23 @@ object MIO {
 
   // --------------------------------------------- Log delegates to these ---------------------------------------------
 
-  private[effect] def log(log: => Log): MIO[Unit] = void :+ ((s, r) => Pure(s.log(log), r))
+  private[effect] def log(log: => Log): MIO[Unit] =
+    if (disableLogging) void else void :+ ((s, r) => Pure(s.log(log), r))
   private[effect] def nameLogsScope[A](name: String, io: MIO[A]): MIO[A] =
-    void :+ { (s, _) =>
-      val start = if (benchmarkScopes) Log.Timestamp.now else Log.Timestamp.empty
-      val (s1, scopeId) = s.openScope(name, start)
-      _openScopes = OpenScope(name, scopeId, start) :: _openScopes
-      Pure(s1, Right(scopeId))
-    } flatMap { scopeId =>
-      io :+ { (s, r) =>
-        _openScopes = if (_openScopes.nonEmpty) _openScopes.tail else Nil
-        val end = if (benchmarkScopes) Log.Timestamp.now else Log.Timestamp.empty
-        Pure(s.closeScope(scopeId, end), r)
+    if (disableLogging) io
+    else
+      void :+ { (s, _) =>
+        val start = if (benchmarkScopes) Log.Timestamp.now else Log.Timestamp.empty
+        val (s1, scopeId) = s.openScope(name, start)
+        _openScopes = OpenScope(name, scopeId, start) :: _openScopes
+        Pure(s1, Right(scopeId))
+      } flatMap { scopeId =>
+        io :+ { (s, r) =>
+          _openScopes = if (_openScopes.nonEmpty) _openScopes.tail else Nil
+          val end = if (benchmarkScopes) Log.Timestamp.now else Log.Timestamp.empty
+          Pure(s.closeScope(scopeId, end), r)
+        }
       }
-    }
 
   /** Allows the [[run]] loop to sync its accumulated state with [[DirectStyle]]'s `ongoingStates`, so that nested
     * `runSafe` calls see up-to-date state and their changes are propagated back into the run loop.

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -244,7 +244,7 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
             evalWithLocals(inner, locals, overrides)
 
           case TypeApply(Select(qualifier, name), typeArgs)
-              if name.decodedName.toString == "isInstanceOf" && typeArgs.size == 1 =>
+              if name.decodedName.toString == "isInstanceOf" && typeArgs.sizeIs == 1 =>
             evalWithLocals(qualifier, locals, overrides).flatMap { receiver =>
               runtimeClassOf(typeArgs.head.tpe) match {
                 case Some(clazz) => Right(clazz.isInstance(receiver))
@@ -663,7 +663,7 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
         val byArity = candidates.filter(_.getParameterCount == args.size)
         val exactMatch =
           if (byArity.isEmpty) None
-          else if (byArity.size == 1) Some((byArity.head, args))
+          else if (byArity.sizeIs == 1) Some((byArity.head, args))
           else {
             val matching = byArity.filter { exec =>
               val paramTypes = exec.getParameterTypes
@@ -3804,7 +3804,7 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
 
   private def dstrResolveMethod(qualTpe: c.Type, methodSym: Symbol): Option[Method] = {
     val instanceTpe: UntypedType = qualTpe.widen
-    val methods = UntypedMethod.methods(instanceTpe)
+    val methods = UntypedMethod.unsortedMethods(instanceTpe) // order-independent: `.find` by symbol identity
     val termSym = if (methodSym.isMethod) methodSym.asMethod else methodSym.asTerm
     methods
       .find(_.symbol == termSym)

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
@@ -592,7 +592,10 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
         .flatMap(parseCtorOption)
     override def constructors(instanceTpe: UntypedType): List[UntypedMethod] =
       instanceTpe.decls.filter(_.isConstructor).flatMap(parseCtorOption).toList
-    override def methods(instanceTpe: UntypedType): List[UntypedMethod] = {
+    override def methods(instanceTpe: UntypedType): List[UntypedMethod] =
+      sortMethods(unsortedMethods(instanceTpe))
+
+    override def unsortedMethods(instanceTpe: UntypedType): List[UntypedMethod] = {
       // Defined in the type or its parent, or synthetic
       val classMembers = instanceTpe.members
       // Defined exatcly in the type
@@ -607,7 +610,7 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
 
           val allMembers = classMembers ++ companionMembers
           val allDeclared = classDeclared ++ companionDeclared
-          val moduleBySymbol = companionMembers.toList.map(_ -> companionRef).toMap[Symbol, UntypedExpr]
+          val moduleBySymbol = companionMembers.iterator.map(_ -> companionRef).toMap[Symbol, UntypedExpr]
           (allMembers, allDeclared, moduleBySymbol)
         }
         .getOrElse((classMembers, classDeclared, Map.empty[Symbol, UntypedExpr]))
@@ -620,32 +623,30 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
         (argument, idx) <- primaryConstructor.asMethod.paramLists.flatten.zipWithIndex
       } yield symbolName(argument) -> idx).toMap
 
-      sortMethods(
-        members
-          .filterNot(_.isConstructor) // Constructors are handled by `primaryConstructor` and `constructors`
-          .filterNot { s =>
-            val name = symbolName(s)
-            // val/vars create both term and method symbols - one of them is redundant, but we have to allow terms to not lose ctor arguments.
-            // We can recognize extra term symbols by checking if the name ends with " " (for term) or not (for method).
-            name.endsWith(" ") ||
-            // Default parameters are methods, but we don't want them
-            name.contains("$default$") ||
-            // Class static initializer is a method, but we don't want it
-            name == "<clinit>"
-          }
-          .flatMap { s =>
-            val fieldNames = Set(symbolName(s), symbolName(s) + "_=")
-            val module = moduleBySymbol.get(s)
-            parseOption(
-              isDeclared = declared(s) && !methodsConsideredSynthetic(s),
-              isConstructorArgument = (constructorArguments.keySet & fieldNames).nonEmpty,
-              constructorArgumentIndex = fieldNames.flatMap(constructorArguments.get).headOption,
-              isCaseField = s.isMethod && s.asMethod.isCaseAccessor,
-              module = module
-            )(s)
-          }
-          .toList
-      )
+      members
+        .filterNot(_.isConstructor) // Constructors are handled by `primaryConstructor` and `constructors`
+        .filterNot { s =>
+          val name = symbolName(s)
+          // val/vars create both term and method symbols - one of them is redundant, but we have to allow terms to not lose ctor arguments.
+          // We can recognize extra term symbols by checking if the name ends with " " (for term) or not (for method).
+          name.endsWith(" ") ||
+          // Default parameters are methods, but we don't want them
+          name.contains("$default$") ||
+          // Class static initializer is a method, but we don't want it
+          name == "<clinit>"
+        }
+        .flatMap { s =>
+          val fieldNames = Set(symbolName(s), symbolName(s) + "_=")
+          val module = moduleBySymbol.get(s)
+          parseOption(
+            isDeclared = declared(s) && !methodsConsideredSynthetic(s),
+            isConstructorArgument = (constructorArguments.keySet & fieldNames).nonEmpty,
+            constructorArgumentIndex = fieldNames.flatMap(constructorArguments.get).headOption,
+            isCaseField = s.isMethod && s.asMethod.isCaseAccessor,
+            module = module
+          )(s)
+        }
+        .toList
     }
 
     override def defaultValue(instanceTpe: UntypedType)(param: UntypedParameter): Option[UntypedMethod] = if (

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -299,7 +299,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
           case Typed(inner, _) =>
             evalWithLocals(inner, locals, overrides)
 
-          case TypeApply(Select(qualifier, name), typeArgs) if name == "isInstanceOf" && typeArgs.size == 1 =>
+          case TypeApply(Select(qualifier, name), typeArgs) if name == "isInstanceOf" && typeArgs.sizeIs == 1 =>
             evalWithLocals(qualifier, locals, overrides).flatMap { receiver =>
               runtimeClassOf(typeArgs.head.tpe) match {
                 case Some(clazz) => Right(clazz.isInstance(receiver))
@@ -895,7 +895,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
         val byArity = candidates.filter(_.getParameterCount == args.size)
         val exactMatch =
           if byArity.isEmpty then None
-          else if byArity.size == 1 then Some((byArity.head, adaptArgs(byArity.head, args)))
+          else if byArity.sizeIs == 1 then Some((byArity.head, adaptArgs(byArity.head, args)))
           else {
             val matching = byArity.filter { exec =>
               val paramTypes = exec.getParameterTypes
@@ -6351,7 +6351,7 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
     val qualTpe = qualTpeAny.asInstanceOf[TypeRepr]
     val methodSym = methodSymAny.asInstanceOf[Symbol]
     val instanceTpe: UntypedType = qualTpe.widen
-    val methods = UntypedMethod.methods(instanceTpe)
+    val methods = UntypedMethod.unsortedMethods(instanceTpe) // order-independent: `.find` by symbol identity
     methods
       .find(_.symbol == methodSym)
       .map(_.asTyped(using UntypedType.toTyped[Any](instanceTpe)))

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -902,7 +902,10 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
                 )
             )
       }
-    override def methods(instanceTpe: UntypedType): List[UntypedMethod] = {
+    override def methods(instanceTpe: UntypedType): List[UntypedMethod] =
+      sortMethods(unsortedMethods(instanceTpe))
+
+    override def unsortedMethods(instanceTpe: UntypedType): List[UntypedMethod] = {
       val symbol = instanceTpe.typeSymbol
       // `fieldMembers` only returns the type's OWN fields, so `val` fields inherited from parent CLASSES (e.g. the
       // constructor vals of an abstract parent) are neither methods nor own fields and would vanish entirely. Walk the
@@ -947,7 +950,7 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
 
           val allMembers = classMembers ++ companionMembers
           val allDeclared = classDeclared ++ companionDeclared
-          val moduleBySymbol = companionMembers.toList.map(_ -> companionRef).toMap[Symbol, UntypedExpr]
+          val moduleBySymbol = companionMembers.iterator.map(_ -> companionRef).toMap[Symbol, UntypedExpr]
           (allMembers, allDeclared, moduleBySymbol)
         }
         .getOrElse((classMembers, classDeclared, Map.empty[Symbol, UntypedExpr]))
@@ -962,31 +965,29 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
         if !field.isNoSymbol
       } yield field.name).toSet
 
-      sortMethods(
-        members
-          .filterNot(_.isNoSymbol)
-          .filterNot(_.isClassConstructor) // Constructors are handled by `primaryConstructor` and `constructors`
-          .filterNot { s =>
-            val name = s.name
-            (name == "apply" && s.flags
-              .is(Flags.Synthetic)) || // Generated apply methods that just forward the arguments to the constructor
-            name.contains("$default$") || // Default parameters are methods, but we don't want them
-            name == "<clinit>" // Class static initializer is a method, but we don't want it
-          }
-          .filterNot(excludedMethods)
-          .flatMap { s =>
-            val isSetter = s.name.endsWith("_=")
-            val fieldName = if isSetter then s.name.dropRight(2) else s.name
-            val module = moduleBySymbol.get(s)
-            UntypedMethod.parseOption(
-              isDeclared = declared(s) && !methodsConsideredSynthetic(s),
-              isConstructorArgument = constructorArguments.contains(fieldName) && !isSetter,
-              constructorArgumentIndex = if isSetter then None else constructorArguments.get(fieldName),
-              isCaseField = caseFields(fieldName) && !isSetter,
-              module = module
-            )(s)
-          }
-      )
+      members
+        .filterNot(_.isNoSymbol)
+        .filterNot(_.isClassConstructor) // Constructors are handled by `primaryConstructor` and `constructors`
+        .filterNot { s =>
+          val name = s.name
+          (name == "apply" && s.flags
+            .is(Flags.Synthetic)) || // Generated apply methods that just forward the arguments to the constructor
+          name.contains("$default$") || // Default parameters are methods, but we don't want them
+          name == "<clinit>" // Class static initializer is a method, but we don't want it
+        }
+        .filterNot(excludedMethods)
+        .flatMap { s =>
+          val isSetter = s.name.endsWith("_=")
+          val fieldName = if isSetter then s.name.dropRight(2) else s.name
+          val module = moduleBySymbol.get(s)
+          UntypedMethod.parseOption(
+            isDeclared = declared(s) && !methodsConsideredSynthetic(s),
+            isConstructorArgument = constructorArguments.contains(fieldName) && !isSetter,
+            constructorArgumentIndex = if isSetter then None else constructorArguments.get(fieldName),
+            isCaseField = caseFields(fieldName) && !isSetter,
+            module = module
+          )(s)
+        }
     }
 
     override def defaultValue(instanceTpe: UntypedType)(param: UntypedParameter): Option[UntypedMethod] =

--- a/hearth/src/main/scala/hearth/Environments.scala
+++ b/hearth/src/main/scala/hearth/Environments.scala
@@ -296,6 +296,23 @@ trait Environments extends EnvironmentCrossQuotesSupport { env: MacroCommons =>
         fp.effect.MIO.timeoutDeadlineNanos = Long.MaxValue
     }
 
+    /** Runs `thunk` with MIO logging turned into no-ops: while active, `Log.info`/`warn`/`error` and `Log.namedScope`
+      * record nothing, avoiding the per-entry and per-scope allocations.
+      *
+      * UNSAFE and opt-in: any log rendering during `thunk` will be empty, so only use it when the logs are guaranteed
+      * to be discarded. [[hearth.MIOIntegrations.MioExprOps.runToExprOrFail]] enables it automatically when every
+      * rendering knob is `DontRender` (and neither error-failing nor benchmarking is on). The flag is saved and
+      * restored, so nesting is safe.
+      *
+      * @since 0.4.1
+      */
+    final def withMioLoggingDisabled[A](thunk: => A): A = {
+      val previous = fp.effect.MIO.disableLogging
+      fp.effect.MIO.disableLogging = true
+      try thunk
+      finally fp.effect.MIO.disableLogging = previous
+    }
+
     /** Sets up MIO to use benchmark scopes based on the hearth.mioBenchmarkScopes setting.
       *
       * It would add to MIO logging output the duration for each scope execution if enabled by

--- a/hearth/src/main/scala/hearth/MIOIntegrations.scala
+++ b/hearth/src/main/scala/hearth/MIOIntegrations.scala
@@ -64,8 +64,14 @@ trait MIOIntegrations { this: MacroTypedCommons =>
         renderFailure: (String, fp.data.NonEmptyVector[Throwable]) => String
     ): Expr[A] = Environment.handleMioTerminationException {
       Environment.configureMioBenchmarking()
+      // When nothing will ever be rendered (all knobs DontRender, no error-failing, no benchmarking/flame graph),
+      // the whole log tree is discarded — so skip building it and make logging a no-op to save allocations.
+      val loggingFullyDiscarded =
+        infoRendering == DontRender && warnRendering == DontRender && errorRendering == DontRender &&
+          !failOnErrorLog && !fp.effect.MIO.benchmarkScopes
       Environment.withMioTimeout(timeout) {
-        io.unsafe.runSync
+        if (loggingFullyDiscarded) Environment.withMioLoggingDisabled(io.unsafe.runSync)
+        else io.unsafe.runSync
       } match {
         case Right((state, result)) =>
           val flameGraphError = writeFlameGraphIfConfigured(macroName, state)
@@ -93,7 +99,7 @@ trait MIOIntegrations { this: MacroTypedCommons =>
               def warnLogs = state.logs.render(macroName, warnRendering)
               def errorLogs = state.logs.render(macroName, errorRendering)
 
-              val logs = infoLogs.orElse(warnLogs).orElse(errorLogs).filter(_.trim.count(_ == '\n') > 0)
+              val logs = infoLogs.orElse(warnLogs).orElse(errorLogs).filter(_.trim.contains('\n'))
               val msg = logs.map(renderFailure(_, errors)).getOrElse(renderFailure("", errors))
 
               def fallbackMessage =
@@ -107,7 +113,7 @@ trait MIOIntegrations { this: MacroTypedCommons =>
           val flameGraphError = writeFlameGraphIfConfigured(macroName, timeoutEx.capturedState)
           val renderedLogs = timeoutEx.capturedState.logs
             .render(macroName, warnRendering)
-            .filter(_.trim.count(_ == '\n') > 0)
+            .filter(_.trim.contains('\n'))
           val timeoutMsg = s"Macro '$macroName' timed out after ${timeout.toMillis}ms"
           val fullMsg = Vector(Some(timeoutMsg), renderedLogs, flameGraphError).flatten.mkString("\n")
           Environment.reportErrorAndAbort(fullMsg)

--- a/hearth/src/main/scala/hearth/data/DataCommons.scala
+++ b/hearth/src/main/scala/hearth/data/DataCommons.scala
@@ -78,7 +78,7 @@ private[data] trait DataCommons {
         if (nested.isEmpty) {
           // No nested values -> there should be exactly one leaf
           if (leafs.isEmpty) Left(List(s"$key: no value"))
-          else if (leafs.size == 1) parseString(leafs.head).map(data => key -> data).left.map(e => List(s"$key: $e"))
+          else if (leafs.sizeIs == 1) parseString(leafs.head).map(data => key -> data).left.map(e => List(s"$key: $e"))
           else Left(List(s"$key: multiple values: ${leafs.mkString(", ")}"))
         } else {
           // There are nested values -> there should be no leafs

--- a/hearth/src/main/scala/hearth/std/StdExtensions.scala
+++ b/hearth/src/main/scala/hearth/std/StdExtensions.scala
@@ -134,6 +134,25 @@ trait StdExtensions { this: MacroCommons =>
         case None      => ProviderResult.skipped(companionName, "No providers registered")
       }
     }
+
+    // Memoizes the (expensive) provider scan by the queried type, so re-parsing the same type within one macro
+    // expansion runs the providers at most once. The provenance that `firstMatch` records as a side effect is
+    // stored alongside the result and replayed on every call (hit or miss), so `lastMatchProvenance` stays correct.
+    private type CachedFirstMatch[A] = (ProviderResult[Provided[A]], Option[ProviderProvenance])
+    private lazy val firstMatchCache = new Type.Cache[CachedFirstMatch]
+
+    /** [[firstMatch]] memoized by the queried type; use in `parse` instead of `firstMatch` to avoid re-scanning
+      * providers for a type already seen in this expansion. Reproduces `firstMatch`'s [[lastMatchProvenance]] side
+      * effect on a cache hit.
+      */
+    final protected def firstMatchCached[A: Type](companionName: String): ProviderResult[Provided[A]] = {
+      val (result, provenance) = firstMatchCache.getOrPut(Type[A]) {
+        val r = firstMatch[A](companionName)
+        (r, lastMatchProvenanceValue)
+      }
+      lastMatchProvenanceValue = provenance
+      result
+    }
   }
 
   /** Represents a possible smart constructor for the given input and output types.
@@ -451,7 +470,7 @@ trait StdExtensions { this: MacroCommons =>
 
     override def parse[A: Type]: ProviderResult[IsCollection[A]] = if (isBottomType[A])
       ProviderResult.skipped("IsCollection", bottomTypeSkipReason)
-    else firstMatch[A]("IsCollection")
+    else firstMatchCached[A]("IsCollection")
   }
 
   /** Proof that the type is a map of the given key and value types.
@@ -576,7 +595,7 @@ trait StdExtensions { this: MacroCommons =>
 
     override def parse[A: Type]: ProviderResult[IsOption[A]] = if (isBottomType[A])
       ProviderResult.skipped("IsOption", bottomTypeSkipReason)
-    else firstMatch[A]("IsOption")
+    else firstMatchCached[A]("IsOption")
   }
 
   /** Proof that the type is an either of the given left and right types.
@@ -640,7 +659,7 @@ trait StdExtensions { this: MacroCommons =>
 
     override def parse[A: Type]: ProviderResult[IsEither[A]] = if (isBottomType[A])
       ProviderResult.skipped("IsEither", bottomTypeSkipReason)
-    else firstMatch[A]("IsEither")
+    else firstMatchCached[A]("IsEither")
   }
 
   /** Proof that the type is a value type of the given inner type.
@@ -685,7 +704,7 @@ trait StdExtensions { this: MacroCommons =>
 
     override def parse[A: Type]: ProviderResult[IsValueType[A]] = if (isBottomType[A])
       ProviderResult.skipped("IsValueType", bottomTypeSkipReason)
-    else firstMatch[A]("IsValueType")
+    else firstMatchCached[A]("IsValueType")
   }
 
   implicit final class EnvironmentStdExtensionsOps(private val environment: Environment.type) {

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaCollection.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaCollection.scala
@@ -39,9 +39,10 @@ final class IsCollectionProviderForScalaCollection extends StandardMacroExtensio
           override def build: CtorLikeOf[scala.collection.mutable.Builder[Item, CtorResult], A] = {
             implicit val builderType: Type[scala.collection.mutable.Builder[Item, CtorResult]] =
               Builder[Item, CtorResult]
-            val resultMethod = Method.methodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
-              case m: Method.OnInstance if m.name == "result" && m.isNullary => m
-            }
+            val resultMethod =
+              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
+                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              }
             CtorLikeOf.PlainValue(
               buildExpr,
               resultMethod
@@ -67,9 +68,10 @@ final class IsCollectionProviderForScalaCollection extends StandardMacroExtensio
           override def build: CtorLikeOf[scala.collection.mutable.Builder[Pair, CtorResult], A] = {
             implicit val builderType: Type[scala.collection.mutable.Builder[Pair, CtorResult]] =
               Builder[Pair, CtorResult]
-            val resultMethod = Method.methodsOf[scala.collection.mutable.Builder[Pair, CtorResult]].collectFirst {
-              case m: Method.OnInstance if m.name == "result" && m.isNullary => m
-            }
+            val resultMethod =
+              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Pair, CtorResult]].collectFirst {
+                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              }
             CtorLikeOf.PlainValue(
               buildExpr,
               resultMethod

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaOption.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaOption.scala
@@ -53,7 +53,7 @@ final class IsCollectionProviderForScalaOption extends StandardMacroExtension { 
               (builder: Expr[scala.collection.mutable.Builder[Item, List[Item]]]) =>
                 Expr.quote {
                   val list = Expr.splice(builder).result()
-                  if (list.size <= 1)
+                  if (list.lengthIs <= 1)
                     Right(Expr.splice(Expr.quote(list.headOption).asInstanceOf[Expr[A]]))
                   else Left(s"Expected at most 1 element for Option, got $${list.size}")
                 },

--- a/hearth/src/main/scala/hearth/std/extensions/IsValueTypeProviderForAnyVal.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsValueTypeProviderForAnyVal.scala
@@ -43,7 +43,7 @@ final class IsValueTypeProviderForAnyVal extends StandardMacroExtension { loader
             ctor.isAvailable(AtCallSite) && ctor.parameters.flatten.sizeIs == 1
           }
           (name, argument) <- ctor.parameters.flatten.headOption
-          ctorArgumentMethods = tpe.methods.filter { method =>
+          ctorArgumentMethods = tpe.unsortedMethods.filter { method =>
             method.isConstructorArgument
           }
           if ctorArgumentMethods.sizeIs == 1

--- a/hearth/src/main/scala/hearth/typed/Classes.scala
+++ b/hearth/src/main/scala/hearth/typed/Classes.scala
@@ -43,7 +43,23 @@ trait Classes { this: MacroCommons =>
 
     final lazy val constructors: List[Method] = tpe.constructors
     final lazy val methods: List[Method] = tpe.methods
-    final def method(name: String): List[Method] = methods.filter(_.name == name)
+
+    /** Like [[methods]] but WITHOUT the position-resolving sort - cheaper; use when order does not matter. See
+      * [[Type.unsortedMethods]].
+      */
+    final lazy val unsortedMethods: List[Method] = tpe.unsortedMethods
+
+    /** All overloads named `name`, in the same deterministic order as [[methods]] but computed by sorting only the
+      * matching subset rather than the whole member list.
+      */
+    final def method(name: String): List[Method] = sortedMethodsMatching(_.name == name)
+
+    /** Filters [[unsortedMethods]] and sorts only the (small) matching subset - an identical result to
+      * `methods.filter(p)` but without sorting every member. The `.view` avoids materializing the filtered list before
+      * it is sorted.
+      */
+    final protected def sortedMethodsMatching(p: Method => Boolean): List[Method] =
+      UntypedMethod.sortMethodsBy(unsortedMethods.view.filter(p))(_.asUntyped)
 
     final def asSingleton: Option[SingletonValue[A]] = SingletonValue.unapply(tpe)
     final def asNamedTuple: Option[NamedTuple[A]] = NamedTuple.unapply(tpe)
@@ -104,11 +120,70 @@ trait Classes { this: MacroCommons =>
 
     /** The type is incompatible with the requested class view.
       *
+      * `reason` is evaluated lazily: it is usually built by pretty-printing a type (expensive), yet most callers only
+      * look at `toOption` / `toEither.isRight` and discard it. Formerly a `case class` with an eager `reason`; now a
+      * plain class computing it on first access. The former surface (value equality, `toString`, `Product` access,
+      * `Incompatible(reason)` construction and extraction) is preserved — only the TASTy `case` flag is gone.
+      *
       * @since 0.3.0
       */
-    final case class Incompatible(reason: String) extends ClassViewResult[Nothing] {
+    final class Incompatible private (reasonThunk: () => String) extends ClassViewResult[Nothing] {
+
+      // Binary-compatibility shim for the former `case class`'s public primary constructor `this(String)`. Like the
+      // companion `apply(String)` shim below, `private[ClassViewResult]` is emitted as a PUBLIC `<init>(String)`, so
+      // `new Incompatible(reason)` in code compiled against 0.4.0 still links, while new source cannot see it. Remove
+      // on the next major release.
+      @deprecated(
+        "binary-compatibility shim for the former case class; use ClassViewResult.Incompatible(=> String)",
+        "0.4.1"
+      )
+      private[ClassViewResult] def this(reason: String) = this(() => reason)
+
+      lazy val reason: String = reasonThunk()
       def toOption: Option[Nothing] = None
       def toEither: Either[String, Nothing] = Left(reason)
+
+      override def toString: String = s"Incompatible($reason)"
+      override def equals(other: Any): Boolean = other match {
+        case that: Incompatible => that.canEqual(this) && reason == that.reason
+        case _                  => false
+      }
+      override def hashCode: Int = reason.hashCode
+      override def canEqual(that: Any): Boolean = that.isInstanceOf[Incompatible]
+      override def productArity: Int = 1
+      override def productElement(n: Int): Any =
+        if (n == 0) reason else throw new IndexOutOfBoundsException(n.toString)
+      override def productPrefix: String = "Incompatible"
+
+      // Binary-compatibility shims for the former `case class`'s synthesized `copy` / `copy$default$1` (instance
+      // methods). `private[ClassViewResult]` => public bytecode for 0.4.0-compiled callers, hidden from new source.
+      @deprecated(
+        "binary-compatibility shim for the former case class; use ClassViewResult.Incompatible(=> String)",
+        "0.4.1"
+      )
+      private[ClassViewResult] def copy(reason: String): Incompatible = new Incompatible(() => reason)
+      @deprecated("binary-compatibility shim for the former case class", "0.4.1")
+      private[ClassViewResult] def copy$default$1(): String = reason
+    }
+    object Incompatible {
+
+      /** Builds an [[Incompatible]] whose `reason` is computed lazily on first access. */
+      def apply(reason: => String): Incompatible = new Incompatible(() => reason)
+
+      /** Binary-compatibility shim for the former `case class`'s synthesized `apply(String)`.
+        *
+        * Kept so code compiled against 0.4.0 (which linked against `apply(java.lang.String)`) still links. It is
+        * `private[ClassViewResult]`, which Scala emits as a '''public''' bytecode method (satisfying old callers) while
+        * hiding it from all new source: new call sites therefore resolve `Incompatible(...)` to the lazy
+        * `apply(=> String)` above with no overload ambiguity, and the `reason` stays lazily evaluated. Remove on the
+        * next major release.
+        */
+      @deprecated("binary-compatibility shim for the former case class; use apply(=> String)", "0.4.1")
+      private[ClassViewResult] def apply(reason: String): Incompatible = new Incompatible(() => reason)
+
+      // Returns `Some` (not `Option`) so the pattern `case Incompatible(reason)` stays irrefutable and sealed
+      // `ClassViewResult` matches remain exhaustive, exactly as with the former `case class`.
+      def unapply(incompatible: Incompatible): Some[String] = Some(incompatible.reason)
     }
   }
 
@@ -136,8 +211,12 @@ trait Classes { this: MacroCommons =>
   }
   object SingletonValue {
 
+    private type Result[A] = Option[SingletonValue[A]]
+    private lazy val unapplyCache = new Type.Cache[Result]
     def unapply[A](tpe: Type[A]): Option[SingletonValue[A]] =
-      Expr.singletonOf[A](using tpe).map(new SingletonValue(tpe, _))
+      unapplyCache.getOrPut(tpe) {
+        Expr.singletonOf[A](using tpe).map(new SingletonValue(tpe, _))
+      }
 
     /** Parses a type as a [[SingletonValue]].
       *
@@ -219,9 +298,13 @@ trait Classes { this: MacroCommons =>
   }
   object NamedTuple {
 
+    private type Result[A] = Option[NamedTuple[A]]
+    private lazy val unapplyCache = new Type.Cache[Result]
     def unapply[A](tpe: Type[A]): Option[NamedTuple[A]] =
-      if (tpe.isNamedTuple) tpe.primaryConstructor.map(new NamedTuple(tpe, _))
-      else None
+      unapplyCache.getOrPut(tpe) {
+        if (tpe.isNamedTuple) tpe.primaryConstructor.map(new NamedTuple(tpe, _))
+        else None
+      }
 
     /** Parses a type as a [[NamedTuple]].
       *
@@ -269,7 +352,7 @@ trait Classes { this: MacroCommons =>
       *
       * @since 0.1.0
       */
-    lazy val caseFields: List[Method] = methods.filter(_.isCaseField)
+    lazy val caseFields: List[Method] = sortedMethodsMatching(_.isCaseField)
 
     /** The canonical, compiler-synthesized `copy` method, if one exists.
       *
@@ -299,7 +382,8 @@ trait Classes { this: MacroCommons =>
 
     private lazy val canonicalCopyMethod: Option[Method.OnInstance.Of[A]] = {
       val constructorShape = primaryConstructor.asUntyped.parameters.map(_.keys.toList)
-      methods.collectFirst {
+      // order-independent: unique `copy` matching the primary-constructor shape
+      Method.unsortedMethodsOf[A].collectFirst {
         case oi: Method.OnInstance
             if oi.name == "copy" && oi.asUntyped.parameters.map(_.keys.toList) == constructorShape =>
           oi.asInstanceOf[Method.OnInstance.Of[A]]
@@ -486,9 +570,13 @@ trait Classes { this: MacroCommons =>
       case _                                    => name
     }
 
+    private type Result[A] = Option[CaseClass[A]]
+    private lazy val unapplyCache = new Type.Cache[Result]
     def unapply[A](tpe: Type[A]): Option[CaseClass[A]] =
-      if (tpe.isCaseClass) tpe.primaryConstructor.map(new CaseClass(tpe, _))
-      else None
+      unapplyCache.getOrPut(tpe) {
+        if (tpe.isCaseClass) tpe.primaryConstructor.map(new CaseClass(tpe, _))
+        else None
+      }
 
     /** Parses a type as a [[CaseClass]].
       *
@@ -673,11 +761,15 @@ trait Classes { this: MacroCommons =>
   }
   object Enum {
 
+    private type Result[A] = Option[Enum[A]]
+    private lazy val unapplyCache = new Type.Cache[Result]
     def unapply[A](tpe: Type[A]): Option[Enum[A]] =
-      if (tpe.isSealed) tpe.directChildren.map(children => new Enum(tpe, children))
-      else if (tpe.isEnumeration) tpe.directChildren.map(children => new Enum(tpe, children))
-      else if (tpe.isUnionType) tpe.directChildren.map(children => new Enum(tpe, children))
-      else None
+      unapplyCache.getOrPut(tpe) {
+        if (tpe.isSealed) tpe.directChildren.map(children => new Enum(tpe, children))
+        else if (tpe.isEnumeration) tpe.directChildren.map(children => new Enum(tpe, children))
+        else if (tpe.isUnionType) tpe.directChildren.map(children => new Enum(tpe, children))
+        else None
+      }
 
     /** Parses a type as an [[Enum]].
       *
@@ -715,8 +807,8 @@ trait Classes { this: MacroCommons =>
       val defaultConstructor: Method
   ) extends Class[A]()(using tpe0) {
 
-    lazy val beanGetters: List[Method] = methods.filter(_.isJavaGetter)
-    lazy val beanSetters: List[Method] = methods.filter(_.isJavaSetter)
+    lazy val beanGetters: List[Method] = sortedMethodsMatching(_.isJavaGetter)
+    lazy val beanSetters: List[Method] = sortedMethodsMatching(_.isJavaSetter)
 
     /** Builds `new A()` via the default constructor, applying no setters.
       *
@@ -842,9 +934,13 @@ trait Classes { this: MacroCommons =>
   }
   object JavaBean {
 
+    private type Result[A] = Option[JavaBean[A]]
+    private lazy val unapplyCache = new Type.Cache[Result]
     def unapply[A](tpe: Type[A]): Option[JavaBean[A]] =
-      if (tpe.isJavaBean) tpe.defaultConstructor.map(new JavaBean(tpe, _))
-      else None
+      unapplyCache.getOrPut(tpe) {
+        if (tpe.isJavaBean) tpe.defaultConstructor.map(new JavaBean(tpe, _))
+        else None
+      }
 
     /** Parses a type as a [[JavaBean]].
       *
@@ -1273,7 +1369,7 @@ trait Classes { this: MacroCommons =>
         val classParents = allParentTypes.filter(p => !p.asUntyped.isTrait)
         val traitParentsList = allParentTypes.filter(p => p.asUntyped.isTrait)
 
-        if (classParents.size > 1)
+        if (classParents.sizeIs > 1)
           ClassViewResult.Incompatible(AnonymousInstanceError.MultipleClassParents(classParents).message)
         else {
           val classParentValidation: Either[String, Option[(??, List[Method])]] = classParents.headOption match {
@@ -1305,7 +1401,8 @@ trait Classes { this: MacroCommons =>
 
     private def classifyMethods[A: Type](parentTypes: List[??]): List[ClassifiedMethod] = {
       val allMethods: List[(Method, ??)] = parentTypes.flatMap { parentType =>
-        val methods = UntypedMethod.methods(parentType.asUntyped).map(_.asTyped[A])
+        // order-independent: the result is grouped by (name, signature) and finally sorted below
+        val methods = UntypedMethod.unsortedMethods(parentType.asUntyped).map(_.asTyped[A])
         methods
           .filterNot(_.isConstructor)
           .filterNot(_.isSynthetic)
@@ -1340,7 +1437,7 @@ trait Classes { this: MacroCommons =>
             }
           } else {
             val concreteImpls = methodsWithParent.filterNot(_._1.isAbstract)
-            if (concreteImpls.size > 1 && hasDistinctDeclaredImpls(concreteImpls)) {
+            if (concreteImpls.sizeIs > 1 && hasDistinctDeclaredImpls(concreteImpls)) {
               List(ClassifiedMethod(method, MethodClassification.DiamondConflict, declaredIn))
             } else {
               List(ClassifiedMethod(method, MethodClassification.MayOverride, declaredIn))
@@ -1358,14 +1455,10 @@ trait Classes { this: MacroCommons =>
 
     private def hasDistinctDeclaredImpls(impls: List[(Method, ??)]): Boolean = {
       val declared = impls.filter(_._1.isDeclared)
-      if (declared.size > 1) {
+      if (declared.sizeIs > 1) {
         val distinctSources = declared.map(_._2).distinctBy(_.asUntyped.plainPrint)
-        distinctSources.size > 1
-      } else if (declared.isEmpty) {
-        false
-      } else {
-        false
-      }
+        distinctSources.sizeIs > 1
+      } else false
     }
   }
 }

--- a/hearth/src/main/scala/hearth/typed/Methods.scala
+++ b/hearth/src/main/scala/hearth/typed/Methods.scala
@@ -618,17 +618,32 @@ trait Methods { this: MacroCommons =>
     def constructorsOf[A: Type]: List[Method] =
       UntypedType.fromTyped[A].constructors.map(_.asTyped[A])
 
-    /** Returns all methods (declared, inherited and synthetic) of `A`, each as a builder chain resolved against `A`.
+    /** Returns all methods (declared, inherited and synthetic) of `A`, each as a builder chain resolved against `A`, in
+      * a STABLE, deterministic order (see [[UntypedMethod.methods]]).
+      *
+      * The ordering is comparatively expensive (it resolves each declared method's source position). '''Prefer
+      * [[unsortedMethodsOf]] unless you rely on the order''' - most callers only search by name.
       *
       * @since 0.4.0
       *
       * @tparam A
       *   the instance type the methods are resolved against
       * @return
-      *   every method visible on `A` as a [[Method]]
+      *   every method visible on `A` as a [[Method]], in deterministic order
       */
     def methodsOf[A: Type]: List[Method] =
       UntypedType.fromTyped[A].methods.map(_.asTyped[A])
+
+    /** Like [[methodsOf]] but in raw discovery order, WITHOUT the expensive position-resolving sort (see
+      * [[UntypedMethod.unsortedMethods]]).
+      *
+      * Cheaper than [[methodsOf]]; the order is unspecified. '''Recommended''' whenever the result is only searched or
+      * filtered by name (`find`/`collectFirst`/`filter`/`exists`) rather than consumed as a deterministic sequence.
+      *
+      * @since 0.4.1
+      */
+    def unsortedMethodsOf[A: Type]: List[Method] =
+      UntypedType.fromTyped[A].unsortedMethods.map(_.asTyped[A])
 
     private[hearth] def buildChain(
         asUntyped: UntypedMethod,

--- a/hearth/src/main/scala/hearth/typed/Types.scala
+++ b/hearth/src/main/scala/hearth/typed/Types.scala
@@ -1016,6 +1016,58 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
     }
     final def ModuleCodec[ModuleSingleton <: Singleton]: TypeCodec[ModuleSingleton] =
       ModuleCodecImpl.asInstanceOf[TypeCodec[ModuleSingleton]]
+
+    /** A mutable, macro-expansion-scoped memo keyed by `Type`, storing one `F[Result]` per distinct type.
+      *
+      * Intended for caching the results of expensive per-type computations (class-view parsing, std-extension provider
+      * scans, etc.) so they run at most once per type within a single macro expansion.
+      *
+      * Keys are compared with [[=:=]] (semantic type equality), '''not''' `==`: a `Type[A]` has no value-based
+      * `equals`, so on Scala 3 `==` is reference identity and would miss almost every hit. `=:=` results are themselves
+      * memoized on Scala 3, so repeated lookups stay cheap. A miss simply recomputes, so a stale, partial, or leaky
+      * cache can never yield a wrong result — only less speed-up.
+      *
+      * Not thread-safe; a macro expansion is single-threaded.
+      *
+      * @since 0.4.1
+      */
+    final class Cache[F[_]] {
+      private val impl = scala.collection.mutable.ListBuffer.empty[Cache.Entry[F]]
+
+      /** Returns the cached `F[Result]` for a type `=:=` `key`, or `None`. */
+      def get[Result](key: Type[Result]): Option[F[Result]] =
+        impl.collectFirst { case e if e.key =:= key => e.value.asInstanceOf[F[Result]] }
+
+      /** Stores `value` under `key`. Does not deduplicate — call [[getOrPut]] to avoid recomputation. */
+      def put[Result](key: Type[Result], value: F[Result]): Unit = {
+        impl += Cache.Entry[F, Result](key, value)
+        ()
+      }
+
+      /** Returns the cached `F[Result]` for a type `=:=` `key`, computing and storing `value` on a miss. */
+      def getOrPut[Result](key: Type[Result])(value: => F[Result]): F[Result] =
+        get(key).getOrElse {
+          val result = value
+          put(key, result)
+          result
+        }
+    }
+    object Cache {
+
+      /** A single `(key, value)` entry, hiding the concrete `Result` type behind an abstract type member. */
+      sealed trait Entry[F[_]] {
+        type Result
+        def key: Type[Result]
+        def value: F[Result]
+      }
+      object Entry {
+        def apply[F[_], R](k: Type[R], v: F[R]): Entry[F] = new Entry[F] {
+          type Result = R
+          val key: Type[R] = k
+          val value: F[R] = v
+        }
+      }
+    }
   }
 
   implicit final class TypeMethods[A](private val tpe: Type[A]) {
@@ -1042,8 +1094,17 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
     def constructors: List[Method { type Instance = A }] =
       Method.constructorsOf(using tpe).map(_.asInstanceOf[Method { type Instance = A }])
 
+    /** All methods of `A` in a stable, deterministic order - see [[Method.methodsOf]]. Costlier than
+      * [[unsortedMethods]]; prefer that unless you rely on ordering.
+      */
     def methods: List[Method { type Instance = A }] =
       Method.methodsOf(using tpe).map(_.asInstanceOf[Method { type Instance = A }])
+
+    /** All methods of `A` in raw discovery order, without the expensive position-resolving sort - see
+      * [[Method.unsortedMethodsOf]]. Recommended when the result is only searched/filtered by name.
+      */
+    def unsortedMethods: List[Method { type Instance = A }] =
+      Method.unsortedMethodsOf(using tpe).map(_.asInstanceOf[Method { type Instance = A }])
 
     def companionObject: Option[Expr_??] = Type.companionObject(using tpe)
 

--- a/hearth/src/main/scala/hearth/typename/TypeNameMacros.scala
+++ b/hearth/src/main/scala/hearth/typename/TypeNameMacros.scala
@@ -10,7 +10,7 @@ private[typename] trait TypeNameMacros { this: MacroCommons =>
     Type
       .of[TypeName.type]
       .asUntyped
-      .methods
+      .unsortedMethods // order-independent: name-selected ignore-set for implicit summoning
       .collect { case method if method.name == "derived" => method }
       .toSeq
 

--- a/hearth/src/main/scala/hearth/untyped/UntypedMethods.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedMethods.scala
@@ -221,7 +221,30 @@ trait UntypedMethods { this: MacroCommons =>
       */
     def primaryConstructor(instanceTpe: UntypedType): Option[UntypedMethod]
     def constructors(instanceTpe: UntypedType): List[UntypedMethod]
+
+    /** All of `instanceTpe`'s methods in a STABLE, deterministic, cross-platform-consistent order: constructor
+      * arguments first (by their position in the primary constructor), then declared methods by source [[Position]],
+      * then inherited/synthetic methods by name (see [[sortMethods]]).
+      *
+      * Establishing that order resolves each declared method's [[Position]], which is comparatively expensive (it is
+      * what shows up as `positionOf` in profiles). '''Prefer the cheaper [[unsortedMethods]] unless you actually rely
+      * on the ordering''' (e.g. presenting members to a user, or emitting them in a reproducible sequence).
+      * `methods == sortMethods(unsortedMethods(instanceTpe))`.
+      *
+      * @since 0.1.0
+      */
     def methods(instanceTpe: UntypedType): List[UntypedMethod]
+
+    /** All of `instanceTpe`'s methods in raw discovery order, WITHOUT the [[sortMethods]] pass.
+      *
+      * Cheaper than [[methods]] - it does not resolve method [[Position]]s - but the order is unspecified and may
+      * differ across platforms and compiler versions. '''Recommended''' whenever the result is only searched or
+      * filtered by name (`find`/`collectFirst`/`filter`/`exists`/membership) rather than consumed as a deterministic
+      * sequence.
+      *
+      * @since 0.4.1
+      */
+    def unsortedMethods(instanceTpe: UntypedType): List[UntypedMethod]
 
     def defaultValue(instanceTpe: UntypedType)(param: UntypedParameter): Option[UntypedMethod]
 
@@ -240,20 +263,42 @@ trait UntypedMethods { this: MacroCommons =>
       * non-constructor-argument methods, ordered by source position. Then inherited/synthetic methods, ordered by name
       * using [[hearth.fp.NaturalLanguageOrdering]] (which handles _1, _2, ..., _10, _11 correctly).
       */
-    final protected def sortMethods(methods: List[UntypedMethod]): List[UntypedMethod] = {
-      val (ctorArgs, rest) = methods.partition(_.isConstructorArgument)
-      val sortedCtorArgs = ctorArgs.sortBy(_.constructorArgumentIndex.getOrElse(Int.MaxValue))
+    final protected def sortMethods(methods: List[UntypedMethod]): List[UntypedMethod] =
+      sortMethodsBy(methods)(identity)
 
-      val (declared, others) = rest.partitionMap { method =>
-        method.position match {
-          case Some(position) if method.isDeclared => Left(position -> method)
-          case _                                   => Right(method)
-        }
+    /** [[sortMethods]] generalized over any element type that can produce an [[UntypedMethod]] key.
+      *
+      * Because the sort key of each element is computed purely from that element (its ctor-arg index, declaration
+      * position, or name), `sortMethodsBy(xs.filter(p)) == sortMethodsBy(xs).filter(p)` - so a caller that wants only
+      * some methods (e.g. `caseFields`, `beanGetters`, `method(name)`) can filter FIRST and sort the small subset
+      * instead of sorting the whole member list. Pass a `.view.filter(...)` to avoid materializing the intermediate.
+      *
+      * `toUntyped` is invoked exactly ONCE per element (its key is captured up front), so it is safe to pass a typed
+      * `_.asUntyped`. `position` is still resolved only for declared methods (the expensive `positionOf`).
+      *
+      * @since 0.4.1
+      */
+    final private[hearth] def sortMethodsBy[M](methods: IterableOnce[M])(toUntyped: M => UntypedMethod): List[M] = {
+      import scala.collection.mutable.ListBuffer
+      val ctorArgs = ListBuffer.empty[(Int, M)]
+      val declared = ListBuffer.empty[(Position, M)]
+      val others = ListBuffer.empty[(String, M)]
+      methods.iterator.foreach { m =>
+        val u = toUntyped(m)
+        if (u.isConstructorArgument) ctorArgs += ((u.constructorArgumentIndex.getOrElse(Int.MaxValue), m))
+        else if (u.isDeclared)
+          u.position match {
+            case Some(position) => declared += ((position, m))
+            case None           => others += ((u.name, m))
+          }
+        else others += ((u.name, m))
       }
-      val sortedDeclared = declared.sortBy(_._1).map(_._2)
-      val sortedOthers = others.sortBy(_.name)(hearth.fp.NaturalLanguageOrdering.caseInsensitive)
 
-      sortedCtorArgs ++ sortedDeclared ++ sortedOthers
+      val result = ListBuffer.empty[M]
+      ctorArgs.sortBy(_._1).foreach { case (_, m) => result += m }
+      declared.sortBy(_._1).foreach { case (_, m) => result += m }
+      others.sortBy(_._1)(hearth.fp.NaturalLanguageOrdering.caseInsensitive).foreach { case (_, m) => result += m }
+      result.toList
     }
 
     // Defaults methods' positions are 1-indexed. They are named `methodName$default$indexOfParameter`.

--- a/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
@@ -524,7 +524,14 @@ trait UntypedTypes { this: MacroCommons =>
 
     def primaryConstructor: Option[UntypedMethod] = UntypedMethod.primaryConstructor(untyped)
     def constructors: List[UntypedMethod] = UntypedMethod.constructors(untyped)
+
+    /** Methods in stable, deterministic order - see [[UntypedMethod.methods]]. Costlier than [[unsortedMethods]]. */
     def methods: List[UntypedMethod] = UntypedMethod.methods(untyped)
+
+    /** Methods in raw discovery order (cheaper - no position sort) - see [[UntypedMethod.unsortedMethods]]. Recommended
+      * when only searching/filtering by name.
+      */
+    def unsortedMethods: List[UntypedMethod] = UntypedMethod.unsortedMethods(untyped)
 
     def companionObject: Option[(UntypedType, UntypedExpr)] = UntypedType.companionObject(untyped)
 

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
@@ -63,9 +63,10 @@ final class IsCollectionProviderForJavaBitSet extends StandardMacroExtension { l
             implicit val intType: Type[Int] = Int
             implicit val builderType: Type[scala.collection.mutable.Builder[Int, CtorResult]] =
               Builder[Int, CtorResult]
-            val resultMethod = Method.methodsOf[scala.collection.mutable.Builder[Int, CtorResult]].collectFirst {
-              case m: Method.OnInstance if m.name == "result" && m.isNullary => m
-            }
+            val resultMethod =
+              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Int, CtorResult]].collectFirst {
+                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Int, CtorResult]]) => Expr.quote(Expr.splice(expr).result()),
               resultMethod

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
@@ -130,9 +130,16 @@ final class IsCollectionProviderForJavaCollection extends StandardMacroExtension
                       // Bypass EnumSet.noneOf type bound (E <: Enum[E]) via reflection:
                       // Scala 2 cannot infer E for the static method call due to
                       // F-bounded polymorphism + Class invariance.
+                      //
+                      // Resolve the reflective classes via `Class.forName` STRINGS rather than
+                      // `classOf[java.util.EnumSet[?]]` / `classOf[java.lang.Class[?]]` wildcard literals: those print
+                      // RAW (`classOf[java.util.EnumSet]`) after a downstream `c.untypecheck` + re-typecheck on Scala 2
+                      // and fail with "class EnumSet takes type parameters". `Class.forName` strings survive re-typecheck
+                      // unchanged. See issue #321.
                       val cls: java.lang.Class[?] = Expr.splice(enumClassExpr)
-                      classOf[java.util.EnumSet[?]]
-                        .getMethod("noneOf", classOf[java.lang.Class[?]])
+                      java.lang.Class
+                        .forName("java.util.EnumSet")
+                        .getMethod("noneOf", java.lang.Class.forName("java.lang.Class"))
                         .invoke(null, cls)
                         .asInstanceOf[java.util.EnumSet[?]]
                     }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
@@ -89,9 +89,10 @@ final class IsCollectionProviderForJavaCollection extends StandardMacroExtension
           override def build: CtorLikeOf[scala.collection.mutable.Builder[Item, CtorResult], A] = {
             implicit val builderType: Type[scala.collection.mutable.Builder[Item, CtorResult]] =
               Builder[Item, CtorResult]
-            val resultMethod = Method.methodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
-              case m: Method.OnInstance if m.name == "result" && m.isNullary => m
-            }
+            val resultMethod =
+              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
+                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Item, CtorResult]]) =>
                 Expr.quote(Expr.splice(expr).result()),

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
@@ -89,9 +89,10 @@ final class IsCollectionProviderForJavaDictionary extends StandardMacroExtension
           override def build: CtorLikeOf[scala.collection.mutable.Builder[Pair, CtorResult], A] = {
             implicit val builderType: Type[scala.collection.mutable.Builder[Pair, CtorResult]] =
               Builder[Pair, CtorResult]
-            val resultMethod = Method.methodsOf[scala.collection.mutable.Builder[Pair, CtorResult]].collectFirst {
-              case m: Method.OnInstance if m.name == "result" && m.isNullary => m
-            }
+            val resultMethod =
+              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Pair, CtorResult]].collectFirst {
+                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Pair, CtorResult]]) =>
                 Expr.quote(Expr.splice(expr).result()),
@@ -171,7 +172,7 @@ final class IsCollectionProviderForJavaDictionary extends StandardMacroExtension
                 Builder[(String, String), java.util.Properties]
               val resultMethod =
                 Method
-                  .methodsOf[scala.collection.mutable.Builder[(String, String), java.util.Properties]]
+                  .unsortedMethodsOf[scala.collection.mutable.Builder[(String, String), java.util.Properties]]
                   .collectFirst {
                     case m: Method.OnInstance if m.name == "result" && m.isNullary => m
                   }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaEnumeration.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaEnumeration.scala
@@ -61,9 +61,10 @@ final class IsCollectionProviderForJavaEnumeration extends StandardMacroExtensio
           override def build: CtorLikeOf[scala.collection.mutable.Builder[Item, CtorResult], A] = {
             implicit val builderType: Type[scala.collection.mutable.Builder[Item, CtorResult]] =
               Builder[Item, CtorResult]
-            val resultMethod = Method.methodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
-              case m: Method.OnInstance if m.name == "result" && m.isNullary => m
-            }
+            val resultMethod =
+              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
+                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Item, CtorResult]]) =>
                 Expr.quote(Expr.splice(expr).result()),

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterator.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterator.scala
@@ -61,9 +61,10 @@ final class IsCollectionProviderForJavaIterator extends StandardMacroExtension {
           override def build: CtorLikeOf[scala.collection.mutable.Builder[Item, CtorResult], A] = {
             implicit val builderType: Type[scala.collection.mutable.Builder[Item, CtorResult]] =
               Builder[Item, CtorResult]
-            val resultMethod = Method.methodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
-              case m: Method.OnInstance if m.name == "result" && m.isNullary => m
-            }
+            val resultMethod =
+              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
+                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Item, CtorResult]]) =>
                 Expr.quote(Expr.splice(expr).result()),

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
@@ -101,9 +101,10 @@ final class IsCollectionProviderForJavaMap extends StandardMacroExtension { load
           override def build: CtorLikeOf[scala.collection.mutable.Builder[Pair, CtorResult], A] = {
             implicit val builderType: Type[scala.collection.mutable.Builder[Pair, CtorResult]] =
               Builder[Pair, CtorResult]
-            val resultMethod = Method.methodsOf[scala.collection.mutable.Builder[Pair, CtorResult]].collectFirst {
-              case m: Method.OnInstance if m.name == "result" && m.isNullary => m
-            }
+            val resultMethod =
+              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Pair, CtorResult]].collectFirst {
+                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Pair, CtorResult]]) =>
                 Expr.quote(Expr.splice(expr).result()),
@@ -162,9 +163,10 @@ final class IsCollectionProviderForJavaMap extends StandardMacroExtension { load
           override def build: CtorLikeOf[scala.collection.mutable.Builder[Pair, CtorResult], A] = {
             implicit val builderType: Type[scala.collection.mutable.Builder[Pair, CtorResult]] =
               Builder[Pair, CtorResult]
-            val resultMethod = Method.methodsOf[scala.collection.mutable.Builder[Pair, CtorResult]].collectFirst {
-              case m: Method.OnInstance if m.name == "result" && m.isNullary => m
-            }
+            val resultMethod =
+              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Pair, CtorResult]].collectFirst {
+                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Pair, CtorResult]]) =>
                 Expr.quote(Expr.splice(expr).result()),

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaOptional.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaOptional.scala
@@ -61,7 +61,7 @@ final class IsCollectionProviderForJavaOptional extends StandardMacroExtension {
               (builder: Expr[scala.collection.mutable.Builder[Item, List[Item]]]) =>
                 Expr.quote {
                   val list = Expr.splice(builder).result()
-                  if (list.size <= 1)
+                  if (list.lengthIs <= 1)
                     Right(
                       Expr.splice(
                         Expr

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaStream.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaStream.scala
@@ -73,9 +73,10 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
           override def build: CtorLikeOf[scala.collection.mutable.Builder[Item, CtorResult], A] = {
             implicit val builderType: Type[scala.collection.mutable.Builder[Item, CtorResult]] =
               Builder[Item, CtorResult]
-            val resultMethod = Method.methodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
-              case m: Method.OnInstance if m.name == "result" && m.isNullary => m
-            }
+            val resultMethod =
+              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
+                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Item, CtorResult]]) =>
                 Expr.quote(Expr.splice(expr).result()),
@@ -124,9 +125,10 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
             implicit val intType: Type[Int] = Int
             implicit val builderType: Type[scala.collection.mutable.Builder[Int, CtorResult]] =
               Builder[Int, CtorResult]
-            val resultMethod = Method.methodsOf[scala.collection.mutable.Builder[Int, CtorResult]].collectFirst {
-              case m: Method.OnInstance if m.name == "result" && m.isNullary => m
-            }
+            val resultMethod =
+              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Int, CtorResult]].collectFirst {
+                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Int, CtorResult]]) => Expr.quote(Expr.splice(expr).result()),
               resultMethod
@@ -174,9 +176,10 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
             implicit val longType: Type[Long] = Long
             implicit val builderType: Type[scala.collection.mutable.Builder[Long, CtorResult]] =
               Builder[Long, CtorResult]
-            val resultMethod = Method.methodsOf[scala.collection.mutable.Builder[Long, CtorResult]].collectFirst {
-              case m: Method.OnInstance if m.name == "result" && m.isNullary => m
-            }
+            val resultMethod =
+              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Long, CtorResult]].collectFirst {
+                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Long, CtorResult]]) =>
                 Expr.quote(Expr.splice(expr).result()),
@@ -226,7 +229,7 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
             implicit val builderType: Type[scala.collection.mutable.Builder[Double, CtorResult]] =
               Builder[Double, CtorResult]
             val resultMethod =
-              Method.methodsOf[scala.collection.mutable.Builder[Double, CtorResult]].collectFirst {
+              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Double, CtorResult]].collectFirst {
                 case m: Method.OnInstance if m.name == "result" && m.isNullary => m
               }
             CtorLikeOf.PlainValue(

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaBoolean.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaBoolean.scala
@@ -24,7 +24,7 @@ final class IsValueTypeProviderForJavaBoolean extends StandardMacroExtension { l
 
       private lazy val valueOfMethod: Option[Method] = {
         implicit val jBoolean: Type[java.lang.Boolean] = JBoolean
-        Method.methodsOf[java.lang.Boolean].collectFirst {
+        Method.unsortedMethodsOf[java.lang.Boolean].collectFirst {
           case m
               if m.name == "valueOf" && m.isUnary && !m.isInstanceOf[Method.OnInstance] &&
                 m.parameters.flatten.headOption.exists { case (_, p) => p.tpe.Underlying <:< Boolean } =>
@@ -33,7 +33,7 @@ final class IsValueTypeProviderForJavaBoolean extends StandardMacroExtension { l
       }
 
       @scala.annotation.nowarn
-      private val isValueType: IsValueType[java.lang.Boolean] = {
+      private lazy val isValueType: IsValueType[java.lang.Boolean] = {
         implicit val boolean: Type[Boolean] = Boolean
         implicit val jBoolean: Type[java.lang.Boolean] = JBoolean
         Existential[IsValueTypeOf[java.lang.Boolean, *], Boolean](new IsValueTypeOf[java.lang.Boolean, Boolean] {
@@ -44,7 +44,7 @@ final class IsValueTypeProviderForJavaBoolean extends StandardMacroExtension { l
               (expr: Expr[Boolean]) => Expr.quote(java.lang.Boolean.valueOf(Expr.splice(expr))),
               valueOfMethod
             )
-          override val ctors: CtorLikes[java.lang.Boolean] = CtorLikes
+          override lazy val ctors: CtorLikes[java.lang.Boolean] = CtorLikes
             .unapply(JBoolean)
             .getOrElse(NonEmptyList.one(Existential[CtorLikeOf[*, java.lang.Boolean], Boolean](wrap)))
         })

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaByte.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaByte.scala
@@ -24,7 +24,7 @@ final class IsValueTypeProviderForJavaByte extends StandardMacroExtension { load
 
       private lazy val valueOfMethod: Option[Method] = {
         implicit val jByte: Type[java.lang.Byte] = JByte
-        Method.methodsOf[java.lang.Byte].collectFirst {
+        Method.unsortedMethodsOf[java.lang.Byte].collectFirst {
           case m
               if m.name == "valueOf" && m.isUnary && !m.isInstanceOf[Method.OnInstance] &&
                 m.parameters.flatten.headOption.exists { case (_, p) => p.tpe.Underlying <:< Byte } =>
@@ -33,7 +33,7 @@ final class IsValueTypeProviderForJavaByte extends StandardMacroExtension { load
       }
 
       @scala.annotation.nowarn
-      private val isValueType: IsValueType[java.lang.Byte] = {
+      private lazy val isValueType: IsValueType[java.lang.Byte] = {
         implicit val byte: Type[Byte] = Byte
         implicit val jByte: Type[java.lang.Byte] = JByte
         Existential[IsValueTypeOf[java.lang.Byte, *], Byte](new IsValueTypeOf[java.lang.Byte, Byte] {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaCharacter.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaCharacter.scala
@@ -24,7 +24,7 @@ final class IsValueTypeProviderForJavaCharacter extends StandardMacroExtension {
 
       private lazy val valueOfMethod: Option[Method] = {
         implicit val jCharacter: Type[java.lang.Character] = JCharacter
-        Method.methodsOf[java.lang.Character].collectFirst {
+        Method.unsortedMethodsOf[java.lang.Character].collectFirst {
           case m
               if m.name == "valueOf" && m.isUnary && !m.isInstanceOf[Method.OnInstance] &&
                 m.parameters.flatten.headOption.exists { case (_, p) => p.tpe.Underlying <:< Char } =>
@@ -33,7 +33,7 @@ final class IsValueTypeProviderForJavaCharacter extends StandardMacroExtension {
       }
 
       @scala.annotation.nowarn
-      private val isValueType: IsValueType[java.lang.Character] = {
+      private lazy val isValueType: IsValueType[java.lang.Character] = {
         implicit val char: Type[Char] = Char
         implicit val jCharacter: Type[java.lang.Character] = JCharacter
         Existential[IsValueTypeOf[java.lang.Character, *], Char](new IsValueTypeOf[java.lang.Character, Char] {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaDouble.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaDouble.scala
@@ -24,7 +24,7 @@ final class IsValueTypeProviderForJavaDouble extends StandardMacroExtension { lo
 
       private lazy val valueOfMethod: Option[Method] = {
         implicit val jDouble: Type[java.lang.Double] = JDouble
-        Method.methodsOf[java.lang.Double].collectFirst {
+        Method.unsortedMethodsOf[java.lang.Double].collectFirst {
           case m
               if m.name == "valueOf" && m.isUnary && !m.isInstanceOf[Method.OnInstance] &&
                 m.parameters.flatten.headOption.exists { case (_, p) => p.tpe.Underlying <:< Double } =>
@@ -33,7 +33,7 @@ final class IsValueTypeProviderForJavaDouble extends StandardMacroExtension { lo
       }
 
       @scala.annotation.nowarn
-      private val isValueType: IsValueType[java.lang.Double] = {
+      private lazy val isValueType: IsValueType[java.lang.Double] = {
         implicit val double: Type[Double] = Double
         implicit val jDouble: Type[java.lang.Double] = JDouble
         Existential[IsValueTypeOf[java.lang.Double, *], Double](new IsValueTypeOf[java.lang.Double, Double] {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaFloat.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaFloat.scala
@@ -24,7 +24,7 @@ final class IsValueTypeProviderForJavaFloat extends StandardMacroExtension { loa
 
       private lazy val valueOfMethod: Option[Method] = {
         implicit val jFloat: Type[java.lang.Float] = JFloat
-        Method.methodsOf[java.lang.Float].collectFirst {
+        Method.unsortedMethodsOf[java.lang.Float].collectFirst {
           case m
               if m.name == "valueOf" && m.isUnary && !m.isInstanceOf[Method.OnInstance] &&
                 m.parameters.flatten.headOption.exists { case (_, p) => p.tpe.Underlying <:< Float } =>
@@ -33,7 +33,7 @@ final class IsValueTypeProviderForJavaFloat extends StandardMacroExtension { loa
       }
 
       @scala.annotation.nowarn
-      private val isValueType: IsValueType[java.lang.Float] = {
+      private lazy val isValueType: IsValueType[java.lang.Float] = {
         implicit val float: Type[Float] = Float
         implicit val jFloat: Type[java.lang.Float] = JFloat
         Existential[IsValueTypeOf[java.lang.Float, *], Float](new IsValueTypeOf[java.lang.Float, Float] {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaInteger.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaInteger.scala
@@ -24,7 +24,7 @@ final class IsValueTypeProviderForJavaInteger extends StandardMacroExtension { l
 
       private lazy val valueOfMethod: Option[Method] = {
         implicit val jInteger: Type[java.lang.Integer] = JInteger
-        Method.methodsOf[java.lang.Integer].collectFirst {
+        Method.unsortedMethodsOf[java.lang.Integer].collectFirst {
           case m
               if m.name == "valueOf" && m.isUnary && !m.isInstanceOf[Method.OnInstance] &&
                 m.parameters.flatten.headOption.exists { case (_, p) => p.tpe.Underlying <:< Int } =>
@@ -33,7 +33,7 @@ final class IsValueTypeProviderForJavaInteger extends StandardMacroExtension { l
       }
 
       @scala.annotation.nowarn
-      private val isValueType: IsValueType[java.lang.Integer] = {
+      private lazy val isValueType: IsValueType[java.lang.Integer] = {
         implicit val int: Type[Int] = Int
         implicit val jInteger: Type[java.lang.Integer] = JInteger
         Existential[IsValueTypeOf[java.lang.Integer, *], Int](new IsValueTypeOf[java.lang.Integer, Int] {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaLong.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaLong.scala
@@ -24,7 +24,7 @@ final class IsValueTypeProviderForJavaLong extends StandardMacroExtension { load
 
       private lazy val valueOfMethod: Option[Method] = {
         implicit val jLong: Type[java.lang.Long] = JLong
-        Method.methodsOf[java.lang.Long].collectFirst {
+        Method.unsortedMethodsOf[java.lang.Long].collectFirst {
           case m
               if m.name == "valueOf" && m.isUnary && !m.isInstanceOf[Method.OnInstance] &&
                 m.parameters.flatten.headOption.exists { case (_, p) => p.tpe.Underlying <:< Long } =>
@@ -33,7 +33,7 @@ final class IsValueTypeProviderForJavaLong extends StandardMacroExtension { load
       }
 
       @scala.annotation.nowarn
-      private val isValueType: IsValueType[java.lang.Long] = {
+      private lazy val isValueType: IsValueType[java.lang.Long] = {
         implicit val long: Type[Long] = Long
         implicit val jLong: Type[java.lang.Long] = JLong
         Existential[IsValueTypeOf[java.lang.Long, *], Long](new IsValueTypeOf[java.lang.Long, Long] {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaShort.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaShort.scala
@@ -24,7 +24,7 @@ final class IsValueTypeProviderForJavaShort extends StandardMacroExtension { loa
 
       private lazy val valueOfMethod: Option[Method] = {
         implicit val jShort: Type[java.lang.Short] = JShort
-        Method.methodsOf[java.lang.Short].collectFirst {
+        Method.unsortedMethodsOf[java.lang.Short].collectFirst {
           case m
               if m.name == "valueOf" && m.isUnary && !m.isInstanceOf[Method.OnInstance] &&
                 m.parameters.flatten.headOption.exists { case (_, p) => p.tpe.Underlying <:< Short } =>
@@ -33,7 +33,7 @@ final class IsValueTypeProviderForJavaShort extends StandardMacroExtension { loa
       }
 
       @scala.annotation.nowarn
-      private val isValueType: IsValueType[java.lang.Short] = {
+      private lazy val isValueType: IsValueType[java.lang.Short] = {
         implicit val short: Type[Short] = Short
         implicit val jShort: Type[java.lang.Short] = JShort
         Existential[IsValueTypeOf[java.lang.Short, *], Short](new IsValueTypeOf[java.lang.Short, Short] {


### PR DESCRIPTION
Two commits toward Hearth 0.4.1, bundled because Chimney's 2.0.0 migration (scalalandio/chimney#904) consumes both together.

## 1. Fix #321 — EnumSet provider factory survives downstream Scala 2 re-typecheck

The `isEnumSet` factory quote resolved reflection via wildcard `classOf[java.util.EnumSet[?]]` / `classOf[java.lang.Class[?]]` literals, which print raw (`class EnumSet takes type parameters`) after a downstream `c.untypecheck` + re-typecheck on Scala 2. Now uses `Class.forName` strings, which survive re-typecheck. Unblocks removal of Chimney's `javaEnumSetFactoryCompat` workaround. (Negative control: pre-fix Hearth + workaround removed reproduces the exact error.)

## 2. Compilation performance (addresses Chimney compile-time regressions)

- **`Type.Cache[F[_]]`** — a per-expansion memo keyed by type, compared with `=:=` (a `Type` has no value equality, so `==` is reference identity on Scala 3 and would miss). `get`/`put`/`getOrPut`; a miss only recomputes, so it can never return a wrong result.
- **Memoized heavy per-type parsing** with it: each class-view `unapply` (`SingletonValue`/`NamedTuple`/`CaseClass`/`Enum`/`JavaBean`) and the std provider scan (`firstMatchCached` in `ProvidedCompanion`, used by `IsCollection`/`IsOption`/`IsEither`/`IsValueType`; `IsMap` transitively). `firstMatchCached` snapshots and replays `lastMatchProvenance` so that observable state stays correct on cache hits.
- **Lazy `ClassViewResult.Incompatible.reason`** (case class → plain class): the reason is an expensive `Type.prettyPrint` most callers discard. Source surface (`unapply`/`equals`/`hashCode`/`toString`/`Product`, `Incompatible(reason)` build+extract) preserved; only the TASTy `case` flag dropped. MiMa filters added (2.13 + Scala 3 `Mirror` encodings) and for the additive `Type.Cache`.
- **`Environment.withMioLoggingDisabled { thunk }`** backed by `MIO.disableLogging`, no-ops `Log` entries + `namedScope` to skip allocations. `runToExprOrFail` enables it automatically when every rendering knob is `DontRender` (and no error-failing / benchmarking) — i.e. when the whole log tree is discarded anyway.

## Verification

Full suite green on Scala 2.13 (1183) and 3 (1311) + sandwich; MiMa + scalafmt clean on both versions.