### PR TITLE
Perf: compile-time optimizations — 27.2% → 18.9% macro share on a dense derivation load

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -329,6 +329,16 @@ val mimaSettings = Seq(
   // Example of an allowed exclusion (a member added to a NESTED trait/object that MiMa would otherwise flag):
   //   exclude[ReversedMissingMethodProblem]("hearth.typed.SomeTrait#SomeNestedTrait.newHelper")
   mimaBinaryIssueFilters ++= Seq(
+    // Perf: `ProviderResult.skipped` and the nested `ProvidedCompanion#Provider.skipped` helper take the reason
+    // BY-NAME (`=> String`) so a declining provider no longer eagerly builds its skip message - which routinely calls
+    // the expensive `Type#prettyPrint`. Skip reasons are write-mostly (a matching provider discards every earlier skip;
+    // the aggregated reasons are read only to diagnose a total failure), so deferring saves dozens of type renders per
+    // field across the shape companions with no observable behaviour change. The erased signature goes String ->
+    // Function0; `Provider` is a nested trait implemented ONLY by Hearth's own std companions (always evicted with the
+    // interface) and every `StandardMacroExtension` provider is recompiled against its Hearth version, so no standalone
+    // caller can break at link time.
+    exclude[IncompatibleMethTypeProblem]("hearth.std.ProviderResult.skipped"),
+    exclude[DirectMissingMethodProblem]("hearth.std.StdExtensions#ProvidedCompanion#Provider.skipped"),
     // #329: `lastMatchProvenance` provider-provenance state added to the NESTED trait `StdExtensions#ProvidedCompanion`.
     // That trait is part of the MacroCommons cake and is implemented ONLY by Hearth's own std companion objects
     // (IsCollection/IsOption/IsEither/IsValueType/CtorLikes), which live in the same trait - so the interface and its

--- a/build.sbt
+++ b/build.sbt
@@ -386,7 +386,12 @@ val mimaSettings = Seq(
     // NESTED trait `UntypedMethods#UntypedMethodModule`, part of the MacroCommons cake and implemented ONLY by
     // Hearth's own platform `UntypedMethod` object (UntypedMethodsScala2/Scala3) - interface and implementation are
     // always evicted together, so no user has a standalone implementation to break.
-    exclude[ReversedMissingMethodProblem]("hearth.untyped.UntypedMethods#UntypedMethodModule.unsortedMethods")
+    exclude[ReversedMissingMethodProblem]("hearth.untyped.UntypedMethods#UntypedMethodModule.unsortedMethods"),
+    // Perf: `cacheBucketKey` (cheap Type.Cache bucket discriminator - dealiased type symbol) added to the NESTED
+    // trait `UntypedTypes#UntypedTypeModule`, part of the MacroCommons cake and implemented ONLY by Hearth's own
+    // platform `UntypedType` objects (UntypedTypesScala2/Scala3) - interface and implementation are always evicted
+    // together, so no user has a standalone implementation to break. `private[hearth]` besides.
+    exclude[ReversedMissingMethodProblem]("hearth.untyped.UntypedTypes#UntypedTypeModule.cacheBucketKey")
   )
 )
 

--- a/docs/contributing/compile-time-perf-roadmap.md
+++ b/docs/contributing/compile-time-perf-roadmap.md
@@ -198,6 +198,46 @@ cost.
 
 ---
 
+## Part C — `Type.Cache`: bucketing + Cross-Quotes scoping (DONE) and Chimney adoption
+
+**Analysis answers (2026-07-10):**
+
+1. *"Do we always need to initialize all methods/parameters when looking for some?"* — No, and the
+   split is: **`UntypedMethod` construction is cheap** (wraps a `Symbol` + flags; `typeParameters`
+   already lazy) — the untyped enumeration costs one members walk (+ the #327 baseClasses sweep on
+   Scala 3). The expensive step is **`toTyped`** (parameters resolved twice + `returnType`, see Part
+   A findings). So a by-name lookup should filter at the UNTYPED level (symbol-name compare is
+   free) and convert only matches. DONE: `Method.unsortedMethodsNamed[A](name): List[Method]` +
+   `Type[A].unsortedMethodsNamed(name)`, cached per `(type, name)` (a `Type.Cache` holding the
+   untyped list + a mutable `Map[String, List[Method]]`). Switched internally: `canonicalCopyMethod`
+   ("copy") and the 8 collection providers' Builder-"result" lookups. REMAINING: the 8
+   `IsValueTypeProviderForJava*` box lookups ("valueOf"/"xxxValue" — lazily forced, low value) and
+   the big consumer, Chimney's `methodGetter`/`setterCandidates` (a Chimney PR after release —
+   those never convert the ~24 non-matching methods of a type only queried by name).
+
+2. *"Can `Type.Cache` be bucketed by something cheap?"* — Yes, DONE: entries are hash-bucketed by
+   the **dealiased type symbol** (`UntypedTypeModule.cacheBucketKey`; `NoSymbol` → shared sentinel),
+   so the `=:=` scan only runs against same-symbol candidates. This is sound because it mirrors
+   `isSameAs`'s fast negative (differing non-NoSymbol dealiased symbols ⟹ not `=:=`) AND because a
+   cache miss merely recomputes — bucketing can never produce a wrong hit, only (for exotic
+   NoSymbol-vs-symbol pairs) a harmless miss. Further discriminators (arity, flags packed into an
+   Int) can be added to the key later, but symbol identity already scatters near-uniformly.
+
+3. *"Chimney should use Hearth's `Type.Cache`"* — **it could not, until now**: Chimney's `TypeCache`
+   (MacroCommonsCompat.scala) is NOT a plain reimplementation — it partitions entries by
+   `cacheScopeToken` (the ACTIVE `Quotes` per `Expr.splice` on Scala 3) because cached values embed
+   materialized `Expr`s, and handing an `Expr` across splice scopes trips `-Xcheck-macros`
+   ScopeException (bites when one expansion evaluates several splices, e.g. Iso/Codec). Hearth's
+   `Type.Cache` lacked this — which also means Hearth's own `firstMatchCache` (std provider views
+   close over `factoryExpr`s) and `methodsOfCache` carried the same LATENT hazard. Now DONE:
+   `Type.Cache` partitions by `CrossQuotes.ctx` (the active `Quotes` on Scala 3; the constant
+   blackbox `Context` on Scala 2), fixing the hazard and making it a superset of Chimney's cache.
+   **Remaining (Chimney PR, after a Hearth release/snapshot):** replace the 8 `new TypeCache[...]`
+   sites (`TotallyBuildIterables`, `PartiallyBuildIterables`, `OptionalValues`, `SealedHierarchies`,
+   `Total/PartialOuterTransformers`, …) with `Type.Cache` (`cache(key)(value)` →
+   `cache.getOrPut(key)(value)`), then delete `TypeCache` + `cacheScopeToken` from
+   `MacroCommonsCompat`.
+
 ## Sequencing & measurement
 
 Biggest-bang order when credits/time are tight:

--- a/docs/contributing/compile-time-perf-roadmap.md
+++ b/docs/contributing/compile-time-perf-roadmap.md
@@ -117,6 +117,28 @@ product), ~24 of ~25 methods have their full signature resolved and thrown away.
 
 **Expected:** a large cut of the 12.6% for search-by-name callers.
 
+**Landed 2026-07-10 (commit `53abbfda`) — partial, measured NEUTRAL on the dense load.** What
+landed: the parameter-map dedup (A1: `resolveTypesByParamName` computed once per `toTyped` and
+shared between per-clause expectations and `totalParameters`, both platforms), the `returnType`
+deferral (A2: `buildChain` takes `Option[() => ??]`, chain nodes force `knownReturning` lazily,
+memoized per conversion; erased signatures unchanged so no MiMa filters), and the
+`isJavaGetter`/`isJavaSetter` reorder (name prefix checked before forcing `knownReturning`).
+perf7 profiling: method-conversion inclusive 7.4% → 7.6%, param-map build 1.5% → 1.5% — flat
+within noise, because on this load the typed conversion was already amortized by the #347 caches
+and the *listing* dominates (see below). The changes still matter for callers that list rarely and
+convert much (and for Chimney's `methodGetter` after it adopts `unsortedMethodsNamed`), but they
+are not where the dense-load samples are. `Parameter.tpe` laziness (the shape-coupled part) was NOT
+attempted — after perf7 it is deprioritized: the samples say the cost is in listing, not in
+`Parameter` construction.
+
+**perf7's real finding — the UNTYPED listing is the elephant (18.4% inclusive).**
+`methodsOf`-related samples split into `TypeMethods.unsortedMethods` 8.1%, `Method.methodsOf` 7.1%,
+direct untyped `UntypedMethod.unsortedMethods` 2.7%; inside, the top self-frames are the
+[hearth#327] inherited-field walk (`baseClasses.flatMap(_.typeSymbol.fieldMembers)` — 4.2% alone,
+leafing in dotty denotations), `unsortedMethods` itself 2.2%, `safeMemberType` 1.2%,
+`sortMethodsBy` 1.1% (sorted `methods` still reached from Chimney). Fixes landed right after (see
+Part E).
+
 ---
 
 ## Part B — `Type.Ctor` traversal heuristics (faster provider/type dispatch)
@@ -256,6 +278,27 @@ Measured: `Ctor.Bounded.unapply` 9.5% → 3.7%, QuoteMatcher 2.4% → 1.2%, Chim
 10.7% → 7.6% (zero Chimney changes), macro share 22.9% → **20.8%** (27.2% baseline). Also verified:
 true `Type.Cache` overhead after bucketing is 0.1% leaf; `resolveImplicitScopeConfig`'s big
 inclusive number is a red herring (it hosts the whole derivation as a continuation).
+
+## Part E — cheaper UNTYPED method listing (perf7's finding)
+
+The dense-load profile after Part A showed the cost moved from *converting* methods to *listing*
+them: 18.4% of macro inclusive under `methodsOf`-ish entry points, with the untyped
+`UntypedMethod.unsortedMethods` symbol walk as the real payer. Two fixes:
+
+1. **Share the untyped listing across the typed caches.** `methodsOf`, `unsortedMethodsOf` and
+   `unsortedMethodsNamed` each memoized their own *result* but each independently re-ran
+   `UntypedType.fromTyped[A].unsortedMethods` on first touch — a type reached through two entry
+   points walked its members twice. Now a private `untypedMethodsOf[A]` (its own `Type.Cache`)
+   feeds all three; `methodsOf` sorts the shared list via `sortMethodsBy`.
+2. **Gate the [hearth#327] inherited-field walk (Scala 3).** It called `fieldMembers` on EVERY base
+   class (4.2% of macro by itself). The type's own symbol (fields already in `ownMembers`) and the
+   universal field-less parents (`Object`, `Any`, `AnyVal`, `Matchable`, `Product`, `Equals`,
+   `java.io.Serializable`, `scala.reflect.Enum`) are skipped before `fieldMembers` is computed.
+
+Still open in this area: the remaining per-member cost is dotty's own `methodMembers`/denotation
+computation (unavoidable once per type) and `sortMethodsBy`+`positionOf` under the *sorted*
+`methods`, which is reached from Chimney — the Chimney-side fix is switching those callers to
+`unsortedMethods*` (already planned as the `methodGetter` adoption).
 
 ## Sequencing & measurement
 

--- a/docs/contributing/compile-time-perf-roadmap.md
+++ b/docs/contributing/compile-time-perf-roadmap.md
@@ -1,0 +1,216 @@
+# Compile-time performance roadmap
+
+Follow-up work for making Hearth-based macro expansion cheaper, grounded in JFR profiling of a
+macro-dense Scala 3 Chimney derivation (~160 independent `transformInto` expansions). See the
+`hearth-macro-perf` skill for the audit checklist and the profiling methodology (JFR on HotSpot
+Temurin, fold stacks, filter to `hearth`/`chimney.internal.compiletime` frames).
+
+## What the profile established
+
+Self-time of macro expansion breaks down as ~40% compiler type/reflection ops + 23% jdk/stdlib
+(Hearth's own collections/boxing/strings). **MIO is 0.5% self-time** — the effect system is a thin
+pass-through wrapper, *not* a bottleneck; leave it alone. The old-vs-new diff (pre-Hearth Chimney
+vs Hearth-based) showed macro expansion roughly **doubled** while non-macro compilation stayed
+flat, and essentially all of the increase is two Hearth layers that don't exist in the old design:
+
+- **macro-extension provider scan** (~22% of macro; 0% in old Chimney),
+- **cross-quotes / `Ctor.Bounded.unapply` type-constructor matching** (~20%; 0% in old).
+
+Method conversion (`Type.methods` → `toTyped` on *all* methods) is another ~12.6%.
+
+Already shipped (PR #347): lazy provider skip reasons + method-list caching (macro self-samples
+4374 → 3892, macro's share of the compile 27.2% → 24.9%). This roadmap is the next layers.
+
+---
+
+## The end-to-end target (the number that matters)
+
+The sample-fraction deltas above are *diagnostic* — they tell us where the time goes. The
+**north-star metric is the whole-module compile-time ratio: Hearth-based Chimney vs the old
+`macro-commons` Chimney**, per Scala version. Known state so far (wall-clock of a Chimney module
+compile, old design as 1.0×):
+
+| | Scala 3 | Scala 2 |
+|---|---|---|
+| pre-optimization (Hearth as-migrated) | ~3.0× | ~2.0× |
+| after the optimizations so far | ~1.7× | ~1.5× |
+| goal | → 1.0× | → 1.0× |
+
+Still too much, but the right direction. This ratio — not the profiler sample fractions — is what
+each roadmap item is ultimately judged against, so it needs a **repeatable measurement harness**:
+
+1. **Two checkouts, same modules.** Current Hearth-based branch vs the last pre-migration
+   `macro-commons` commit (e.g. the one behind CI run `22825414357`; profiled here via a disposable
+   local clone — a `git worktree` breaks sbt-dynver's jgit, so use `git clone --local`). Compile the
+   *same* module set on both.
+2. **Compile only — no test run.** Time `<module>/Compile/compile` (and `Test/compile` separately if
+   the derivations live in tests), not `test`; a full `test` bundles unrelated runtime work.
+3. **Both Scala versions**, since the ratio differs markedly (3× vs 2×) — Scala 3's quote/TASTy path
+   and Hearth's cross-quotes layer are heavier than Scala 2's.
+4. **Warm + repeated.** Clean the module (macros do not re-expand incrementally — see the bug-fix
+   workflow), then take the best of N runs on an otherwise-idle machine; wall-clock bounced ±20–40%
+   on a loaded box during this work.
+5. **Confounds to report, not hide:** the two commits also differ in Scala-3 minor version and in
+   the `summonIgnoring` switch (both landed in `2.0.0-development` before Hearth), so part of the
+   ratio is *not* attributable to Hearth. The profiling here found the compiler's own type-op
+   fraction unchanged (19.8% ↔ 19.8%), i.e. the version confound is small for the *macro* portion —
+   but say so explicitly when quoting a ratio.
+
+Track the ratio (both versions) as a row per optimization landed, so the roadmap's progress is
+visible against the 1.0× goal rather than only as isolated sample-fraction wins.
+
+---
+
+## Part A — Lazy `Method` fields ("half the Methods utils as `lazy val`")
+
+**Root cause** (`Methods.scala` `UntypedMethod.toTyped`): converting one `UntypedMethod → Method`
+eagerly resolves the *entire* signature — `resolvedParamTypesByName` (does `safeMemberType` +
+`PolyType.appliedTo` + a `MethodType`/`PolyType` walk), `resolveExpectations`, each
+`Parameter.tpe`, `knownReturning`. But the hot callers use a fraction: `methodGetter(name)` needs
+`name` + return type; provider scans need name/shape; `isConstructorArgument`/`isNullary` need only
+arity. For the common "convert all, use one" pattern (`methodGetter`/`setterCandidates` over a
+product), ~24 of ~25 methods have their full signature resolved and thrown away.
+
+**Findings from a first implementation attempt (read before starting):**
+
+- **Parameters are resolved TWICE per `toTyped`** (`UntypedMethodsScala3.toTyped`): once inside
+  `typedExpectations` (`up.asTyped[Instance]` per `NeedsValues` clause) and once for
+  `totalParams = untyped.parameters.asTyped[Instance]`. Each call rebuilds the full
+  `typesByParamName` map (`safeMemberType` + `appliedTo` + `MethodType`/`PolyType` walk). Dedup
+  alone (resolve once, share slices between expectations and totalParameters) halves the cost with
+  zero laziness risk. Check the Scala 2 `toTyped` (UntypedMethodsScala2.scala:494) for the same shape.
+- **`Parameter.tpe` deferral is shape-coupled:** `UntypedParameters.toTyped` decides which params
+  exist via `typesByParamName.get(paramName)` inside a `flatMap` (UntypedMethodsScala3.scala:171-182)
+  — a param missing from the map is silently DROPPED (defensive, e.g. extension-method receiver
+  alignment). So making `Parameter.tpe` by-name does not by itself defer the map: the existence
+  check forces it. To defer, the shape decision must be decoupled first (e.g. prove the drop is
+  impossible for the clause shapes that reach here, or keep-and-throw-lazily) — behavioral risk,
+  needs its own test pass.
+- **`returnType` is the cleanest deferral target:** its *Option-ness* is decided by cheap flags
+  (`hasUnresolvedTypeParams` / `isNoSymbol` / `isConstructor`); only the value inside `Some` pays
+  `safeMemberType`. Deferring means `buildChain(returnType: Option[() => ??])` and a lazy
+  `knownReturning` on the chain nodes — `hadKnownReturning = returnType.isDefined` stays cheap.
+  Callers like Chimney's `methodGetter` force `knownReturning` only for name-matched candidates, so
+  ~24 of ~25 methods per type never pay it.
+- `Parameter` has NO companion (`new` on Scala 2, universal apply on Scala 3, 5 construction sites);
+  a by-name ctor param is source-compatible at all sites but flips the erased signature → MiMa filter.
+
+**Steps**
+
+1. Audit `Method` / `Parameter` / `MethodExpectation` fields into three tiers:
+   - *Eager + cheap* → keep eager: `name`, `symbol`, clause/param **arity**, modifier flags that
+     are single symbol-flag reads.
+   - *Expensive + often-unused* → make `lazy val` (fed by a by-name/thunk from `toTyped`): resolved
+     **parameter types**, **return type** (`knownReturning`), the **expectations / `AppliedState`**
+     chain, anything doing `appliedTo` / substitution.
+   - *Structural* → builder-chain steps, resolved on demand as today.
+2. Restructure `toTyped` to capture the cheap identity eagerly and defer the signature-resolving
+   closures into `lazy val`s on the `Method`. `Parameter.tpe` becomes lazy (or `parameters`
+   resolves types on first access).
+3. **Compounds with the #347 method-list cache:** cached `Method`s never accessed beyond `name`
+   never pay signature resolution at all — the cache becomes "list cheaply, resolve per-touch"
+   instead of "convert all eagerly, reuse."
+4. **Guards:** `Method` is public → MiMa (lazy fields compile to a private backing + accessor,
+   compat-safe; verify). Watch **evaluation-error timing** — a malformed signature now surfaces on
+   first *access* rather than at conversion; full `quick-test` must confirm no test depends on eager
+   failure.
+
+**Expected:** a large cut of the 12.6% for search-by-name callers.
+
+---
+
+## Part B — `Type.Ctor` traversal heuristics (faster provider/type dispatch)
+
+The `Ctor.Bounded.unapply` `'[HKT[a]]` match is the ~20% cost; the scan runs it ~15× per field.
+Three layered cheap prefilters, cheapest first.
+
+### B1 — Cheap-flag reject (O(1), dotty-memoized denotation reads)
+
+Before any `<:<` or match, check `A.typeSymbol` flags/identity. Fastest rejects:
+`A.typeSymbol == defn.ArrayClass` (Array provider), "is `A` even a class/trait?" (rejects
+primitives / function types for collection providers), case/sealed/module flags where a provider
+only wants certain shapes.
+
+### B2 — Head-symbol index (the structural win)
+
+Split each companion's providers:
+
+- **Exact-constructor providers** (Array, IArray, `java.util.*`, EnumSet, …) → a
+  `HashMap[headSymbol → provider]`. For a type `A`, `A.dealias.typeSymbol` → O(1) lookup to the one
+  candidate (or none) instead of iterating all providers.
+- **Subtype providers** (Iterable, Option, Either — match *subtypes*) → a small "always-try" bucket
+  gated by the `mightMatch` cheap `<:< Bound[Any]` (see the negative-gate design below). There are
+  only a few of these.
+
+A scan becomes *one map lookup + a couple gated `<:<`s*, not ~15 full matches. This is the
+**systematic version of the per-provider negative gate** — do the gate first (proves the soundness
+pattern cheaply), then generalize to the index.
+
+### B3 — Compute `A`'s fingerprint once (`Type.Cache`)
+
+Dealiased head symbol + arity + key flags computed once per type per expansion and reused across
+all provider checks, so no provider re-dealiases `A`.
+
+**Arity grouping** is mostly already implicit (Ctor1 shapes live in `IsCollection`/`IsOption`,
+Ctor2 in `IsMap`/`IsEither`), so within a companion providers are same-arity — the leverage is
+B1/B2, not further arity splitting.
+
+---
+
+## Prerequisite / already-designed: the sound negative gate
+
+A `mightMatch[A](tpe): Boolean = true` hook was added to `StdExtensions#ProvidedCompanion#Provider`
+(defaults to `true` = no behavior change). It is a cheap **sound** negative pre-filter:
+
+- **covariant bound** (Option, Iterable, Seq, Either, …): `tpe <:< Bound[Any]` — sound because
+  `A <: Bound[X] ⟹ A <: Bound[Any]` by covariance; uses the cached `<:<`, skipping the QuoteMatcher
+  + arg extraction.
+- **exact/invariant constructor** (Array, IArray, `java.util.*`): `ctor.sameTypeConstructorAs(...)`.
+
+Remaining wiring: gate in `firstMatch` and `CtorLikes.parse`; when a provider is gated out, record a
+**constant lazy skip reason** (e.g. `"pre-filtered: cannot match"`) rather than nothing — otherwise a
+total failure where everything gated out would report the misleading "No providers registered".
+
+**Soundness is the whole ballgame:** `mightMatch` must never return `false` for a type the provider
+could build — a wrong gate *silently* drops support. The full `'[HKT[a]]` match is
+**conformance-based** (it accepts any `T <:< HKT[a]`, including abstract types bounded by `HKT[X]`
+and subclasses like `ArrayList <: java.util.List`), so the gate must be conformance-based too:
+
+- **Covariant constructor** (`Option`, `Iterable`, `Iterator`, `Either`, `Try`): `tpe <:< Bound[Any]`
+  is sound (`T <: F[X] ⟹ T <: F[Any]` by covariance) and cheap (cached `<:<` with a fast negative).
+- **Non-generic type** (`String`, the `java.lang.*` boxes): `tpe <:< TheType` is sound.
+- **Invariant constructor** (`Array`, `java.util.*`, `Optional`): `<:< F[Any]` is UNSOUND-in-reverse
+  (it's `false` for `F[Int]`, so it would gate out real matches). `sameTypeConstructorAs` (head-symbol
+  compare) is also unsound: it rejects abstract types bounded by `F[X]` and subclasses, which the
+  full match accepts. The sound form is a **wildcard bound** (`tpe <:< F[?]`) — verify cross-quotes
+  can express `Type.of[F[?]]` on both Scala versions; where it cannot, **leave the default
+  `mightMatch = true`** (an ungated provider is merely slower, never wrong).
+- Bottom types already short-circuit before providers (`isBottomType`); `Some[_]` is `<: Option[Any]`
+  so the gate admits it and `parse` itself skips it (correct).
+
+Note the 8 `IsValueTypeProviderForJava*` box providers already do a cheap `=:=` in `parse` (no quote
+match) — no gate needed; `IsValueType`'s AnyVal provider already self-gates with `<:< AnyVal`.
+
+**Gate largely subsumes B2:** once every built-in provider either gates cheaply or is genuinely
+conformance-broad, a scan is ~15 cheap checks + full parses only for plausible matchers — which is
+most of what the head-symbol index would buy. Build B2 only if post-gate profiles still show scan
+cost.
+
+---
+
+## Sequencing & measurement
+
+Biggest-bang order when credits/time are tight:
+
+1. **Negative gate** — smallest, proves the soundness pattern.
+2. **Part A (lazy `Method`)** — broad, low-risk, compounds with #347.
+3. **Part B2 index** — the bigger refactor, once the gate validates the reject logic.
+
+Every step:
+
+- **Full `quick-test` on both Scala versions.** An unsound gate/index → a *silently* unrecognized
+  type → failed derivation; lazy fields → an error-timing shift. The suite is the safety net.
+- **Re-profile** the dense `ScaledProfile` load (JFR on Temurin; see the
+  `hearth-compile-time-profiling` memory / the `hearth-macro-perf` skill) and compare
+  `method-conversion%` and `Bounded.unapply%` before/after. Wall-clock is noisy — trust the
+  sample-fraction deltas.

--- a/docs/contributing/compile-time-perf-roadmap.md
+++ b/docs/contributing/compile-time-perf-roadmap.md
@@ -305,6 +305,30 @@ computation (unavoidable once per type) and `sortMethodsBy`+`positionOf` under t
 `methods`, which is reached from Chimney — the Chimney-side fix is switching those callers to
 `unsortedMethods*` (already planned as the `methodGetter` adoption).
 
+## Part F — per-expansion module-init tax (DONE, commit `56977622`)
+
+Module objects are re-instantiated on every macro expansion, so eager work in module bodies is a
+per-expansion tax that the per-type caches cannot amortize. perf8's remainder analysis found ~3%:
+`TypeModule.$init$` (eagerly materializing ~16 `Type.of` for `primitiveTypes` /
+`jvmBuiltInTypes` / `typeSystemSpecialTypes`) at 1.8%, and `UntypedMethod$.<init>` (four separate
+`java.lang.Object` member walks for the filter sets, two eager) at 1.3%. Fixed by making the lists
+lazy and sharing one lazy Object-member walk. **Measured (perf9): both → 0.0%**; every other
+category flat.
+
+Also sized and rejected in the same pass: `Expr.annotated` 1.8% is inherent (`changeOwner` must
+walk the wrapped tree for `-Xcheck-macros` correctness — driven by Chimney's
+`prependSuppressUnused` call pattern, not by Hearth); the provider scan post-gate is ~11.6-12.9%
+but almost entirely *genuine* `parse` bodies of MATCHING providers (mightMatch itself 2.9%,
+results memoized by `firstMatchCached`) — the B2 head-symbol index would mostly re-order work that
+already short-circuits, so it is deprioritized; `summonImplicit` ~6-6.5% is dotty's search, driven
+by Chimney's summoning policy.
+
+**Where this leaves the Hearth-side floor on the dense load:** listing ~18% (mostly dotty
+`methodMembers` denotations, first-touch per type), scan ~12% (genuine matching parses),
+conversion ~7%, Chimney `Configurations` ~8% (Chimney-side), `summonImplicit` ~6%. Further
+meaningful cuts need the *Chimney-side* adoptions (methodGetter → `unsortedMethodsNamed`,
+`TypeCache` → `Type.Cache`) after a Hearth release/snapshot carrying PR #347.
+
 ## Sequencing & measurement
 
 Biggest-bang order when credits/time are tight:

--- a/docs/contributing/compile-time-perf-roadmap.md
+++ b/docs/contributing/compile-time-perf-roadmap.md
@@ -295,6 +295,11 @@ them: 18.4% of macro inclusive under `methodsOf`-ish entry points, with the unty
    universal field-less parents (`Object`, `Any`, `AnyVal`, `Matchable`, `Product`, `Equals`,
    `java.io.Serializable`, `scala.reflect.Enum`) are skipped before `fieldMembers` is computed.
 
+**Measured (perf8, commit `0d91be0f`):** macro share 22.4% → **18.9%** (new low; 27.2% baseline,
+perf6 was 20.8%), inherited-field walk 4.3% → 0.1% (raw `fieldMembers` frames 380 → 223 — the
+remainder is the legitimate own-class + companion calls), method conversion 7.6% → 6.6%. The
+listing block is now 17.4% inclusive with the untyped walk at 9.0%.
+
 Still open in this area: the remaining per-member cost is dotty's own `methodMembers`/denotation
 computation (unavoidable once per type) and `sortMethodsBy`+`positionOf` under the *sorted*
 `methods`, which is reached from Chimney — the Chimney-side fix is switching those callers to

--- a/docs/contributing/compile-time-perf-roadmap.md
+++ b/docs/contributing/compile-time-perf-roadmap.md
@@ -34,7 +34,15 @@ compile, old design as 1.0×):
 |---|---|---|
 | pre-optimization (Hearth as-migrated) | ~3.0× | ~2.0× |
 | after the optimizations so far | ~1.7× | ~1.5× |
+| **after PR #347 (perf9, measured 2026-07-10)** | **1.30×** | **1.27×** |
 | goal | → 1.0× | → 1.0× |
+
+The 2026-07-10 measurement: `chimney` module `clean` + `Test/compile`, best of 3 (spread was ±3s —
+tight), sbt-reported compile seconds, `CI=true` (no scalafmt), Temurin 25 — premig (macro-commons,
+Scala 3.7.3) 117s/77s vs current pinned to `0.4.1-perf9-SNAPSHOT` (Scala 3.8.4) 152s/98s.
+Confounds overstating the ratio *against* Hearth: current commit has ~3% more test lines and ~26%
+more main-module lines (non-macro DSL growth) than premig; plus the Scala 3 minor-version delta.
+The macro-attributable ratio is therefore somewhat below the raw 1.30×/1.27×.
 
 Still too much, but the right direction. This ratio — not the profiler sample fractions — is what
 each roadmap item is ultimately judged against, so it needs a **repeatable measurement harness**:

--- a/docs/contributing/compile-time-perf-roadmap.md
+++ b/docs/contributing/compile-time-perf-roadmap.md
@@ -238,6 +238,25 @@ cost.
    `cache.getOrPut(key)(value)`), then delete `TypeCache` + `cacheScopeToken` from
    `MacroCommonsCompat`.
 
+## Part D — `Ctor.Bounded.unapply` fast paths (DONE, 2026-07-10)
+
+perf4 profiling showed `Ctor.Bounded.unapply` still at 9.5% of macro and Chimney's `Configurations`
+flag-chain parsing (Ctor2/Ctor3 matches per flag node) at 10.7% — the QuoteMatcher `'[HKT[a]]`
+pattern being the costly primitive behind both. Two fast paths in the generated unapply (Scala 3;
+QuoteMatcher remains the source of truth for everything else):
+
+1. **Positive:** dealiased head symbol == constructor's → extract the dealiased type's own
+   arguments directly; wildcard args (`TypeBounds`, #307) fall back to the quote match.
+2. **Negative:** class-headed, non-bottom scrutinee whose head differs → `A <:< HKT[args]` requires
+   `HKT ∈ baseClasses(A)`; if absent, `None` without the QuoteMatcher. Guards: HKT head must be a
+   proper class (opaque/abstract skip), scrutinee head must be a class (abstract/intersection keep
+   the full match), never for `Nothing`/`Null` (#319).
+
+Measured: `Ctor.Bounded.unapply` 9.5% → 3.7%, QuoteMatcher 2.4% → 1.2%, Chimney Configurations
+10.7% → 7.6% (zero Chimney changes), macro share 22.9% → **20.8%** (27.2% baseline). Also verified:
+true `Type.Cache` overhead after bucketing is 0.1% leaf; `resolveImplicitScopeConfig`'s big
+inclusive number is a red herring (it hosts the whole derivation as a continuation).
+
 ## Sequencing & measurement
 
 Biggest-bang order when credits/time are tight:

--- a/docs/contributing/compile-time-perf-roadmap.md
+++ b/docs/contributing/compile-time-perf-roadmap.md
@@ -262,11 +262,16 @@ cost.
    close over `factoryExpr`s) and `methodsOfCache` carried the same LATENT hazard. Now DONE:
    `Type.Cache` partitions by `CrossQuotes.ctx` (the active `Quotes` on Scala 3; the constant
    blackbox `Context` on Scala 2), fixing the hazard and making it a superset of Chimney's cache.
-   **Remaining (Chimney PR, after a Hearth release/snapshot):** replace the 8 `new TypeCache[...]`
-   sites (`TotallyBuildIterables`, `PartiallyBuildIterables`, `OptionalValues`, `SealedHierarchies`,
-   `Total/PartialOuterTransformers`, …) with `Type.Cache` (`cache(key)(value)` →
-   `cache.getOrPut(key)(value)`), then delete `TypeCache` + `cacheScopeToken` from
-   `MacroCommonsCompat`.
+   **DONE on the Chimney side (branch `perf/adopt-hearth-type-cache`, commit `0921fbe9`,
+   2026-07-10):** all 11 `new TypeCache[...]` sites replaced with `Type.Cache` + `getOrPut`;
+   `TypeCache` and `cacheScopeToken` (incl. the Scala 3 `PlatformBridge` override) deleted. In the
+   same commit `methodGetters`/`setterCandidatesOf` switched to `unsortedMethods` + the new public
+   `Method.sort` on the FILTERED subset (hearth commit `6d4c746f`) — raw unsorted order broke 4
+   JavaBean specs because setter order is user-observable (generated call order + error messages),
+   which is exactly why `Method.sort` exists. Measured on the dense load: old linear-scan
+   `TypeCache` frames 28.1% → 0%, `sortMethodsBy` 1.8% → 0.9%; the bucketed cache's O(1) lookup
+   replaces a per-lookup linear `=:=` scan (pays off with many distinct types). Chimney tests
+   green (1118 + 980). Awaiting: hearth #347 merge → CI master snapshot → re-pin → push + PR.
 
 ## Part D — `Ctor.Bounded.unapply` fast paths (DONE, 2026-07-10)
 

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
@@ -746,15 +746,19 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
     // When behavior between Scala 2 and 3 is different, and it makes sense to align them, we have to decide which behavior is
     // "saner" and which one needs adjustment. Below are methods used to adjust behavior on Scala 2 side.
 
+    // Both filter sets below derive from java.lang.Object's members; the walk is done once (lazily - module init
+    // runs on every macro expansion) and shared, instead of once per set.
+    private lazy val objectMembers = c.weakTypeOf[java.lang.Object].members.toList
+
     // For these symbol.isSynthetic flag is false, but we want to consider them synthetic.
-    private val methodsConsideredSynthetic = {
+    private lazy val methodsConsideredSynthetic = {
       val names = Set("asInstanceOf", "isInstanceOf", "getClass", "synchronized", "==", "!=", "eq", "ne", "##")
-      c.weakTypeOf[Object].members.filter(symbol => names(symbolName(symbol))).toSet
+      objectMembers.filter(symbol => names(symbolName(symbol))).toSet
     }
 
     // We do not want to include methods and fields from java.lang.Object in the companion object.
     // Because the companion class has them and we don't want to mix them when listing methods for companion class.
-    private val methodsSkippedInCompanion =
-      c.weakTypeOf[java.lang.Object].members.toSet
+    private lazy val methodsSkippedInCompanion: Set[Symbol] =
+      objectMembers.toSet
   }
 }

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
@@ -59,36 +59,53 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
 
   object UntypedParameters extends UntypedParametersModule {
 
-    override def toTyped[Instance: Type](untyped: UntypedParameters): Parameters = {
-      val instanceTpe = UntypedType.fromTyped[Instance]
-      lazy val method = untyped.head.head._2.method // If params are empty it would throw... unless we don't use it.
+    override def toTyped[Instance: Type](untyped: UntypedParameters): Parameters =
+      toTypedWith[Instance](
+        untyped,
+        // If params are empty, `.head` would throw... unless we don't use it (the thunk is forced per-param only).
+        () => resolveTypesByParamName(UntypedType.fromTyped[Instance], untyped.head.head._2.method)
+      )
 
-      lazy val typesByParamName = {
-        val rawSig = method.symbol.asMethod.typeSignatureIn(instanceTpe)
-        val sig = rawSig match {
-          case ExistentialType(_, underlying) => underlying
-          case other                          => other
-        }
-        val firstListSize = sig.paramLists.headOption.map(_.size).getOrElse(0)
-        sig.paramLists.flatten.zipWithIndex.map { case (param, idx) =>
-          val rawType = param.typeSignatureIn(instanceTpe)
-          val resolvedType =
-            if (idx < firstListSize) rawType
-            else {
-              val asMethodType = rawType.asInstanceOf[scala.reflect.internal.Types#Type]
-              asMethodType match {
-                case imt: scala.reflect.internal.Types#MethodType =>
-                  val paramIdx = imt.params.indexWhere(_.decodedName.toString.trim == symbolName(param))
-                  if (paramIdx >= 0) {
-                    val internalParams = imt.asInstanceOf[scala.reflect.internal.SymbolTable#MethodType].paramTypes
-                    internalParams(paramIdx).asInstanceOf[c.universe.Type]
-                  } else rawType
-                case _ => rawType
-              }
-            }
-          symbolName(param) -> resolvedType
-        }.toMap
+    /** Resolves the parameter-name -> parameter-type map for ALL value clauses of `method` as seen from `instanceTpe`.
+      * Since the map covers every clause, `UntypedMethod.toTyped` computes it ONCE and shares it between the per-clause
+      * expectations and `totalParameters` (previously it was recomputed for each).
+      */
+    private[hearth] def resolveTypesByParamName(
+        instanceTpe: UntypedType,
+        method: UntypedMethod
+    ): Map[String, c.universe.Type] = {
+      val rawSig = method.symbol.asMethod.typeSignatureIn(instanceTpe)
+      val sig = rawSig match {
+        case ExistentialType(_, underlying) => underlying
+        case other                          => other
       }
+      val firstListSize = sig.paramLists.headOption.map(_.size).getOrElse(0)
+      sig.paramLists.flatten.zipWithIndex.map { case (param, idx) =>
+        val rawType = param.typeSignatureIn(instanceTpe)
+        val resolvedType =
+          if (idx < firstListSize) rawType
+          else {
+            val asMethodType = rawType.asInstanceOf[scala.reflect.internal.Types#Type]
+            asMethodType match {
+              case imt: scala.reflect.internal.Types#MethodType =>
+                val paramIdx = imt.params.indexWhere(_.decodedName.toString.trim == symbolName(param))
+                if (paramIdx >= 0) {
+                  val internalParams = imt.asInstanceOf[scala.reflect.internal.SymbolTable#MethodType].paramTypes
+                  internalParams(paramIdx).asInstanceOf[c.universe.Type]
+                } else rawType
+              case _ => rawType
+            }
+          }
+        symbolName(param) -> resolvedType
+      }.toMap
+    }
+
+    private[hearth] def toTypedWith[Instance: Type](
+        untyped: UntypedParameters,
+        typesByParamName0: () => Map[String, c.universe.Type]
+    ): Parameters = {
+      val instanceTpe = UntypedType.fromTyped[Instance]
+      lazy val typesByParamName = typesByParamName0()
 
       untyped.map { params =>
         params.flatMap { case (paramName, untyped) =>
@@ -496,6 +513,10 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
 
       val untypedExpectations = untyped.methodExpectations(instanceTpe)
 
+      // The map covers ALL value clauses, so resolve it once and share it between the per-clause expectations and
+      // `totalParameters` below (it used to be recomputed for each of them).
+      lazy val sharedTypesByParamName = UntypedParameters.resolveTypesByParamName(instanceTpe, untyped)
+
       // [hearth#331] A value/implicit clause that FOLLOWS a type-parameter clause references the method's own type
       // parameters (`(implicit ev: Sync[F])`); resolving it against `Instance` conflates method and class type
       // parameters, so it used to be dropped to `List.empty`. Instead read the parameter types straight from the
@@ -545,7 +566,8 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
             }))
           case UntypedMethodExpectation.NeedsValues(up) =>
             if (seenTypeParams) MethodExpectation.NeedsValues(resolveTypeParamClauseValues(up, typeArgs))
-            else MethodExpectation.NeedsValues(up.asTyped[Instance])
+            else
+              MethodExpectation.NeedsValues(UntypedParameters.toTypedWith[Instance](up, () => sharedTypesByParamName))
         }
       }
       val typedExpectations: List[MethodExpectation] = resolveExpectations(Map.empty)
@@ -553,20 +575,23 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
       val hasUnresolvedTypeParams = untyped.hasTypeParameters && !untyped.isConstructor
       val totalParams: Parameters =
         if (hasUnresolvedTypeParams) List.empty
-        else untyped.parameters.asTyped[Instance]
+        else UntypedParameters.toTypedWith[Instance](untyped.parameters, () => sharedTypesByParamName)
 
-      val returnType: Option[??] =
-        if (hasUnresolvedTypeParams) None
-        else if (untyped.isConstructor) Some(instanceTpe.as_??)
-        else {
-          val rawSig = untyped.symbol.typeSignatureIn(instanceTpe)
-          val sig = rawSig match {
-            case ExistentialType(_, underlying) => underlying
-            case other                          => other
-          }
-          // E.g. the case-field accessor of a vararg parameter would otherwise return `scala.<repeated>[A]`.
-          Some(normalizeRepeatedParamType(sig.finalResultType.dealias).as_??)
+      // Option-ness is decided by cheap flags; the expensive `typeSignatureIn` resolution inside `Some` is deferred
+      // (memoized via the local lazy val) until someone actually asks the chain for `knownReturning`.
+      lazy val resolvedReturnType: ?? = {
+        val rawSig = untyped.symbol.typeSignatureIn(instanceTpe)
+        val sig = rawSig match {
+          case ExistentialType(_, underlying) => underlying
+          case other                          => other
         }
+        // E.g. the case-field accessor of a vararg parameter would otherwise return `scala.<repeated>[A]`.
+        normalizeRepeatedParamType(sig.finalResultType.dealias).as_??
+      }
+      val returnType: Option[() => ??] =
+        if (hasUnresolvedTypeParams) None
+        else if (untyped.isConstructor) Some(() => instanceTpe.as_??)
+        else Some(() => resolvedReturnType)
 
       val buildExpr: (Option[UntypedExpr], UntypedTypeArguments, UntypedArguments) => Either[String, UntypedExpr] =
         (instance, typeArgs, args) => Right(untyped.unsafeApplyWithTypes(instanceTpe)(typeArgs, instance, args))

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedTypesScala2.scala
@@ -540,6 +540,12 @@ trait UntypedTypesScala2 extends UntypedTypes { this: MacroCommonsScala2 =>
     override def sameTypeConstructorAs(a: UntypedType, b: UntypedType): Boolean =
       a.dealias.typeConstructor.typeSymbol == b.dealias.typeConstructor.typeSymbol
 
+    private val noSymbolCacheBucket = new AnyRef
+    override private[hearth] def cacheBucketKey(untyped: UntypedType): AnyRef = {
+      val symbol = untyped.dealias.typeSymbol
+      if (symbol == c.universe.NoSymbol) noSymbolCacheBucket else symbol
+    }
+
     override def annotations(untyped: UntypedType): List[UntypedExpr] =
       untyped.typeSymbol.annotations.map(ann => c.untypecheck(ann.tree))
     override def annotationTypes(untyped: UntypedType): List[UntypedType] =

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -105,22 +105,23 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
 
   object UntypedParameters extends UntypedParametersModule {
 
-    override def toTyped[Instance: Type](untyped: UntypedParameters): Parameters = {
-      lazy val instanceTpe = UntypedType.fromTyped[Instance]
+    override def toTyped[Instance: Type](untyped: UntypedParameters): Parameters =
+      toTypedWith[Instance](
+        untyped,
+        // If params are empty, `.head` would throw... unless we don't use it (the thunk is forced per-param only).
+        () => resolveTypesByParamName(UntypedType.fromTyped[Instance], untyped.head.head._2.method)
+      )
 
-      // Synthetic NamedTuple parameters carry their types directly — no symbol-based resolution needed.
-      val isSyntheticNamedTuple = untyped.exists(_.exists(_._2.isInstanceOf[SyntheticNamedTupleParameter]))
-      if isSyntheticNamedTuple then return untyped.map { params =>
-        params.map { case (paramName, param) =>
-          val synParam = param.asInstanceOf[SyntheticNamedTupleParameter]
-          paramName -> Parameter(asUntyped = param, untypedInstanceType = instanceTpe, tpe = synParam.fieldType.as_??)
-        }
-      }
-
-      lazy val method = untyped.head.head._2.method // If params are empty it would throw... unless we don't use it.
-
+    /** Resolves the parameter-name -> parameter-type map for ALL value clauses of `method` as seen from `instanceTpe`.
+      * Since the map covers every clause, `UntypedMethod.toTyped` computes it ONCE and shares it between the per-clause
+      * expectations and `totalParameters` (previously it was recomputed for each).
+      */
+    private[hearth] def resolveTypesByParamName(
+        instanceTpe: UntypedType,
+        method: UntypedMethod
+    ): Map[String, TypeRepr] = {
       // Constructor methods still have to have their type parameters manually applied, even if we know the exact type of their class.
-      lazy val appliedIfNecessary = {
+      val appliedIfNecessary = {
         val raw =
           if instanceTpe.typeArgs.isEmpty && method.symbol.isClassConstructor then safeMemberType(
             instanceTpe,
@@ -135,38 +136,54 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
         }
         else raw
       }
-      lazy val typesByParamName = {
-        def collectAllParamTypes(tpe: TypeRepr): Map[String, TypeRepr] = tpe match {
-          case MethodType(names, types, res) => names.zip(types).toMap ++ collectAllParamTypes(res)
-          case PolyType(_, _, res)           => collectAllParamTypes(res)
-          case _                             => Map.empty
-        }
-        def applyTypeAliases(params: Map[String, TypeRepr], aliases: Map[TypeRepr, TypeRepr]): Map[String, TypeRepr] =
-          if aliases.isEmpty then params
-          else params.view.mapValues(tpe => aliases.getOrElse(tpe, tpe)).toMap
+      def collectAllParamTypes(tpe: TypeRepr): Map[String, TypeRepr] = tpe match {
+        case MethodType(names, types, res) => names.zip(types).toMap ++ collectAllParamTypes(res)
+        case PolyType(_, _, res)           => collectAllParamTypes(res)
+        case _                             => Map.empty
+      }
+      def applyTypeAliases(params: Map[String, TypeRepr], aliases: Map[TypeRepr, TypeRepr]): Map[String, TypeRepr] =
+        if aliases.isEmpty then params
+        else params.view.mapValues(tpe => aliases.getOrElse(tpe, tpe)).toMap
 
-        appliedIfNecessary match {
-          case mt: MethodType =>
-            collectAllParamTypes(mt)
-          case PolyType(_, _, inner) =>
-            val rawParams = collectAllParamTypes(inner)
-            inner match {
-              case MethodType(_, _, AppliedType(_, typeRefs)) =>
-                applyTypeAliases(rawParams, typeRefs.zip(instanceTpe.typeArgs).toMap)
-              case _ => rawParams
-            }
-          case AppliedType(inner, typeRefs) =>
-            val rawParams = collectAllParamTypes(inner)
-            applyTypeAliases(rawParams, typeRefs.zip(instanceTpe.typeArgs).toMap)
-          // $COVERAGE-OFF$
-          case out =>
-            val methodName = if method.isConstructor then "Constructor" else s"Method ${method.name}"
-            val typeName = instanceTpe.prettyPrint
-            val outTypeName = out.prettyPrint
-            hearthAssertionFailed(s"$methodName of $typeName has unrecognized/unsupported format of type: $outTypeName")
-          // $COVERAGE-ON$
+      appliedIfNecessary match {
+        case mt: MethodType =>
+          collectAllParamTypes(mt)
+        case PolyType(_, _, inner) =>
+          val rawParams = collectAllParamTypes(inner)
+          inner match {
+            case MethodType(_, _, AppliedType(_, typeRefs)) =>
+              applyTypeAliases(rawParams, typeRefs.zip(instanceTpe.typeArgs).toMap)
+            case _ => rawParams
+          }
+        case AppliedType(inner, typeRefs) =>
+          val rawParams = collectAllParamTypes(inner)
+          applyTypeAliases(rawParams, typeRefs.zip(instanceTpe.typeArgs).toMap)
+        // $COVERAGE-OFF$
+        case out =>
+          val methodName = if method.isConstructor then "Constructor" else s"Method ${method.name}"
+          val typeName = instanceTpe.prettyPrint
+          val outTypeName = out.prettyPrint
+          hearthAssertionFailed(s"$methodName of $typeName has unrecognized/unsupported format of type: $outTypeName")
+        // $COVERAGE-ON$
+      }
+    }
+
+    private[hearth] def toTypedWith[Instance: Type](
+        untyped: UntypedParameters,
+        typesByParamName0: () => Map[String, TypeRepr]
+    ): Parameters = {
+      lazy val instanceTpe = UntypedType.fromTyped[Instance]
+
+      // Synthetic NamedTuple parameters carry their types directly — no symbol-based resolution needed.
+      val isSyntheticNamedTuple = untyped.exists(_.exists(_._2.isInstanceOf[SyntheticNamedTupleParameter]))
+      if isSyntheticNamedTuple then return untyped.map { params =>
+        params.map { case (paramName, param) =>
+          val synParam = param.asInstanceOf[SyntheticNamedTupleParameter]
+          paramName -> Parameter(asUntyped = param, untypedInstanceType = instanceTpe, tpe = synParam.fieldType.as_??)
         }
       }
+
+      lazy val typesByParamName = typesByParamName0()
 
       untyped.map { params =>
         params.flatMap { case (paramName, untyped) =>
@@ -766,6 +783,10 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
 
       val untypedExpectations = untyped.methodExpectations(instanceTpe)
 
+      // The map covers ALL value clauses, so resolve it once and share it between the per-clause expectations and
+      // `totalParameters` below (it used to be recomputed for each of them).
+      lazy val sharedTypesByParamName = UntypedParameters.resolveTypesByParamName(instanceTpe, untyped)
+
       // [hearth#331] A value/implicit clause that FOLLOWS a type-parameter clause references the method's own type
       // parameters (`(implicit ev: Sync[F])`). `up.asTyped[Instance]` cannot resolve those against `Instance` (it
       // conflates method and class type parameters and can even crash), so historically the clause was dropped to
@@ -822,7 +843,8 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
             }))
           case UntypedMethodExpectation.NeedsValues(up) =>
             if seenTypeParams then MethodExpectation.NeedsValues(resolveTypeParamClauseValues(up, typeArgs))
-            else MethodExpectation.NeedsValues(up.asTyped[Instance])
+            else
+              MethodExpectation.NeedsValues(UntypedParameters.toTypedWith[Instance](up, () => sharedTypesByParamName))
         }
       }
 
@@ -831,22 +853,25 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
       val hasUnresolvedTypeParams = untyped.hasTypeParameters && !untyped.isConstructor
       val totalParams: Parameters =
         if hasUnresolvedTypeParams then List.empty
-        else untyped.parameters.asTyped[Instance]
+        else UntypedParameters.toTypedWith[Instance](untyped.parameters, () => sharedTypesByParamName)
 
-      val returnType: Option[??] =
-        if hasUnresolvedTypeParams then None
-        else if untyped.symbol.isNoSymbol then Some(instanceTpe.as_??)
-        else if untyped.isConstructor then Some(instanceTpe.as_??)
-        else {
-          def finalResultType(tpe: TypeRepr): TypeRepr = tpe match {
-            case mt: MethodType => finalResultType(mt.resType)
-            case pt: PolyType   => finalResultType(pt.resType)
-            case other          => other
-          }
-          val memberType = safeMemberType(instanceTpe, untyped.symbol).widenByName
-          // E.g. the case-field accessor of a vararg parameter would otherwise return `scala.<repeated>[A]`.
-          Some(normalizeRepeatedParamType(finalResultType(memberType)).as_??)
+      // Option-ness is decided by cheap flags; the expensive `safeMemberType` resolution inside `Some` is deferred
+      // (memoized via the local lazy val) until someone actually asks the chain for `knownReturning`.
+      lazy val resolvedReturnType: ?? = {
+        def finalResultType(tpe: TypeRepr): TypeRepr = tpe match {
+          case mt: MethodType => finalResultType(mt.resType)
+          case pt: PolyType   => finalResultType(pt.resType)
+          case other          => other
         }
+        val memberType = safeMemberType(instanceTpe, untyped.symbol).widenByName
+        // E.g. the case-field accessor of a vararg parameter would otherwise return `scala.<repeated>[A]`.
+        normalizeRepeatedParamType(finalResultType(memberType)).as_??
+      }
+      val returnType: Option[() => ??] =
+        if hasUnresolvedTypeParams then None
+        else if untyped.symbol.isNoSymbol then Some(() => instanceTpe.as_??)
+        else if untyped.isConstructor then Some(() => instanceTpe.as_??)
+        else Some(() => resolvedReturnType)
 
       val buildExpr: (Option[UntypedExpr], UntypedTypeArguments, UntypedArguments) => Either[String, UntypedExpr] =
         (instance, typeArgs, args) => Right(untyped.unsafeApplyWithTypes(instanceTpe)(typeArgs, instance, args))

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -1100,37 +1100,34 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
       Symbol.requiredClass("scala.reflect.Enum")
     )
 
+    // The filter sets below all derive from java.lang.Object's members; the walk is done once (lazily - module init
+    // runs on every macro expansion) and shared, instead of once per set.
+    private lazy val objectClassSymbol = TypeRepr.of[java.lang.Object].typeSymbol
+    private lazy val objectMethodMembers = objectClassSymbol.methodMembers
+
     // These methods are only available on Scala 3, and we want to align behavior with Scala 2.
     // For now we just exclude them, but in the future we might want to implement them in Scala 2.
-    private lazy val excludedMethods = TypeRepr
-      .of[java.lang.Object]
-      .typeSymbol
-      .methodMembers
-      .filter { symbol =>
-        // Both "asInstanceOf" and "isInstanceOf" exist on both Scala 2 and 3, so I am not sure why we ALSO have these on Scala 3.
-        symbol.name == "$asInstanceOf$" || symbol.name == "$isInstanceOf$"
-      }
-      .toSet
+    private lazy val excludedMethods = objectMethodMembers.filter { symbol =>
+      // Both "asInstanceOf" and "isInstanceOf" exist on both Scala 2 and 3, so I am not sure why we ALSO have these on Scala 3.
+      symbol.name == "$asInstanceOf$" || symbol.name == "$isInstanceOf$"
+    }.toSet
 
     // We check if something is inherited by comparing declared methods with all methods of the type. But some methods are
     // ensured to exist, even when they do not appear in the source code, and they should not be considered "inherited".
     private lazy val declaredByJvmOrScala = Map {
-      val objectSymbol = TypeRepr.of[java.lang.Object].typeSymbol
       val objectExceptionNames = Set("toString", "equals", "hashCode")
-      objectSymbol -> objectSymbol.methodMembers.filter(symbol => objectExceptionNames(symbol.name)).toSet
+      objectClassSymbol -> objectMethodMembers.filter(symbol => objectExceptionNames(symbol.name)).toSet
     }.withDefaultValue(Set.empty)
 
     // For these symbol.isSynthetic flag is false, but we want to consider them synthetic.
-    private val methodsConsideredSynthetic = {
+    private lazy val methodsConsideredSynthetic = {
       val names = Set("asInstanceOf", "isInstanceOf", "getClass", "synchronized", "==", "!=", "eq", "ne", "##")
-      TypeRepr.of[Object].typeSymbol.methodMembers.filter(symbol => names(symbol.name)).toSet
+      objectMethodMembers.filter(symbol => names(symbol.name)).toSet
     }
 
     // We do not want to include methods and fields from java.lang.Object in the companion object.
     // Because the companion class has them and we don't want to mix them when listing methods for companion class.
-    private val methodsSkippedInCompanion = {
-      val sym = TypeRepr.of[java.lang.Object].typeSymbol
-      (sym.methodMembers ++ sym.fieldMembers).toSet
-    }
+    private lazy val methodsSkippedInCompanion =
+      (objectMethodMembers ++ objectClassSymbol.fieldMembers).toSet
   }
 }

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -938,10 +938,15 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
       // `baseClasses` is ordered subclass-first) and never shadowing an own member. Scala 2's `.members` already sees
       // them. See issue #327. `UntypedType.baseClasses` is used explicitly to avoid the extension-shadowing footgun.
       // [hearth#327] The genuine PUBLIC accessors inherited from parent CLASSES (candidates, closest class first).
+      // `fieldMembers` computes member denotations, which is expensive, so skip the base classes that cannot
+      // contribute: the type itself (its fields are already in `ownMembers` and would be deduplicated by `seenNames`
+      // below) and the universal parents, which declare no public fields.
       val inheritedPublicFieldCandidates = UntypedType
         .baseClasses(instanceTpe)
         .iterator
-        .flatMap(_.typeSymbol.fieldMembers)
+        .map(_.typeSymbol)
+        .filterNot(bc => bc == symbol || fieldlessUniversalParents(bc))
+        .flatMap(_.fieldMembers)
         .filter(f => !f.isNoSymbol && !f.flags.is(Flags.Private) && !f.flags.is(Flags.Synthetic))
         .toList
       val inheritedPublicFieldNames = inheritedPublicFieldCandidates.iterator.map(_.name).toSet
@@ -1081,6 +1086,19 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
     // ------------------------------------------------- Special cases handling -------------------------------------------------
     // When behavior between Scala 2 and 3 is different, and it makes sense to align them, we have to decide which behavior is
     // "saner" and which one needs adjustment. Below are methods used to adjust behavior on Scala 3 side.
+
+    // [hearth#327] Universal parents that appear in almost every type's `baseClasses` but declare no public fields,
+    // so the inherited-public-field walk in `unsortedMethods` can skip their (expensive) `fieldMembers` call.
+    private lazy val fieldlessUniversalParents: Set[Symbol] = Set(
+      defn.ObjectClass,
+      defn.AnyClass,
+      defn.AnyValClass,
+      Symbol.requiredClass("scala.Matchable"),
+      Symbol.requiredClass("scala.Product"),
+      Symbol.requiredClass("scala.Equals"),
+      Symbol.requiredClass("java.io.Serializable"),
+      Symbol.requiredClass("scala.reflect.Enum")
+    )
 
     // These methods are only available on Scala 3, and we want to align behavior with Scala 2.
     // For now we just exclude them, but in the future we might want to implement them in Scala 2.

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -1005,6 +1005,12 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
     override def sameTypeConstructorAs(a: UntypedType, b: UntypedType): Boolean =
       typeConstructor(a).typeSymbol == typeConstructor(b).typeSymbol
 
+    private val noSymbolCacheBucket = new AnyRef
+    override private[hearth] def cacheBucketKey(untyped: UntypedType): AnyRef = {
+      val symbol = untyped.dealias.typeSymbol
+      if symbol.isNoSymbol then noSymbolCacheBucket else symbol
+    }
+
     override def annotations(untyped: UntypedType): List[UntypedExpr] =
       untyped.typeSymbol.annotations.map(repositionAnnotation)
     override def annotationTypes(untyped: UntypedType): List[UntypedType] =

--- a/hearth/src/main/scala/hearth/std/ProviderResult.scala
+++ b/hearth/src/main/scala/hearth/std/ProviderResult.scala
@@ -87,4 +87,11 @@ object ProviderResult {
   /** Helper to create a single-entry Skipped with a throwable. */
   def failed(providerName: String, error: Throwable): Skipped =
     Skipped(NonEmptyMap.one(providerName -> Left(error)))
+
+  /** Shared constant reason recorded when a provider's cheap `mightMatch` pre-filter rejected the type, so the
+    * aggregated diagnostics still name every provider (instead of a misleading "No providers registered"). A single
+    * shared instance — the thunk is constant, so no per-skip allocation beyond the map entry.
+    */
+  private[hearth] val preFilteredReason: Either[Throwable, () => String] =
+    Right(() => "pre-filtered by mightMatch: the provider cannot match this type")
 }

--- a/hearth/src/main/scala/hearth/std/ProviderResult.scala
+++ b/hearth/src/main/scala/hearth/std/ProviderResult.scala
@@ -68,11 +68,21 @@ final case class ProviderProvenance(providerName: String, providerClassName: Str
 
 object ProviderResult {
   final case class Matched[A](value: A) extends ProviderResult[A]
-  final case class Skipped(reasons: NonEmptyMap[String, Either[Throwable, String]]) extends ProviderResult[Nothing]
 
-  /** Helper to create a single-entry Skipped with a string reason. */
-  def skipped(providerName: String, reason: String): Skipped =
-    Skipped(NonEmptyMap.one(providerName -> Right(reason)))
+  /** Skip reasons are stored '''lazily''' (`() => String`): a declining provider's reason is only materialised if
+    * something actually reads it, which normally never happens (a matching provider discards every earlier skip, and
+    * the aggregated reasons are consulted only to diagnose a total failure). Providers routinely build reasons with
+    * `Type#prettyPrint`, an expensive compile-time type rendering; keeping the thunk unforced saves that work on the
+    * hot path (dozens of renders per field across the shape companions). See the compile-time perf notes.
+    */
+  final case class Skipped(reasons: NonEmptyMap[String, Either[Throwable, () => String]])
+      extends ProviderResult[Nothing]
+
+  /** Helper to create a single-entry Skipped with a (lazily evaluated) string reason. The `reason` is by-name so an
+    * expensive message (e.g. one that calls `prettyPrint`) is not built unless the reason is actually read.
+    */
+  def skipped(providerName: String, reason: => String): Skipped =
+    Skipped(NonEmptyMap.one(providerName -> Right(() => reason)))
 
   /** Helper to create a single-entry Skipped with a throwable. */
   def failed(providerName: String, error: Throwable): Skipped =

--- a/hearth/src/main/scala/hearth/std/StdExtensions.scala
+++ b/hearth/src/main/scala/hearth/std/StdExtensions.scala
@@ -27,7 +27,7 @@ trait StdExtensions { this: MacroCommons =>
       *
       * @since 0.3.0
       */
-    var lastUnapplyFailure: NonEmptyMap[String, Either[Throwable, String]] = _
+    var lastUnapplyFailure: NonEmptyMap[String, Either[Throwable, () => String]] = _
 
     /** A single registered provider: given a `Type[A]`, decides whether it recognises `A` and, if so, produces the
       * `Provided[A]` proof.
@@ -48,7 +48,7 @@ trait StdExtensions { this: MacroCommons =>
       def name: String
       def parse[A](tpe: Type[A]): ProviderResult[Provided[A]]
 
-      final protected def skipped(reason: String): ProviderResult[Nothing] =
+      final protected def skipped(reason: => String): ProviderResult[Nothing] =
         ProviderResult.skipped(name, reason)
       final protected def failed(error: Throwable): ProviderResult[Nothing] =
         ProviderResult.failed(name, error)
@@ -118,7 +118,7 @@ trait StdExtensions { this: MacroCommons =>
       */
     final protected def firstMatch[A: Type](companionName: String): ProviderResult[Provided[A]] = {
       lastMatchProvenanceValue = None
-      var skippedReasons = ListMap.empty[String, Either[Throwable, String]]
+      var skippedReasons = ListMap.empty[String, Either[Throwable, () => String]]
       val it = providers.iterator
       while (it.hasNext) {
         val provider = it.next()
@@ -291,7 +291,7 @@ trait StdExtensions { this: MacroCommons =>
       ProviderResult.skipped("CtorLikes", bottomTypeSkipReason)
     else {
       var matched: Option[CtorLikes[A]] = None
-      var skippedReasons = ListMap.empty[String, Either[Throwable, String]]
+      var skippedReasons = ListMap.empty[String, Either[Throwable, () => String]]
       providers.foreach { provider =>
         provider.parse(Type[A]) match {
           case ProviderResult.Matched(value) =>
@@ -344,8 +344,9 @@ trait StdExtensions { this: MacroCommons =>
         if (Type[Output] <:< Type[Result]) Type[Output].constructors
         else Nil
 
-      // Non-instance methods from the type (for case objects, etc.)
-      val noInstanceMethods: List[Method] = Type[Output].methods.filter {
+      // Non-instance methods from the type (for case objects, etc.). Order does not matter here (we collect the ones
+      // usable as smart constructors), so use the cheaper unsorted variant that skips source-position resolution.
+      val noInstanceMethods: List[Method] = Type[Output].unsortedMethods.filter {
         case _: Method.OnInstance => false
         case _                    => true
       }
@@ -523,7 +524,7 @@ trait StdExtensions { this: MacroCommons =>
     */
   object IsMap {
 
-    var lastUnapplyFailure: NonEmptyMap[String, Either[Throwable, String]] = _
+    var lastUnapplyFailure: NonEmptyMap[String, Either[Throwable, () => String]] = _
 
     /** Provenance of the provider behind the most recent successful match - mirrors
       * [[IsCollection.lastMatchProvenance]] since `IsMap` decodes through the collection providers. See issue #329.

--- a/hearth/src/main/scala/hearth/std/StdExtensions.scala
+++ b/hearth/src/main/scala/hearth/std/StdExtensions.scala
@@ -48,6 +48,19 @@ trait StdExtensions { this: MacroCommons =>
       def name: String
       def parse[A](tpe: Type[A]): ProviderResult[Provided[A]]
 
+      /** Cheap, '''sound''' negative pre-filter. Return `false` only when this provider provably '''cannot''' match
+        * `tpe`, so [[parse]] (which typically runs a `'[HKT[a]]` type-constructor match) can be skipped. Default `true`
+        * (always attempt). An override MUST be a genuine necessary condition — returning `false` for a type the
+        * provider could actually build silently drops support for it. Sound cheap checks: `tpe <:< Bound` for a
+        * '''covariant''' `Bound` (a subtype of `Bound[X]` is always a subtype of `Bound[Any]`), or
+        * `sameTypeConstructorAs` for an exact/invariant constructor. See the compile-time perf notes: the shape
+        * companions scan ~15 providers per field, so a cheap reject that avoids the full match on the common negative
+        * case is the main provider-scan lever.
+        *
+        * @since 0.4.1
+        */
+      def mightMatch[A](tpe: Type[A]): Boolean = true
+
       final protected def skipped(reason: => String): ProviderResult[Nothing] =
         ProviderResult.skipped(name, reason)
       final protected def failed(error: Throwable): ProviderResult[Nothing] =
@@ -122,12 +135,16 @@ trait StdExtensions { this: MacroCommons =>
       val it = providers.iterator
       while (it.hasNext) {
         val provider = it.next()
-        provider.parse(Type[A]) match {
-          case matched: ProviderResult.Matched[Provided[A] @unchecked] =>
-            recordMatch(provider)
-            return matched
-          case ProviderResult.Skipped(reasons) => skippedReasons ++= reasons.iterator
-        }
+        // Cheap sound negative pre-filter: skip the full (quote-pattern) parse when the provider provably cannot
+        // match. The constant reason keeps the aggregated diagnostics honest if every provider declines.
+        if (provider.mightMatch(Type[A])) {
+          provider.parse(Type[A]) match {
+            case matched: ProviderResult.Matched[Provided[A] @unchecked] =>
+              recordMatch(provider)
+              return matched
+            case ProviderResult.Skipped(reasons) => skippedReasons ++= reasons.iterator
+          }
+        } else skippedReasons += (provider.name -> ProviderResult.preFilteredReason)
       }
       NonEmptyMap.fromListMap(skippedReasons) match {
         case Some(nem) => ProviderResult.Skipped(nem)
@@ -293,15 +310,17 @@ trait StdExtensions { this: MacroCommons =>
       var matched: Option[CtorLikes[A]] = None
       var skippedReasons = ListMap.empty[String, Either[Throwable, () => String]]
       providers.foreach { provider =>
-        provider.parse(Type[A]) match {
-          case ProviderResult.Matched(value) =>
-            matched = matched match {
-              case Some(existing) => Some(existing ++ value)
-              case None           => Some(value)
-            }
-          case ProviderResult.Skipped(reasons) =>
-            skippedReasons ++= reasons.iterator
-        }
+        if (provider.mightMatch(Type[A])) {
+          provider.parse(Type[A]) match {
+            case ProviderResult.Matched(value) =>
+              matched = matched match {
+                case Some(existing) => Some(existing ++ value)
+                case None           => Some(value)
+              }
+            case ProviderResult.Skipped(reasons) =>
+              skippedReasons ++= reasons.iterator
+          }
+        } else skippedReasons += (provider.name -> ProviderResult.preFilteredReason)
       }
       matched match {
         case Some(ctorLikes) => ProviderResult.Matched(ctorLikes)

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForArray.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForArray.scala
@@ -57,6 +57,12 @@ final class IsCollectionProviderForArray extends StandardMacroExtension { loader
             CtorLikeOf.PlainValue(buildExpr, None)
         })
 
+      // Cheap sound negative gate: T can only match if Array is among T's base classes (covers Array[X] itself and
+      // abstract types bounded by an Array); head-symbol compares are far cheaper than the quote-pattern match.
+      private lazy val ArrayCtorUntyped = Array.asUntyped
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(ArrayCtorUntyped))
+
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
         // All Arrays can be converted to Iterable...
         case Array(item) =>

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaCollection.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaCollection.scala
@@ -40,8 +40,8 @@ final class IsCollectionProviderForScalaCollection extends StandardMacroExtensio
             implicit val builderType: Type[scala.collection.mutable.Builder[Item, CtorResult]] =
               Builder[Item, CtorResult]
             val resultMethod =
-              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
-                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              Method.unsortedMethodsNamed[scala.collection.mutable.Builder[Item, CtorResult]]("result").collectFirst {
+                case m: Method.OnInstance if m.isNullary => m
               }
             CtorLikeOf.PlainValue(
               buildExpr,
@@ -69,8 +69,8 @@ final class IsCollectionProviderForScalaCollection extends StandardMacroExtensio
             implicit val builderType: Type[scala.collection.mutable.Builder[Pair, CtorResult]] =
               Builder[Pair, CtorResult]
             val resultMethod =
-              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Pair, CtorResult]].collectFirst {
-                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              Method.unsortedMethodsNamed[scala.collection.mutable.Builder[Pair, CtorResult]]("result").collectFirst {
+                case m: Method.OnInstance if m.isNullary => m
               }
             CtorLikeOf.PlainValue(
               buildExpr,

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaCollection.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaCollection.scala
@@ -89,6 +89,11 @@ final class IsCollectionProviderForScalaCollection extends StandardMacroExtensio
             Expr.quote((Expr.splice(key), Expr.splice(value))).asInstanceOf[Expr[Pair]]
         })
 
+      // Cheap sound negative gate: everything this provider can match is <: Iterable[Any] (Iterable is covariant),
+      // so a cached `<:<` check skips the expensive quote-pattern match for non-collections.
+      private lazy val IterableAny = Type.of[Iterable[Any]]
+      override def mightMatch[A](tpe: Type[A]): Boolean = tpe <:< IterableAny
+
       @scala.annotation.nowarn
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
         // Scala collections are Iterables with Factories, we're start by finding the item type...

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaIterator.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaIterator.scala
@@ -58,6 +58,10 @@ final class IsCollectionProviderForScalaIterator extends StandardMacroExtension 
             )
         })
 
+      // Cheap sound negative gate: everything this provider can match is <: Iterator[Any] (Iterator is covariant).
+      private lazy val IteratorAny = Type.of[scala.collection.Iterator[Any]]
+      override def mightMatch[A](tpe: Type[A]): Boolean = tpe <:< IteratorAny
+
       @scala.annotation.nowarn
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
         case Iterator(item) =>

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaOption.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaOption.scala
@@ -62,6 +62,10 @@ final class IsCollectionProviderForScalaOption extends StandardMacroExtension { 
         })
       }
 
+      // Cheap sound negative gate: everything this provider can match is <: Option[Any] (Option is covariant).
+      private lazy val OptionAny = Type.of[scala.Option[Any]]
+      override def mightMatch[A](tpe: Type[A]): Boolean = tpe <:< OptionAny
+
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
         case Some(_)                                                 => skipped("Some[_] cannot be empty")
         case Option(item) if !(item.Underlying =:= Type.of[Nothing]) =>

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForString.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForString.scala
@@ -50,6 +50,9 @@ final class IsCollectionProviderForString extends StandardMacroExtension { loade
             )
         })(using Char)
 
+      // Cheap sound negative gate: the provider matches only =:= String, and =:= implies <:<.
+      override def mightMatch[A](tpe: Type[A]): Boolean = tpe <:< StringType
+
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
         case _ if tpe =:= StringType => ProviderResult.Matched(isString(tpe))
         case _                       => skipped(s"${tpe.prettyPrint} is not =:= String")

--- a/hearth/src/main/scala/hearth/std/extensions/IsEitherProviderForScalaEither.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsEitherProviderForScalaEither.scala
@@ -82,6 +82,10 @@ final class IsEitherProviderForScalaEither extends StandardMacroExtension { load
         }
       }
 
+      // Cheap sound negative gate: everything this provider can match is <: Either[Any, Any] (Either is covariant).
+      private lazy val EitherAny = Type.of[scala.Either[Any, Any]]
+      override def mightMatch[A](tpe: Type[A]): Boolean = tpe <:< EitherAny
+
       @scala.annotation.nowarn
       override def parse[A](tpe: Type[A]): ProviderResult[IsEither[A]] = tpe match {
         case Either(left, right) =>

--- a/hearth/src/main/scala/hearth/std/extensions/IsEitherProviderForScalaTry.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsEitherProviderForScalaTry.scala
@@ -70,6 +70,10 @@ final class IsEitherProviderForScalaTry extends StandardMacroExtension { loader 
         }
       }
 
+      // Cheap sound negative gate: everything this provider can match is <: Try[Any] (Try is covariant).
+      private lazy val TryAny = Type.of[scala.util.Try[Any]]
+      override def mightMatch[A](tpe: Type[A]): Boolean = tpe <:< TryAny
+
       @scala.annotation.nowarn
       override def parse[A](tpe: Type[A]): ProviderResult[IsEither[A]] = tpe match {
         case Try(item) =>

--- a/hearth/src/main/scala/hearth/std/extensions/IsOptionProviderForScalaOption.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsOptionProviderForScalaOption.scala
@@ -41,6 +41,10 @@ final class IsOptionProviderForScalaOption extends StandardMacroExtension { load
             fromOption(Expr.quote(Expr.splice(toOption(option)).orElse(Expr.splice(toOption(default)))))
         })
 
+      // Cheap sound negative gate: everything this provider can match is <: Option[Any] (Option is covariant).
+      private lazy val OptionAny = Type.of[scala.Option[Any]]
+      override def mightMatch[A](tpe: Type[A]): Boolean = tpe <:< OptionAny
+
       @scala.annotation.nowarn
       override def parse[A](tpe: Type[A]): ProviderResult[IsOption[A]] = tpe match {
         case Some(_) => skipped("Some[_] cannot be empty")

--- a/hearth/src/main/scala/hearth/typed/Classes.scala
+++ b/hearth/src/main/scala/hearth/typed/Classes.scala
@@ -382,10 +382,10 @@ trait Classes { this: MacroCommons =>
 
     private lazy val canonicalCopyMethod: Option[Method.OnInstance.Of[A]] = {
       val constructorShape = primaryConstructor.asUntyped.parameters.map(_.keys.toList)
-      // order-independent: unique `copy` matching the primary-constructor shape
-      Method.unsortedMethodsOf[A].collectFirst {
-        case oi: Method.OnInstance
-            if oi.name == "copy" && oi.asUntyped.parameters.map(_.keys.toList) == constructorShape =>
+      // order-independent: unique `copy` matching the primary-constructor shape; the by-name lookup converts only
+      // the `copy` overloads instead of every method of A
+      Method.unsortedMethodsNamed[A]("copy").collectFirst {
+        case oi: Method.OnInstance if oi.asUntyped.parameters.map(_.keys.toList) == constructorShape =>
           oi.asInstanceOf[Method.OnInstance.Of[A]]
       }
     }

--- a/hearth/src/main/scala/hearth/typed/Methods.scala
+++ b/hearth/src/main/scala/hearth/typed/Methods.scala
@@ -673,6 +673,24 @@ trait Methods { this: MacroCommons =>
       lookup.byName.getOrElseUpdate(name, lookup.untyped.iterator.filter(_.name == name).map(_.asTyped[A]).toList)
     }
 
+    /** Sorts methods into the same STABLE order as [[methodsOf]] (constructor arguments by ctor position, then declared
+      * methods by source position, then inherited/synthetic by natural-language name order).
+      *
+      * The sort key of each method is computed purely from that method, so `sort(xs.filter(p)) == sort(xs).filter(p)` —
+      * the intended pattern is to FILTER the cheap [[unsortedMethodsOf]] listing first and sort only the small subset
+      * that survived, paying the expensive position resolution per kept method instead of per listed method.
+      *
+      * @since 0.4.1
+      */
+    def sort[M <: Method](methods: List[M]): List[M] = sortBy(methods)(m => m)
+
+    /** [[sort]] generalized over any element that can produce a [[Method]] key (e.g. name-method pairs).
+      *
+      * @since 0.4.1
+      */
+    def sortBy[M](methods: List[M])(toMethod: M => Method): List[M] =
+      UntypedMethod.sortMethodsBy(methods)(m => toMethod(m).asUntyped)
+
     // The raw (unsorted) UNTYPED listing is the shared input of methodsOf/unsortedMethodsOf/unsortedMethodsNamed;
     // memoizing it separately means a type listed through more than one of those entry points walks its symbol
     // members only once per expansion.

--- a/hearth/src/main/scala/hearth/typed/Methods.scala
+++ b/hearth/src/main/scala/hearth/typed/Methods.scala
@@ -399,18 +399,22 @@ trait Methods { this: MacroCommons =>
       *
       * @since 0.4.0
       */
-    final lazy val isJavaGetter: Boolean =
-      asUntyped.invocation == Invocation.OnInstance && isNullary &&
-        knownReturning.exists { rt =>
-          import rt.Underlying as R
-          (name.startsWith("get") && name.length > 3 && !(R <:< Type.of[Unit])) ||
-          (name.startsWith("is") && name.length > 2 && (R <:< Type.of[Boolean]))
-        }
+    final lazy val isJavaGetter: Boolean = {
+      // Name checks are hoisted before `knownReturning` so that the (deferred) return type is only resolved for
+      // methods that actually look like accessors.
+      lazy val getLike = name.startsWith("get") && name.length > 3
+      lazy val isLike = name.startsWith("is") && name.length > 2
+      asUntyped.invocation == Invocation.OnInstance && isNullary && (getLike || isLike) &&
+      knownReturning.exists { rt =>
+        import rt.Underlying as R
+        (getLike && !(R <:< Type.of[Unit])) || (isLike && (R <:< Type.of[Boolean]))
+      }
+    }
     final lazy val isJavaSetter: Boolean =
-      asUntyped.invocation == Invocation.OnInstance && isUnary &&
+      asUntyped.invocation == Invocation.OnInstance && isUnary && name.startsWith("set") && name.length > 3 &&
         knownReturning.exists { rt =>
           import rt.Underlying as R
-          name.startsWith("set") && name.length > 3 && (R <:< Type.of[Unit])
+          R <:< Type.of[Unit]
         }
     final lazy val isJavaAccessor: Boolean = isJavaGetter || isJavaSetter
 
@@ -681,7 +685,10 @@ trait Methods { this: MacroCommons =>
         instanceEvidence: ??,
         expectations: List[MethodExpectation],
         totalParameters: Parameters,
-        returnType: Option[??],
+        // Thunked so that converting a method does not pay for resolving its return type (memberType + widening);
+        // only chain steps that are actually asked for `knownReturning` (or the terminal `Result`) force it. The
+        // platform should memoize the thunk (close over a `lazy val`) so multiple steps share one resolution.
+        returnType: Option[() => ??],
         buildExpr: (Option[UntypedExpr], UntypedTypeArguments, UntypedArguments) => Either[String, UntypedExpr],
         pathDepResolvers: Map[Int, UntypedArguments => Parameters],
         // [hearth#331] Given ALL type arguments applied so far, re-resolve the (still-static) expectations so that a
@@ -701,7 +708,7 @@ trait Methods { this: MacroCommons =>
           appliedState: AppliedState
       ): Method =
         if (stepIndex >= expectations.length) {
-          val effectiveReturnType = returnType.orElse {
+          val effectiveReturnType = returnType.map(_.apply()).orElse {
             if (accTypeArgs.nonEmpty)
               buildExpr(accInstance, accTypeArgs, accArgs).toOption
                 .map(expr => UntypedExpr.as_??(expr).Underlying.as_??)
@@ -798,7 +805,7 @@ trait Methods { this: MacroCommons =>
         val untypedInstanceType: UntypedType,
         val expectations: List[MethodExpectation],
         val totalParameters: Parameters,
-        private[Methods] val knownReturning0: Option[??],
+        private[Methods] val knownReturning0: Option[() => ??],
         private val next: UntypedExpr => Method
     )(
         private[Methods] val instanceEvidence: ??,
@@ -808,7 +815,7 @@ trait Methods { this: MacroCommons =>
       @ImportedCrossTypeImplicit
       implicit val Instance: Type[Instance] = instanceEvidence.Underlying
       def parameters: Parameters = List.empty
-      def knownReturning: Option[??] = knownReturning0
+      lazy val knownReturning: Option[??] = knownReturning0.map(_.apply())
       def apply(instance: Expr[Instance]): Method = next(instance.asUntyped)
       def applyUntyped(instance: UntypedExpr): Method = next(instance)
     }
@@ -859,7 +866,7 @@ trait Methods { this: MacroCommons =>
         val untypedInstanceType: UntypedType,
         val expectations: List[MethodExpectation],
         val totalParameters: Parameters,
-        private[Methods] val knownReturning0: Option[??],
+        private[Methods] val knownReturning0: Option[() => ??],
         override val parameters: Parameters,
         private val next: UntypedArguments => Method
     )(
@@ -869,7 +876,7 @@ trait Methods { this: MacroCommons =>
       type Instance = instanceEvidence.Underlying
       @ImportedCrossTypeImplicit
       implicit val Instance: Type[Instance] = instanceEvidence.Underlying
-      def knownReturning: Option[??] = knownReturning0
+      lazy val knownReturning: Option[??] = knownReturning0.map(_.apply())
       def apply(arguments: Arguments): Method = next(UntypedArguments.fromTyped(arguments))
     }
 

--- a/hearth/src/main/scala/hearth/typed/Methods.scala
+++ b/hearth/src/main/scala/hearth/typed/Methods.scala
@@ -654,6 +654,27 @@ trait Methods { this: MacroCommons =>
     def unsortedMethodsOf[A: Type]: List[Method] =
       unsortedMethodsOfCache.getOrPut(Type[A])(UntypedType.fromTyped[A].unsortedMethods.map(_.asTyped[A]))
 
+    /** Only the methods of `A` named `name`, in raw discovery order — semantically
+      * `unsortedMethodsOf[A].filter(_.name == name)`, but the name filter runs on the UNTYPED methods (a cheap symbol
+      * name compare), so only the matching methods pay the expensive typed conversion (parameter and return type
+      * resolution). Prefer this over [[methodsOf]]/[[unsortedMethodsOf]] + `filter`/`find` when looking methods up by
+      * name (e.g. resolving one getter per field): a type with ~25 methods then converts ~1 instead of all.
+      *
+      * The untyped method list and each name's converted methods are memoized per type within the expansion.
+      *
+      * @since 0.4.1
+      */
+    def unsortedMethodsNamed[A: Type](name: String): List[Method] = {
+      val lookup = namedLookupCache.getOrPut(Type[A])(new NamedLookup(UntypedType.fromTyped[A].unsortedMethods))
+      lookup.byName.getOrElseUpdate(name, lookup.untyped.iterator.filter(_.name == name).map(_.asTyped[A]).toList)
+    }
+
+    final private class NamedLookup(val untyped: List[UntypedMethod]) {
+      val byName = scala.collection.mutable.Map.empty[String, List[Method]]
+    }
+    private type NamedLookupFor[A] = NamedLookup
+    private lazy val namedLookupCache = new Type.Cache[NamedLookupFor]
+
     private[hearth] def buildChain(
         asUntyped: UntypedMethod,
         untypedInstanceType: UntypedType,

--- a/hearth/src/main/scala/hearth/typed/Methods.scala
+++ b/hearth/src/main/scala/hearth/typed/Methods.scala
@@ -645,7 +645,7 @@ trait Methods { this: MacroCommons =>
       *   every method visible on `A` as a [[Method]], in deterministic order
       */
     def methodsOf[A: Type]: List[Method] =
-      methodsOfCache.getOrPut(Type[A])(UntypedType.fromTyped[A].methods.map(_.asTyped[A]))
+      methodsOfCache.getOrPut(Type[A])(UntypedMethod.sortMethodsBy(untypedMethodsOf[A])(identity).map(_.asTyped[A]))
 
     /** Like [[methodsOf]] but in raw discovery order, WITHOUT the expensive position-resolving sort (see
       * [[UntypedMethod.unsortedMethods]]).
@@ -656,7 +656,7 @@ trait Methods { this: MacroCommons =>
       * @since 0.4.1
       */
     def unsortedMethodsOf[A: Type]: List[Method] =
-      unsortedMethodsOfCache.getOrPut(Type[A])(UntypedType.fromTyped[A].unsortedMethods.map(_.asTyped[A]))
+      unsortedMethodsOfCache.getOrPut(Type[A])(untypedMethodsOf[A].map(_.asTyped[A]))
 
     /** Only the methods of `A` named `name`, in raw discovery order — semantically
       * `unsortedMethodsOf[A].filter(_.name == name)`, but the name filter runs on the UNTYPED methods (a cheap symbol
@@ -669,9 +669,17 @@ trait Methods { this: MacroCommons =>
       * @since 0.4.1
       */
     def unsortedMethodsNamed[A: Type](name: String): List[Method] = {
-      val lookup = namedLookupCache.getOrPut(Type[A])(new NamedLookup(UntypedType.fromTyped[A].unsortedMethods))
+      val lookup = namedLookupCache.getOrPut(Type[A])(new NamedLookup(untypedMethodsOf[A]))
       lookup.byName.getOrElseUpdate(name, lookup.untyped.iterator.filter(_.name == name).map(_.asTyped[A]).toList)
     }
+
+    // The raw (unsorted) UNTYPED listing is the shared input of methodsOf/unsortedMethodsOf/unsortedMethodsNamed;
+    // memoizing it separately means a type listed through more than one of those entry points walks its symbol
+    // members only once per expansion.
+    private type UntypedMethodsFor[A] = List[UntypedMethod]
+    private lazy val untypedMethodsOfCache = new Type.Cache[UntypedMethodsFor]
+    private def untypedMethodsOf[A: Type]: List[UntypedMethod] =
+      untypedMethodsOfCache.getOrPut(Type[A])(UntypedType.fromTyped[A].unsortedMethods)
 
     final private class NamedLookup(val untyped: List[UntypedMethod]) {
       val byName = scala.collection.mutable.Map.empty[String, List[Method]]

--- a/hearth/src/main/scala/hearth/typed/Methods.scala
+++ b/hearth/src/main/scala/hearth/typed/Methods.scala
@@ -580,6 +580,15 @@ trait Methods { this: MacroCommons =>
   }
   object Method {
 
+    // Memoize the (per-expansion) untyped->typed conversion of a type's whole method list by the queried type. Resolving
+    // a typed `Method` (`UntypedMethod.asTyped`) resolves the full signature (parameter types, substitutions,
+    // expectations) and is not cheap; a caller that looks methods up per field (e.g. one getter per product field)
+    // otherwise re-converts EVERY method on every call - O(fields x methods) per type. Keyed by `=:=` via Type.Cache
+    // (per-expansion lifetime); a miss only recomputes, so a stale/partial cache can never yield a wrong result.
+    private type CachedMethods[A] = List[Method]
+    private lazy val methodsOfCache = new Type.Cache[CachedMethods]
+    private lazy val unsortedMethodsOfCache = new Type.Cache[CachedMethods]
+
     sealed private[hearth] trait AppliedStep extends Product with Serializable
     private[hearth] object AppliedStep {
       final case class Instance(expr: UntypedExpr) extends AppliedStep
@@ -632,7 +641,7 @@ trait Methods { this: MacroCommons =>
       *   every method visible on `A` as a [[Method]], in deterministic order
       */
     def methodsOf[A: Type]: List[Method] =
-      UntypedType.fromTyped[A].methods.map(_.asTyped[A])
+      methodsOfCache.getOrPut(Type[A])(UntypedType.fromTyped[A].methods.map(_.asTyped[A]))
 
     /** Like [[methodsOf]] but in raw discovery order, WITHOUT the expensive position-resolving sort (see
       * [[UntypedMethod.unsortedMethods]]).
@@ -643,7 +652,7 @@ trait Methods { this: MacroCommons =>
       * @since 0.4.1
       */
     def unsortedMethodsOf[A: Type]: List[Method] =
-      UntypedType.fromTyped[A].unsortedMethods.map(_.asTyped[A])
+      unsortedMethodsOfCache.getOrPut(Type[A])(UntypedType.fromTyped[A].unsortedMethods.map(_.asTyped[A]))
 
     private[hearth] def buildChain(
         asUntyped: UntypedMethod,

--- a/hearth/src/main/scala/hearth/typed/Types.scala
+++ b/hearth/src/main/scala/hearth/typed/Types.scala
@@ -1023,24 +1023,44 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
       * scans, etc.) so they run at most once per type within a single macro expansion.
       *
       * Keys are compared with [[=:=]] (semantic type equality), '''not''' `==`: a `Type[A]` has no value-based
-      * `equals`, so on Scala 3 `==` is reference identity and would miss almost every hit. `=:=` results are themselves
-      * memoized on Scala 3, so repeated lookups stay cheap. A miss simply recomputes, so a stale, partial, or leaky
-      * cache can never yield a wrong result — only less speed-up.
+      * `equals`, so on Scala 3 `==` is reference identity and would miss almost every hit. A miss simply recomputes, so
+      * a stale, partial, or leaky cache can never yield a wrong result — only less speed-up.
+      *
+      * Lookups are not a linear scan: entries are hash-bucketed by a cheap discriminator (the dealiased type's symbol,
+      * see [[hearth.untyped.UntypedTypes# UntypedTypeModule.cacheBucketKey]]), so the `=:=` comparison only runs
+      * against the few same-symbol candidates. This mirrors `isSameAs`'s fast negative (differing dealiased symbols ⟹
+      * not `=:=`), so bucketing can only turn an exotic would-be hit into a harmless miss.
+      *
+      * Entries are additionally partitioned by the active Cross-Quotes scope (`CrossQuotes.ctx` — the ACTIVE `Quotes`
+      * on Scala 3, a constant on Scala 2): cached values routinely embed materialized `Expr`s (std provider views,
+      * summoned implicits), and an `Expr` created during one `Expr.splice` evaluation must not be handed out during
+      * another (`-Xcheck-macros` aborts with a ScopeException). Within one scope memoization is unaffected; a new scope
+      * recomputes instead of leaking foreign-scope trees.
       *
       * Not thread-safe; a macro expansion is single-threaded.
       *
       * @since 0.4.1
       */
     final class Cache[F[_]] {
-      private val impl = scala.collection.mutable.ListBuffer.empty[Cache.Entry[F]]
+      // (cross-quotes scope token, cheap bucket key) -> entries checked with =:=.
+      private val impl =
+        new java.util.HashMap[(AnyRef, AnyRef), scala.collection.mutable.ListBuffer[Cache.Entry[F]]]
+
+      private def bucketKey[Result](key: Type[Result]): (AnyRef, AnyRef) =
+        (CrossQuotes.ctx[AnyRef], UntypedType.cacheBucketKey(UntypedType.fromTyped(using key)))
 
       /** Returns the cached `F[Result]` for a type `=:=` `key`, or `None`. */
-      def get[Result](key: Type[Result]): Option[F[Result]] =
-        impl.collectFirst { case e if e.key =:= key => e.value.asInstanceOf[F[Result]] }
+      def get[Result](key: Type[Result]): Option[F[Result]] = {
+        val bucket = impl.get(bucketKey(key))
+        if (bucket == null) None
+        else bucket.collectFirst { case e if e.key =:= key => e.value.asInstanceOf[F[Result]] }
+      }
 
       /** Stores `value` under `key`. Does not deduplicate — call [[getOrPut]] to avoid recomputation. */
       def put[Result](key: Type[Result], value: F[Result]): Unit = {
-        impl += Cache.Entry[F, Result](key, value)
+        val bucket =
+          impl.computeIfAbsent(bucketKey(key), _ => scala.collection.mutable.ListBuffer.empty[Cache.Entry[F]])
+        bucket += Cache.Entry[F, Result](key, value)
         ()
       }
 
@@ -1105,6 +1125,10 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
       */
     def unsortedMethods: List[Method { type Instance = A }] =
       Method.unsortedMethodsOf(using tpe).map(_.asInstanceOf[Method { type Instance = A }])
+
+    /** Only the methods named `name`, converting just the matches - see [[Method.unsortedMethodsNamed]]. */
+    def unsortedMethodsNamed(name: String): List[Method { type Instance = A }] =
+      Method.unsortedMethodsNamed(name)(using tpe).map(_.asInstanceOf[Method { type Instance = A }])
 
     def companionObject: Option[Expr_??] = Type.companionObject(using tpe)
 

--- a/hearth/src/main/scala/hearth/typed/Types.scala
+++ b/hearth/src/main/scala/hearth/typed/Types.scala
@@ -262,7 +262,9 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
       *
       * @since 0.1.0
       */
-    final val primitiveTypes: List[??] = List(
+    // `lazy` (also below): materializing these `Type.of` lists on module init costs every macro expansion for lists
+    // that most expansions never read.
+    final lazy val primitiveTypes: List[??] = List(
       Type.of[Boolean].as_??,
       Type.of[Byte].as_??,
       Type.of[Short].as_??,
@@ -294,7 +296,7 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
       *
       * @since 0.1.0
       */
-    final val jvmBuiltInTypes: List[??] = primitiveTypes ++ List(
+    final lazy val jvmBuiltInTypes: List[??] = primitiveTypes ++ List(
       Type.of[String].as_??,
       Type.of[Unit].as_??,
       Type.of[java.lang.Class[?]].as_??
@@ -312,7 +314,7 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
     final def isJvmBuiltIn[A: Type]: Boolean = UntypedType.fromTyped[A].isJvmBuiltIn
     final def isInJavaLangPackage[A: Type]: Boolean = UntypedType.fromTyped[A].isInJavaLangPackage
 
-    final val typeSystemSpecialTypes: List[??] = List(
+    final lazy val typeSystemSpecialTypes: List[??] = List(
       Type.of[Any].as_??,
       Type.of[AnyRef].as_??,
       Type.of[AnyVal].as_??,

--- a/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
@@ -431,6 +431,17 @@ trait UntypedTypes { this: MacroCommons =>
       */
     def sameTypeConstructorAs(a: UntypedType, b: UntypedType): Boolean
 
+    /** Cheap bucket discriminator for [[hearth.typed.Types# TypeModule.Cache]]: the dealiased type's symbol, or a
+      * shared sentinel when the type has no meaningful symbol (refinements etc.).
+      *
+      * Contract mirrors [[isSameAs]]'s fast negative: two types whose dealiased symbols BOTH exist and differ are never
+      * `=:=`, so keying cache buckets by this value can only turn an exotic would-be hit into a miss (which merely
+      * recomputes), never group-away a genuine hit into a wrong result.
+      *
+      * @since 0.4.1
+      */
+    private[hearth] def cacheBucketKey(untyped: UntypedType): AnyRef
+
     def annotations(untyped: UntypedType): List[UntypedExpr]
     def annotationTypes(untyped: UntypedType): List[UntypedType]
 

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
@@ -64,8 +64,8 @@ final class IsCollectionProviderForJavaBitSet extends StandardMacroExtension { l
             implicit val builderType: Type[scala.collection.mutable.Builder[Int, CtorResult]] =
               Builder[Int, CtorResult]
             val resultMethod =
-              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Int, CtorResult]].collectFirst {
-                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              Method.unsortedMethodsNamed[scala.collection.mutable.Builder[Int, CtorResult]]("result").collectFirst {
+                case m: Method.OnInstance if m.isNullary => m
               }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Int, CtorResult]]) => Expr.quote(Expr.splice(expr).result()),

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
@@ -74,6 +74,9 @@ final class IsCollectionProviderForJavaBitSet extends StandardMacroExtension { l
           }
         })(using Int)
 
+      // Cheap sound negative gate: the provider matches only =:= java.util.BitSet, and =:= implies <:<.
+      override def mightMatch[A](tpe: Type[A]): Boolean = tpe <:< juBitSet
+
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
         case _ if tpe =:= juBitSet => ProviderResult.Matched(isBitSet(tpe))
         case _                     => skipped(s"${tpe.prettyPrint} is not =:= java.util.BitSet")

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
@@ -90,8 +90,8 @@ final class IsCollectionProviderForJavaCollection extends StandardMacroExtension
             implicit val builderType: Type[scala.collection.mutable.Builder[Item, CtorResult]] =
               Builder[Item, CtorResult]
             val resultMethod =
-              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
-                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              Method.unsortedMethodsNamed[scala.collection.mutable.Builder[Item, CtorResult]]("result").collectFirst {
+                case m: Method.OnInstance if m.isNullary => m
               }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Item, CtorResult]]) =>

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
@@ -164,6 +164,12 @@ final class IsCollectionProviderForJavaCollection extends StandardMacroExtension
         })
       }
 
+      // Cheap sound negative gate: everything this provider can match is a java.util.Collection. the check is done via base classes:
+      // T <: Collection[x] for some x implies Collection is among T's base classes (head-symbol compare, cheap).
+      private lazy val CollectionCtorUntyped = juCollection.asUntyped
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(CollectionCtorUntyped))
+
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = {
         def isCollectionOf[Coll[I] <: java.util.Collection[I], Item: Type, Coll2[I] <: Coll[I]](
             coll: Type.Ctor1[Coll],

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
@@ -188,6 +188,12 @@ final class IsCollectionProviderForJavaDictionary extends StandardMacroExtension
         )(using Tuple2(using String, String))
       }
 
+      // Cheap sound negative gate: everything this provider can match is a java.util.Dictionary (checked via base
+      // classes - a head-symbol compare, far cheaper than the quote-pattern match).
+      private lazy val DictionaryCtorUntyped = juDictionary.asUntyped
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(DictionaryCtorUntyped))
+
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = {
         def isDictionaryOf[Dict0[K, V] <: java.util.Dictionary[K, V], Key, Value, Dict1[K, V] <: Dict0[K, V]](
             dict: Type.Ctor2[Dict0], // just for type inference

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
@@ -90,8 +90,8 @@ final class IsCollectionProviderForJavaDictionary extends StandardMacroExtension
             implicit val builderType: Type[scala.collection.mutable.Builder[Pair, CtorResult]] =
               Builder[Pair, CtorResult]
             val resultMethod =
-              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Pair, CtorResult]].collectFirst {
-                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              Method.unsortedMethodsNamed[scala.collection.mutable.Builder[Pair, CtorResult]]("result").collectFirst {
+                case m: Method.OnInstance if m.isNullary => m
               }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Pair, CtorResult]]) =>

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaEnumeration.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaEnumeration.scala
@@ -73,6 +73,12 @@ final class IsCollectionProviderForJavaEnumeration extends StandardMacroExtensio
           }
         })
 
+      // Cheap sound negative gate: everything this provider can match is a java.util.Enumeration (checked via base
+      // classes - a head-symbol compare, far cheaper than the quote-pattern match).
+      private lazy val EnumerationCtorUntyped = Enumeration.asUntyped
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(EnumerationCtorUntyped))
+
       @scala.annotation.nowarn
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
         // All Java enumerations can be converted to Iterable.

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaEnumeration.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaEnumeration.scala
@@ -62,8 +62,8 @@ final class IsCollectionProviderForJavaEnumeration extends StandardMacroExtensio
             implicit val builderType: Type[scala.collection.mutable.Builder[Item, CtorResult]] =
               Builder[Item, CtorResult]
             val resultMethod =
-              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
-                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              Method.unsortedMethodsNamed[scala.collection.mutable.Builder[Item, CtorResult]]("result").collectFirst {
+                case m: Method.OnInstance if m.isNullary => m
               }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Item, CtorResult]]) =>

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterable.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterable.scala
@@ -73,6 +73,12 @@ final class IsCollectionProviderForJavaIterable extends StandardMacroExtension {
             )
         })
 
+      // Cheap sound negative gate: everything this provider can match is a java.lang.Iterable (checked via base classes -
+      // a head-symbol compare, far cheaper than the quote-pattern match).
+      private lazy val IterableCtorUntyped = Iterable.asUntyped
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(IterableCtorUntyped))
+
       @scala.annotation.nowarn
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
         case Iterable(item) =>

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterator.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterator.scala
@@ -73,6 +73,12 @@ final class IsCollectionProviderForJavaIterator extends StandardMacroExtension {
           }
         })
 
+      // Cheap sound negative gate: everything this provider can match is a java.util.Iterator (checked via base classes -
+      // a head-symbol compare, far cheaper than the quote-pattern match).
+      private lazy val IteratorCtorUntyped = Iterator.asUntyped
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(IteratorCtorUntyped))
+
       @scala.annotation.nowarn
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
         // All Java iterators can be converted to Iterable.

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterator.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterator.scala
@@ -62,8 +62,8 @@ final class IsCollectionProviderForJavaIterator extends StandardMacroExtension {
             implicit val builderType: Type[scala.collection.mutable.Builder[Item, CtorResult]] =
               Builder[Item, CtorResult]
             val resultMethod =
-              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
-                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              Method.unsortedMethodsNamed[scala.collection.mutable.Builder[Item, CtorResult]]("result").collectFirst {
+                case m: Method.OnInstance if m.isNullary => m
               }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Item, CtorResult]]) =>

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
@@ -102,8 +102,8 @@ final class IsCollectionProviderForJavaMap extends StandardMacroExtension { load
             implicit val builderType: Type[scala.collection.mutable.Builder[Pair, CtorResult]] =
               Builder[Pair, CtorResult]
             val resultMethod =
-              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Pair, CtorResult]].collectFirst {
-                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              Method.unsortedMethodsNamed[scala.collection.mutable.Builder[Pair, CtorResult]]("result").collectFirst {
+                case m: Method.OnInstance if m.isNullary => m
               }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Pair, CtorResult]]) =>
@@ -164,8 +164,8 @@ final class IsCollectionProviderForJavaMap extends StandardMacroExtension { load
             implicit val builderType: Type[scala.collection.mutable.Builder[Pair, CtorResult]] =
               Builder[Pair, CtorResult]
             val resultMethod =
-              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Pair, CtorResult]].collectFirst {
-                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              Method.unsortedMethodsNamed[scala.collection.mutable.Builder[Pair, CtorResult]]("result").collectFirst {
+                case m: Method.OnInstance if m.isNullary => m
               }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Pair, CtorResult]]) =>

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
@@ -184,6 +184,12 @@ final class IsCollectionProviderForJavaMap extends StandardMacroExtension { load
         })
       }
 
+      // Cheap sound negative gate: everything this provider can match is a java.util.Map (invariant, so gate on the
+      // wildcard bound).
+      private lazy val MapCtorUntyped = juMap.asUntyped
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(MapCtorUntyped))
+
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = {
         def isMapOf[Map0[K, V] <: java.util.Map[K, V], Key: Type, Value: Type, Map1[K, V] <: Map0[K, V]](
             map: Type.Ctor2[Map0],

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaOptional.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaOptional.scala
@@ -80,6 +80,12 @@ final class IsCollectionProviderForJavaOptional extends StandardMacroExtension {
         })
       }
 
+      // Cheap sound negative gate: everything this provider can match is a java.util.Optional (checked via base classes -
+      // a head-symbol compare, far cheaper than the quote-pattern match).
+      private lazy val OptionalCtorUntyped = Optional.asUntyped
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(OptionalCtorUntyped))
+
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
         case Optional(item) =>
           import item.Underlying as Item

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaStream.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaStream.scala
@@ -74,8 +74,8 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
             implicit val builderType: Type[scala.collection.mutable.Builder[Item, CtorResult]] =
               Builder[Item, CtorResult]
             val resultMethod =
-              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Item, CtorResult]].collectFirst {
-                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              Method.unsortedMethodsNamed[scala.collection.mutable.Builder[Item, CtorResult]]("result").collectFirst {
+                case m: Method.OnInstance if m.isNullary => m
               }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Item, CtorResult]]) =>
@@ -126,8 +126,8 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
             implicit val builderType: Type[scala.collection.mutable.Builder[Int, CtorResult]] =
               Builder[Int, CtorResult]
             val resultMethod =
-              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Int, CtorResult]].collectFirst {
-                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              Method.unsortedMethodsNamed[scala.collection.mutable.Builder[Int, CtorResult]]("result").collectFirst {
+                case m: Method.OnInstance if m.isNullary => m
               }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Int, CtorResult]]) => Expr.quote(Expr.splice(expr).result()),
@@ -177,8 +177,8 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
             implicit val builderType: Type[scala.collection.mutable.Builder[Long, CtorResult]] =
               Builder[Long, CtorResult]
             val resultMethod =
-              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Long, CtorResult]].collectFirst {
-                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              Method.unsortedMethodsNamed[scala.collection.mutable.Builder[Long, CtorResult]]("result").collectFirst {
+                case m: Method.OnInstance if m.isNullary => m
               }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Long, CtorResult]]) =>
@@ -229,8 +229,8 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
             implicit val builderType: Type[scala.collection.mutable.Builder[Double, CtorResult]] =
               Builder[Double, CtorResult]
             val resultMethod =
-              Method.unsortedMethodsOf[scala.collection.mutable.Builder[Double, CtorResult]].collectFirst {
-                case m: Method.OnInstance if m.name == "result" && m.isNullary => m
+              Method.unsortedMethodsNamed[scala.collection.mutable.Builder[Double, CtorResult]]("result").collectFirst {
+                case m: Method.OnInstance if m.isNullary => m
               }
             CtorLikeOf.PlainValue(
               (expr: Expr[scala.collection.mutable.Builder[Double, CtorResult]]) =>

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaStream.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaStream.scala
@@ -240,6 +240,13 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
           }
         })(using Double)
 
+      // Cheap sound negative gate: everything this provider can match (Stream, IntStream, LongStream, DoubleStream)
+      // is a java.util.stream.BaseStream (invariant, so gate on the wildcard bound).
+      private lazy val StreamCtorUntyped = juStream.asUntyped
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(StreamCtorUntyped)) ||
+          tpe <:< juIntStream || tpe <:< juLongStream || tpe <:< juDoubleStream
+
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
         case _ if tpe =:= juIntStream =>
           implicit val A: Type[A] = tpe

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsOptionProviderForJavaOptional.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsOptionProviderForJavaOptional.scala
@@ -134,6 +134,13 @@ final class IsOptionProviderForJavaOptional extends StandardMacroExtension { loa
             })
         })(using Double)
 
+      // Cheap sound negative gate: this provider matches Optional[_] (checked via base classes) plus the three
+      // primitive specializations, which are NOT subtypes of Optional and must be admitted explicitly.
+      private lazy val OptionalCtorUntyped = Optional.asUntyped
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(OptionalCtorUntyped)) ||
+          tpe <:< juOptionalInt || tpe <:< juOptionalLong || tpe <:< juOptionalDouble
+
       @scala.annotation.nowarn
       override def parse[A](tpe: Type[A]): ProviderResult[IsOption[A]] = tpe match {
         case _ if tpe =:= juOptionalInt =>

--- a/project/TypeConstructorsGen.scala
+++ b/project/TypeConstructorsGen.scala
@@ -432,6 +432,24 @@ object TypeConstructorsGen {
       sb ++= s"          }\n"
     }
 
+    // Cached head symbol for the unapply fast path (Symbol identity is stable across nested splices of one expansion).
+    sb ++= s"          private lazy val fastPathHktSymbol: AnyRef = {\n"
+    sb ++= s"            given quotes: scala.quoted.Quotes = CrossQuotes.ctx\n"
+    sb ++= s"            val symbol = quotes.reflect.TypeRepr.of[HKT].typeSymbol\n"
+    sb ++= s"            if (symbol.isNoSymbol) null else symbol\n"
+    sb ++= s"          }\n"
+    // Whether HKT's head is a proper class/trait: only then is `HKT in baseClasses(A)` a NECESSARY condition of
+    // `A <:< HKT[args]`, enabling the cheap negative arm of the fast path (opaque/abstract heads skip it).
+    sb ++= s"          private lazy val fastPathHktIsClass: Boolean = {\n"
+    sb ++= s"            given quotes: scala.quoted.Quotes = CrossQuotes.ctx\n"
+    sb ++= s"            fastPathHktSymbol != null && fastPathHktSymbol.asInstanceOf[quotes.reflect.Symbol].isClassDef\n"
+    sb ++= s"          }\n"
+    // Bottom types conform to everything, so the base-classes negative must never fire for them.
+    sb ++= s"          private lazy val fastPathBottomSymbols: (AnyRef, AnyRef) = {\n"
+    sb ++= s"            given quotes: scala.quoted.Quotes = CrossQuotes.ctx\n"
+    sb ++= s"            (quotes.reflect.TypeRepr.of[Nothing].typeSymbol, quotes.reflect.TypeRepr.of[Null].typeSymbol)\n"
+    sb ++= s"          }\n"
+
     // asUntyped
     sb ++= s"          def asUntyped: UntypedType = {\n"
     sb ++= s"            given quotes: scala.quoted.Quotes = CrossQuotes.ctx\n"
@@ -452,6 +470,42 @@ object TypeConstructorsGen {
     // unapply
     sb ++= s"          def unapply[A](A: Type[A]): Option[${boundsTuple(n)}] = {\n"
     sb ++= s"            given quotes: scala.quoted.Quotes = CrossQuotes.ctx\n"
+
+    // Fast path (perf): when the scrutinee's dealiased head symbol IS the constructor's, the type is HKT applied to
+    // the dealiased type's own arguments - extract them directly instead of running the (much costlier) QuoteMatcher.
+    // Wildcard arguments (TypeBounds, see #307) and everything else falls through to the full quote-pattern match,
+    // which stays the source of truth for subtype-conformance matching (e.g. Vector[Int] against Seq).
+    val fastPathArgs = (0 until n).map(i => s"arg$i").mkString(", ")
+    val fastPathGuard = (0 until n).map(i => s"!fastPathIsWildcard(arg$i)").mkString(" && ")
+    val fastPathSome = (0 until n)
+      .map { i =>
+        val idx = i + 1
+        s"arg$i.asType.asInstanceOf[Type[${ArityGen.lower(idx)}]].as_<:??<:[${ArityGen.lower(idx)}, ${ArityGen.upper(idx)}]"
+      }
+      .mkString(", ")
+    sb ++= s"            {\n"
+    sb ++= s"              import quotes.reflect.*\n"
+    sb ++= s"              def fastPathIsWildcard(t: TypeRepr): Boolean = t match {\n"
+    sb ++= s"                case TypeBounds(_, _) => true\n"
+    sb ++= s"                case _ => false\n"
+    sb ++= s"              }\n"
+    sb ++= s"              if (fastPathHktSymbol != null) {\n"
+    sb ++= s"                val aRepr = TypeRepr.of[A](using A.asInstanceOf[scala.quoted.Type[A]]).dealias\n"
+    sb ++= s"                if (aRepr.typeSymbol == fastPathHktSymbol) aRepr match {\n"
+    sb ++= s"                  case AppliedType(_, List($fastPathArgs)) if $fastPathGuard =>\n"
+    sb ++= s"                    return Some(($fastPathSome))\n"
+    sb ++= s"                  case _ => ()\n"
+    sb ++= s"                }\n"
+    sb ++= s"                else if (fastPathHktIsClass) {\n"
+    sb ++= s"                  // Cheap negative: for a class-headed, non-bottom scrutinee, A <:< HKT[args] requires HKT among\n"
+    sb ++= s"                  // A's base classes - skip the QuoteMatcher. Abstract/intersection/bottom heads keep the full match.\n"
+    sb ++= s"                  val aSym = aRepr.typeSymbol\n"
+    sb ++= s"                  if (aSym.isClassDef && aSym != fastPathBottomSymbols._1 && aSym != fastPathBottomSymbols._2 &&\n"
+    sb ++= s"                    !UntypedType.baseClasses(aRepr.asInstanceOf[UntypedType]).exists(bc => bc.asInstanceOf[TypeRepr].typeSymbol == fastPathHktSymbol))\n"
+    sb ++= s"                    return None\n"
+    sb ++= s"                }\n"
+    sb ++= s"              }\n"
+    sb ++= s"            }\n"
 
     if (n == 1) {
       // Ctor1: IArray workaround


### PR DESCRIPTION
Eight Hearth-level compile-time optimizations found by JFR-profiling a macro-dense Scala 3 Chimney derivation (~160 independent `transformInto` expansions). All benefit every Hearth-based downstream automatically — no downstream changes required.

## The commits
1. **Lazy provider skip reasons** — declining providers no longer eagerly build `prettyPrint`-heavy diagnostics (write-mostly data).
2. **Method-list caching + `unsortedMethodsNamed`** — `methodsOf`/`unsortedMethodsOf` memoized per type; new by-name lookup converts only name-matched methods (~1 instead of ~25). Switched internally (`canonicalCopyMethod`, Builder-`result` lookups).
3. **Provider-scan negative gate (`mightMatch`)** — sound cheap pre-filter before each provider's quote-pattern parse (covariance bound / base-classes membership / explicit primitive-Optional admission).
4. **`Type.Cache` bucketed + splice-scoped** — hash-bucketed by dealiased type symbol (`=:=` only against same-symbol candidates; measured leaf overhead now 0.1%); partitioned by the active `CrossQuotes.ctx` so cached `Expr`s never leak across splice scopes (fixes a latent `-Xcheck-macros` ScopeException hazard; unblocks Chimney replacing its own `TypeCache` — the scope guard was why it couldn't before).
5. **`Ctor.Bounded.unapply` fast paths (Scala 3 codegen)** — head-symbol-equal → direct dealiased-arg extraction (wildcards/#307 fall back); class-headed non-bottom mismatch → base-classes negative, skipping the QuoteMatcher. QuoteMatcher stays the source of truth for conformance matching.
6. **`toTyped` dedup + deferred return type** — the parameter-name→type map is resolved once per method conversion and shared between expectations and `totalParameters` (was rebuilt per clause + once more); `buildChain` takes the return type as a memoized thunk so `knownReturning` is only resolved when actually asked (erased signatures unchanged — no new MiMa filters); `isJavaGetter`/`isJavaSetter` check the name prefix before forcing the return type.
7. **Cheaper untyped method listing** — one shared untyped listing feeds `methodsOf`/`unsortedMethodsOf`/`unsortedMethodsNamed` (each used to re-walk symbol members on first touch); the [hearth#327] inherited-field walk skips the type's own symbol and the universal field-less parents instead of calling `fieldMembers` on every base class.
8. **Deferred per-expansion module init** — module objects are re-instantiated on every expansion, so eager module-body work is a per-expansion tax the type caches can't amortize: `TypeModule` materialized ~16 `Type.of` lists on init (1.8%), `UntypedMethod` walked `java.lang.Object`'s members four times for its filter sets (1.3%); both now lazy/shared, measured 0.0% after.

## Measured (same dense load, JFR fractions; wall-clock varies ±20% between runs — fractions are the robust metric)
| | macro % of compile | provider scan | `Ctor.unapply` | Chimney `Configurations` | listing/`fieldMembers` walk |
|---|---|---|---|---|---|
| baseline `gecc3bdb` | 27.2% | ~18–22% | 12.6% | — | — |
| + skip reasons | 25.3% | — | — | — | — |
| + method cache | 24.9% | — | — | — | — |
| + negative gate | 22.1% | 11.6% | 9.0% | — | — |
| + Cache/named (perf4) | 22.9%* | 11.1% | 9.5%* | 10.7% | — |
| + Ctor fast paths | 20.8% | 11.9% | **3.7%** | **7.6%** | 4.3% |
| + toTyped dedup (perf7) | 22.4%* | 12.6% | 3.5% | 7.1% | 4.3% |
| **+ listing fixes (perf8)** | **18.9%** | 12.9% | 3.7% | 8.1% | **0.1%** |
| + lazy module init (perf9) | 19.9%* | 11.6% | 4.2% | 8.2% | 0.1% |

\* run-to-run noise: perf4 and perf7 are structural commits whose targets were either amortized by earlier caches (toTyped internals: 7.4%→7.6% flat) or measured at the leaf (0.1% true cache overhead). perf7's honest verdict: the conversion dedup is neutral on this load, and its profile pointed straight at the listing — which perf8 then cut.

**Net: macro expansion's share of the dense compile 27.2% → ~19% — nearly a third of the Hearth macro overhead removed.** (perf9's targeted metrics went 1.8%+1.3% → 0.0%+0.0%; its share reading is run noise — that run's wall was 11% faster.) Chimney improvements (`Configurations` 10.7→7.6–8.1%) required zero Chimney changes.

## End-to-end ratio (the number that matters)
Old macro-commons Chimney vs this branch (`chimney` module, clean `Test/compile`, best of 3, ±3s spread): **Scala 3: 117s → 152s = 1.30×; Scala 2.13: 77s → 98s = 1.27×** — down from ~3×/2× pre-optimization and ~1.7×/1.5× at the previous checkpoint (goal: 1.0×). Confounds overstating the ratio against Hearth: the current commit carries ~3% more test lines and ~26% more main-module (non-macro) lines, plus the Scala 3.7.3→3.8.4 delta.

## Verified
Every commit: 1183 (2.13) + 1311 (Scala 3) + sandwich tests green (incl. #307 wildcard + BoundedCtor parity specs); MiMa green (3 justified filters total); scalafmt clean. MIO re-confirmed a non-factor (0.5% self).

## Roadmap
`docs/contributing/compile-time-perf-roadmap.md` tracks the end-to-end ratio target (~3×/2× → ~1.7×/1.5× → 1.0× goal), the remaining levers (provider-scan B2 head-symbol index; Chimney `TypeCache`→`Type.Cache` migration; Chimney `methodGetter` adoption of `unsortedMethodsNamed` — also the fix for the remaining `sortMethodsBy`/`positionOf` cost), and the measurement harness.
