### PR TITLE
Fix binary break: restore strict Provider.skipped signatures (extensions link again)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -329,16 +329,11 @@ val mimaSettings = Seq(
   // Example of an allowed exclusion (a member added to a NESTED trait/object that MiMa would otherwise flag):
   //   exclude[ReversedMissingMethodProblem]("hearth.typed.SomeTrait#SomeNestedTrait.newHelper")
   mimaBinaryIssueFilters ++= Seq(
-    // Perf: `ProviderResult.skipped` and the nested `ProvidedCompanion#Provider.skipped` helper take the reason
-    // BY-NAME (`=> String`) so a declining provider no longer eagerly builds its skip message - which routinely calls
-    // the expensive `Type#prettyPrint`. Skip reasons are write-mostly (a matching provider discards every earlier skip;
-    // the aggregated reasons are read only to diagnose a total failure), so deferring saves dozens of type renders per
-    // field across the shape companions with no observable behaviour change. The erased signature goes String ->
-    // Function0; `Provider` is a nested trait implemented ONLY by Hearth's own std companions (always evicted with the
-    // interface) and every `StandardMacroExtension` provider is recompiled against its Hearth version, so no standalone
-    // caller can break at link time.
-    exclude[IncompatibleMethTypeProblem]("hearth.std.ProviderResult.skipped"),
-    exclude[DirectMissingMethodProblem]("hearth.std.StdExtensions#ProvidedCompanion#Provider.skipped"),
+    // NOTE: `skipped` briefly went by-name here (filters existed for the String -> Function0 signature change) but
+    // that BROKE pre-compiled provider extensions at link time - kindlings' cats-integration threw NoSuchMethodError
+    // from its `parse` when loaded by a newer Hearth. The "every extension is recompiled against its Hearth version"
+    // justification was wrong: extensions are ServiceLoader-loaded binaries. The strict `skipped(String)` signatures
+    // are restored (laziness lives in the new `skippedLazily`), so those filters are gone.
     // #329: `lastMatchProvenance` provider-provenance state added to the NESTED trait `StdExtensions#ProvidedCompanion`.
     // That trait is part of the MacroCommons cake and is implemented ONLY by Hearth's own std companion objects
     // (IsCollection/IsOption/IsEither/IsValueType/CtorLikes), which live in the same trait - so the interface and its

--- a/hearth/src/main/scala-3/hearth/std/extensions/IsCollectionProviderForIArray.scala
+++ b/hearth/src/main/scala-3/hearth/std/extensions/IsCollectionProviderForIArray.scala
@@ -154,11 +154,11 @@ final class IsCollectionProviderForIArray extends StandardMacroExtension { loade
               }
               ProviderResult.Matched(isCollection(A, toIterable, factoryExpr, buildExpr))
             case None =>
-              skipped(s"${tpe.prettyPrint} is IArray[${Item.prettyPrint}] but ClassTag not found")
+              skippedLazily(s"${tpe.prettyPrint} is IArray[${Item.prettyPrint}] but ClassTag not found")
           }
 
         // Other types are not (Scala built-in) collections - if they should be supported, another extension can take care of it.
-        case _ => skipped(s"${tpe.prettyPrint} is not IArray[_]")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not IArray[_]")
       }
     })
   }

--- a/hearth/src/main/scala-3/hearth/std/extensions/IsValueTypeProviderForOpaque.scala
+++ b/hearth/src/main/scala-3/hearth/std/extensions/IsValueTypeProviderForOpaque.scala
@@ -78,8 +78,10 @@ final class IsValueTypeProviderForOpaque extends StandardMacroExtension { loader
       override def name: String = loader.getClass.getName
 
       override def parse[A](tpe: Type[A]): ProviderResult[IsValueType[A]] =
-        if !tpe.isOpaqueType then skipped(s"${tpe.prettyPrint} is not an opaque type")
-        else if tpe.isIArray then skipped(s"${tpe.prettyPrint} is IArray (handled by IsCollectionProviderForIArray)")
+        if !tpe.isOpaqueType then skippedLazily(s"${tpe.prettyPrint} is not an opaque type")
+        else if tpe.isIArray then skippedLazily(
+          s"${tpe.prettyPrint} is IArray (handled by IsCollectionProviderForIArray)"
+        )
         else {
           implicit val A: Type[A] = tpe
           val repr: UntypedType = UntypedType.fromTyped[A]
@@ -112,7 +114,7 @@ final class IsValueTypeProviderForOpaque extends StandardMacroExtension { loader
                 })
               )
             case None =>
-              skipped(s"${tpe.prettyPrint} is an opaque type but no suitable constructor found")
+              skippedLazily(s"${tpe.prettyPrint} is an opaque type but no suitable constructor found")
           }
         }
     })

--- a/hearth/src/main/scala/hearth/std/ProviderResult.scala
+++ b/hearth/src/main/scala/hearth/std/ProviderResult.scala
@@ -78,11 +78,22 @@ object ProviderResult {
   final case class Skipped(reasons: NonEmptyMap[String, Either[Throwable, () => String]])
       extends ProviderResult[Nothing]
 
-  /** Helper to create a single-entry Skipped with a (lazily evaluated) string reason. The `reason` is by-name so an
+  /** Helper to create a single-entry Skipped with a lazily evaluated string reason. The `reason` is by-name so an
     * expensive message (e.g. one that calls `prettyPrint`) is not built unless the reason is actually read.
+    *
+    * (A separate name because Scala forbids overloading on by-name-ness alone, and [[skipped]] must keep its
+    * strict-`String` bytecode signature: provider extensions compiled against hearth <= 0.4.0 call it.)
+    *
+    * @since 0.4.1
     */
-  def skipped(providerName: String, reason: => String): Skipped =
+  def skippedLazily(providerName: String, reason: => String): Skipped =
     Skipped(NonEmptyMap.one(providerName -> Right(() => reason)))
+
+  /** Helper to create a single-entry Skipped with an eagerly-built string reason - see [[skippedLazily]] for the
+    * preferred lazy variant.
+    */
+  def skipped(providerName: String, reason: String): Skipped =
+    skippedLazily(providerName, reason)
 
   /** Helper to create a single-entry Skipped with a throwable. */
   def failed(providerName: String, error: Throwable): Skipped =

--- a/hearth/src/main/scala/hearth/std/StdExtensions.scala
+++ b/hearth/src/main/scala/hearth/std/StdExtensions.scala
@@ -61,8 +61,20 @@ trait StdExtensions { this: MacroCommons =>
         */
       def mightMatch[A](tpe: Type[A]): Boolean = true
 
-      final protected def skipped(reason: => String): ProviderResult[Nothing] =
-        ProviderResult.skipped(name, reason)
+      /** Skips with a lazily-built reason: `reason` is only evaluated if the diagnostics are actually rendered. Prefer
+        * this over [[skipped]] whenever the message is expensive (e.g. involves `Type#prettyPrint`).
+        *
+        * (A separate name because Scala forbids overloading on by-name-ness alone, and [[skipped]] must keep its
+        * strict-`String` bytecode signature: provider extensions compiled against hearth <= 0.4.0 call it.)
+        *
+        * @since 0.4.1
+        */
+      final protected def skippedLazily(reason: => String): ProviderResult[Nothing] =
+        ProviderResult.skippedLazily(name, reason)
+
+      /** Skips with an eagerly-built reason - see [[skippedLazily]] for the preferred lazy variant. */
+      final protected def skipped(reason: String): ProviderResult[Nothing] =
+        skippedLazily(reason)
       final protected def failed(error: Throwable): ProviderResult[Nothing] =
         ProviderResult.failed(name, error)
     }
@@ -148,7 +160,7 @@ trait StdExtensions { this: MacroCommons =>
       }
       NonEmptyMap.fromListMap(skippedReasons) match {
         case Some(nem) => ProviderResult.Skipped(nem)
-        case None      => ProviderResult.skipped(companionName, "No providers registered")
+        case None      => ProviderResult.skippedLazily(companionName, "No providers registered")
       }
     }
 
@@ -305,7 +317,7 @@ trait StdExtensions { this: MacroCommons =>
   object CtorLikes extends ProvidedCompanion[CtorLikes] {
 
     override def parse[A: Type]: ProviderResult[CtorLikes[A]] = if (isBottomType[A])
-      ProviderResult.skipped("CtorLikes", bottomTypeSkipReason)
+      ProviderResult.skippedLazily("CtorLikes", bottomTypeSkipReason)
     else {
       var matched: Option[CtorLikes[A]] = None
       var skippedReasons = ListMap.empty[String, Either[Throwable, () => String]]
@@ -327,7 +339,7 @@ trait StdExtensions { this: MacroCommons =>
         case None            =>
           NonEmptyMap.fromListMap(skippedReasons) match {
             case Some(nem) => ProviderResult.Skipped(nem)
-            case None      => ProviderResult.skipped("CtorLikes", "No providers registered")
+            case None      => ProviderResult.skippedLazily("CtorLikes", "No providers registered")
           }
       }
     }
@@ -489,7 +501,7 @@ trait StdExtensions { this: MacroCommons =>
   object IsCollection extends ProvidedCompanion[IsCollection] {
 
     override def parse[A: Type]: ProviderResult[IsCollection[A]] = if (isBottomType[A])
-      ProviderResult.skipped("IsCollection", bottomTypeSkipReason)
+      ProviderResult.skippedLazily("IsCollection", bottomTypeSkipReason)
     else firstMatchCached[A]("IsCollection")
   }
 
@@ -555,7 +567,7 @@ trait StdExtensions { this: MacroCommons =>
         case ProviderResult.Matched(isCollection) if isCollection.value.asMap.isDefined =>
           ProviderResult.Matched(isCollection.asInstanceOf[IsMap[A]])
         case ProviderResult.Matched(_) =>
-          ProviderResult.skipped("IsMap", s"${Type[A].prettyPrint} is a collection but not a Map")
+          ProviderResult.skippedLazily("IsMap", s"${Type[A].prettyPrint} is a collection but not a Map")
         case s: ProviderResult.Skipped => s
       }
 
@@ -614,7 +626,7 @@ trait StdExtensions { this: MacroCommons =>
   object IsOption extends ProvidedCompanion[IsOption] {
 
     override def parse[A: Type]: ProviderResult[IsOption[A]] = if (isBottomType[A])
-      ProviderResult.skipped("IsOption", bottomTypeSkipReason)
+      ProviderResult.skippedLazily("IsOption", bottomTypeSkipReason)
     else firstMatchCached[A]("IsOption")
   }
 
@@ -678,7 +690,7 @@ trait StdExtensions { this: MacroCommons =>
   object IsEither extends ProvidedCompanion[IsEither] {
 
     override def parse[A: Type]: ProviderResult[IsEither[A]] = if (isBottomType[A])
-      ProviderResult.skipped("IsEither", bottomTypeSkipReason)
+      ProviderResult.skippedLazily("IsEither", bottomTypeSkipReason)
     else firstMatchCached[A]("IsEither")
   }
 
@@ -723,7 +735,7 @@ trait StdExtensions { this: MacroCommons =>
   object IsValueType extends ProvidedCompanion[IsValueType] {
 
     override def parse[A: Type]: ProviderResult[IsValueType[A]] = if (isBottomType[A])
-      ProviderResult.skipped("IsValueType", bottomTypeSkipReason)
+      ProviderResult.skippedLazily("IsValueType", bottomTypeSkipReason)
     else firstMatchCached[A]("IsValueType")
   }
 

--- a/hearth/src/main/scala/hearth/std/extensions/CtorLikeProviderForEitherIterableStringOrValue.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/CtorLikeProviderForEitherIterableStringOrValue.scala
@@ -34,7 +34,7 @@ final class CtorLikeProviderForEitherIterableStringOrValue extends StandardMacro
           })
         ) match {
           case Some(ctors) => ProviderResult.Matched(ctors)
-          case None        => skipped(s"no Either[Iterable[String], A] constructors found for ${tpe.prettyPrint}")
+          case None        => skippedLazily(s"no Either[Iterable[String], A] constructors found for ${tpe.prettyPrint}")
         }
       }
     })

--- a/hearth/src/main/scala/hearth/std/extensions/CtorLikeProviderForEitherIterableThrowableOrValue.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/CtorLikeProviderForEitherIterableThrowableOrValue.scala
@@ -34,7 +34,7 @@ final class CtorLikeProviderForEitherIterableThrowableOrValue extends StandardMa
           })
         ) match {
           case Some(ctors) => ProviderResult.Matched(ctors)
-          case None        => skipped(s"no Either[Iterable[Throwable], A] constructors found for ${tpe.prettyPrint}")
+          case None => skippedLazily(s"no Either[Iterable[Throwable], A] constructors found for ${tpe.prettyPrint}")
         }
       }
     })

--- a/hearth/src/main/scala/hearth/std/extensions/CtorLikeProviderForEitherStringOrValue.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/CtorLikeProviderForEitherStringOrValue.scala
@@ -34,7 +34,7 @@ final class CtorLikeProviderForEitherStringOrValue extends StandardMacroExtensio
           })
         ) match {
           case Some(ctors) => ProviderResult.Matched(ctors)
-          case None        => skipped(s"no Either[String, A] constructors found for ${tpe.prettyPrint}")
+          case None        => skippedLazily(s"no Either[String, A] constructors found for ${tpe.prettyPrint}")
         }
       }
     })

--- a/hearth/src/main/scala/hearth/std/extensions/CtorLikeProviderForEitherThrowableOrValue.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/CtorLikeProviderForEitherThrowableOrValue.scala
@@ -34,7 +34,7 @@ final class CtorLikeProviderForEitherThrowableOrValue extends StandardMacroExten
           })
         ) match {
           case Some(ctors) => ProviderResult.Matched(ctors)
-          case None        => skipped(s"no Either[Throwable, A] constructors found for ${tpe.prettyPrint}")
+          case None        => skippedLazily(s"no Either[Throwable, A] constructors found for ${tpe.prettyPrint}")
         }
       }
     })

--- a/hearth/src/main/scala/hearth/std/extensions/CtorLikeProviderForPlainValue.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/CtorLikeProviderForPlainValue.scala
@@ -32,7 +32,7 @@ final class CtorLikeProviderForPlainValue extends StandardMacroExtension { loade
           })
         ) match {
           case Some(ctors) => ProviderResult.Matched(ctors)
-          case None        => skipped(s"no plain value constructors found for ${tpe.prettyPrint}")
+          case None        => skippedLazily(s"no plain value constructors found for ${tpe.prettyPrint}")
         }
       }
     })

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForArray.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForArray.scala
@@ -158,11 +158,11 @@ final class IsCollectionProviderForArray extends StandardMacroExtension { loader
               }
               ProviderResult.Matched(isCollection(A, toIterable, factoryExpr, buildExpr))
             case None =>
-              skipped(s"${tpe.prettyPrint} is Array[${Item.prettyPrint}] but ClassTag not found")
+              skippedLazily(s"${tpe.prettyPrint} is Array[${Item.prettyPrint}] but ClassTag not found")
           }
 
         // Other types are not (Scala built-in) collections - if they should be supported, another extension can take care of it.
-        case _ => skipped(s"${tpe.prettyPrint} is not Array[_]")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not Array[_]")
       }
     })
   }

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaCollection.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaCollection.scala
@@ -119,11 +119,11 @@ final class IsCollectionProviderForScalaCollection extends StandardMacroExtensio
                   ProviderResult.Matched(isCollection(A, factoryExpr, buildExpr))
               }
             case None =>
-              skipped(s"${tpe.prettyPrint} is <: Iterable[${Item.prettyPrint}] but Factory not found")
+              skippedLazily(s"${tpe.prettyPrint} is <: Iterable[${Item.prettyPrint}] but Factory not found")
           }
 
         // Other types are not (Scala built-in) collections - if they should be supported, another extension can take care of it.
-        case _ => skipped(s"${tpe.prettyPrint} is not <: Iterable[_]")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not <: Iterable[_]")
       }
     })
   }

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaIterator.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaIterator.scala
@@ -69,7 +69,7 @@ final class IsCollectionProviderForScalaIterator extends StandardMacroExtension 
           implicit val A: Type[A] = tpe
           implicit val IteratorItem: Type[scala.collection.Iterator[Item]] = Iterator[Item]
           ProviderResult.Matched(isIterator[A, Item](tpe, _.upcast[scala.collection.Iterator[Item]], _.upcast[A]))
-        case _ => skipped(s"${tpe.prettyPrint} is not Iterator[_]")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not Iterator[_]")
       }
     })
   }

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaOption.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaOption.scala
@@ -67,13 +67,13 @@ final class IsCollectionProviderForScalaOption extends StandardMacroExtension { 
       override def mightMatch[A](tpe: Type[A]): Boolean = tpe <:< OptionAny
 
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
-        case Some(_)                                                 => skipped("Some[_] cannot be empty")
+        case Some(_)                                                 => skippedLazily("Some[_] cannot be empty")
         case Option(item) if !(item.Underlying =:= Type.of[Nothing]) =>
           import item.Underlying as Item
           implicit val A: Type[A] = tpe
           implicit val OptionItem: Type[scala.Option[Item]] = Option[Item]
           ProviderResult.Matched(isOption[A, Item](_.upcast[scala.Option[Item]], _.upcast[A]))
-        case _ => skipped(s"${tpe.prettyPrint} is not Option[_]")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not Option[_]")
       }
     })
   }

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForString.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForString.scala
@@ -55,7 +55,7 @@ final class IsCollectionProviderForString extends StandardMacroExtension { loade
 
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
         case _ if tpe =:= StringType => ProviderResult.Matched(isString(tpe))
-        case _                       => skipped(s"${tpe.prettyPrint} is not =:= String")
+        case _                       => skippedLazily(s"${tpe.prettyPrint} is not =:= String")
       }
     })
   }

--- a/hearth/src/main/scala/hearth/std/extensions/IsEitherProviderForScalaEither.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsEitherProviderForScalaEither.scala
@@ -96,7 +96,7 @@ final class IsEitherProviderForScalaEither extends StandardMacroExtension { load
           ProviderResult.Matched(
             isEither[A, LeftValue, RightValue](_.upcast[Either[LeftValue, RightValue]], _.upcast[A])
           )
-        case _ => skipped(s"${tpe.prettyPrint} is not Either[_, _]")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not Either[_, _]")
       }
     })
   }

--- a/hearth/src/main/scala/hearth/std/extensions/IsEitherProviderForScalaTry.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsEitherProviderForScalaTry.scala
@@ -81,7 +81,7 @@ final class IsEitherProviderForScalaTry extends StandardMacroExtension { loader 
           implicit val A: Type[A] = tpe
           implicit val TryItem: Type[Try[Item]] = Try[Item]
           ProviderResult.Matched(isTry[A, Item](_.upcast[Try[Item]], _.upcast[A]))
-        case _ => skipped(s"${tpe.prettyPrint} is not Try[_]")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not Try[_]")
       }
     })
   }

--- a/hearth/src/main/scala/hearth/std/extensions/IsOptionProviderForScalaOption.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsOptionProviderForScalaOption.scala
@@ -47,14 +47,14 @@ final class IsOptionProviderForScalaOption extends StandardMacroExtension { load
 
       @scala.annotation.nowarn
       override def parse[A](tpe: Type[A]): ProviderResult[IsOption[A]] = tpe match {
-        case Some(_) => skipped("Some[_] cannot be empty")
+        case Some(_) => skippedLazily("Some[_] cannot be empty")
         case Option(item)
             if !(item.Underlying =:= Type.of[Nothing]) /* Nothing is a special case, cannot be of something */ =>
           import item.Underlying as Item
           implicit val A: Type[A] = tpe
           implicit val OptionItem: Type[Option[Item]] = Option[Item]
           ProviderResult.Matched(isOption[A, Item](_.upcast[Option[Item]], _.upcast[A]))
-        case _ => skipped(s"${tpe.prettyPrint} is not Option[_]")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not Option[_]")
       }
     })
   }

--- a/hearth/src/main/scala/hearth/std/extensions/IsValueTypeProviderForAnyVal.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsValueTypeProviderForAnyVal.scala
@@ -83,9 +83,10 @@ final class IsValueTypeProviderForAnyVal extends StandardMacroExtension { loader
         }
         result match {
           case Some(value) => ProviderResult.Matched(value)
-          case None => skipped(s"${tpe.prettyPrint} is <: AnyVal but no suitable single-param public constructor found")
+          case None        =>
+            skippedLazily(s"${tpe.prettyPrint} is <: AnyVal but no suitable single-param public constructor found")
         }
-      } else skipped(s"${tpe.prettyPrint} is not <: AnyVal")
+      } else skippedLazily(s"${tpe.prettyPrint} is not <: AnyVal")
     })
   }
 }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
@@ -79,7 +79,7 @@ final class IsCollectionProviderForJavaBitSet extends StandardMacroExtension { l
 
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] = tpe match {
         case _ if tpe =:= juBitSet => ProviderResult.Matched(isBitSet(tpe))
-        case _                     => skipped(s"${tpe.prettyPrint} is not =:= java.util.BitSet")
+        case _                     => skippedLazily(s"${tpe.prettyPrint} is not =:= java.util.BitSet")
       }
     })
   }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
@@ -289,9 +289,9 @@ final class IsCollectionProviderForJavaCollection extends StandardMacroExtension
             (classHierarchy orElse interfaceHierarchy) match {
               case Some(result) => ProviderResult.Matched(result)
               case None         =>
-                skipped(s"${tpe.prettyPrint} is <: java.util.Collection[_] but no matching concrete type found")
+                skippedLazily(s"${tpe.prettyPrint} is <: java.util.Collection[_] but no matching concrete type found")
             }
-          case _ => skipped(s"${tpe.prettyPrint} is not <: java.util.Collection[_]")
+          case _ => skippedLazily(s"${tpe.prettyPrint} is not <: java.util.Collection[_]")
         }
       }
     })

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
@@ -243,9 +243,9 @@ final class IsCollectionProviderForJavaDictionary extends StandardMacroExtension
               }
             } match {
               case Some(result) => ProviderResult.Matched(result)
-              case None         => skipped(s"${tpe.prettyPrint} is <: java.util.Dictionary[_, _] but no matching concrete type found")
+              case None         => skippedLazily(s"${tpe.prettyPrint} is <: java.util.Dictionary[_, _] but no matching concrete type found")
             }
-          case _ => skipped(s"${tpe.prettyPrint} is not <: java.util.Dictionary[_, _]")
+          case _ => skippedLazily(s"${tpe.prettyPrint} is not <: java.util.Dictionary[_, _]")
         }
         // format: on
       }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaEnumeration.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaEnumeration.scala
@@ -89,7 +89,7 @@ final class IsCollectionProviderForJavaEnumeration extends StandardMacroExtensio
           ProviderResult.Matched(isCollection[A, Item](A, _.upcast[java.util.Enumeration[Item]], _.upcast[A]))
 
         // Other types are not Java enumerations - if they should be supported, another extension can take care of it.
-        case _ => skipped(s"${tpe.prettyPrint} is not <: java.util.Enumeration[_]")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not <: java.util.Enumeration[_]")
       }
     })
   }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterable.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterable.scala
@@ -93,10 +93,10 @@ final class IsCollectionProviderForJavaIterable extends StandardMacroExtension {
           if (Type[A] =:= IterableItem)
             ProviderResult.Matched(isIterable[A, Item](A, _.upcast[java.lang.Iterable[Item]], _.upcast[A]))
           else
-            skipped(
+            skippedLazily(
               s"${tpe.prettyPrint} is a proper subtype of java.lang.Iterable[_]; only exact java.lang.Iterable is handled here"
             )
-        case _ => skipped(s"${tpe.prettyPrint} is not <: java.lang.Iterable[_]")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not <: java.lang.Iterable[_]")
       }
     })
   }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterator.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaIterator.scala
@@ -89,7 +89,7 @@ final class IsCollectionProviderForJavaIterator extends StandardMacroExtension {
           ProviderResult.Matched(isCollection[A, Item](A, _.upcast[java.util.Iterator[Item]], _.upcast[A]))
 
         // Other types are not Java iterators - if they should be supported, another extension can take care of it.
-        case _ => skipped(s"${tpe.prettyPrint} is not <: java.util.Iterator[_]")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not <: java.util.Iterator[_]")
       }
     })
   }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
@@ -285,9 +285,10 @@ final class IsCollectionProviderForJavaMap extends StandardMacroExtension { load
 
             (classHierarchy orElse interfaceHierarchy) match {
               case Some(result) => ProviderResult.Matched(result)
-              case None => skipped(s"${tpe.prettyPrint} is <: java.util.Map[_, _] but no matching concrete type found")
+              case None         =>
+                skippedLazily(s"${tpe.prettyPrint} is <: java.util.Map[_, _] but no matching concrete type found")
             }
-          case _ => skipped(s"${tpe.prettyPrint} is not <: java.util.Map[_, _]")
+          case _ => skippedLazily(s"${tpe.prettyPrint} is not <: java.util.Map[_, _]")
         }
       }
     })

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaOptional.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaOptional.scala
@@ -92,7 +92,7 @@ final class IsCollectionProviderForJavaOptional extends StandardMacroExtension {
           implicit val A: Type[A] = tpe
           implicit val OptionalItem: Type[java.util.Optional[Item]] = Optional[Item]
           ProviderResult.Matched(isOptional[A, Item](_.upcast[java.util.Optional[Item]], _.upcast[A]))
-        case _ => skipped(s"${tpe.prettyPrint} is not Optional[_]")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not Optional[_]")
       }
     })
   }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaStream.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaStream.scala
@@ -257,7 +257,7 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
                 isIntStream[A](A, _.upcast[java.util.stream.IntStream], accumulatorFactoryInfoExpr)
               )
             case None =>
-              skipped(s"${tpe.prettyPrint} is IntStream but AccumulatorFactoryInfo not found")
+              skippedLazily(s"${tpe.prettyPrint} is IntStream but AccumulatorFactoryInfo not found")
           }
         case _ if tpe =:= juLongStream =>
           implicit val A: Type[A] = tpe
@@ -268,7 +268,7 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
                 isLongStream[A](A, _.upcast[java.util.stream.LongStream], accumulatorFactoryInfoExpr)
               )
             case None =>
-              skipped(s"${tpe.prettyPrint} is LongStream but AccumulatorFactoryInfo not found")
+              skippedLazily(s"${tpe.prettyPrint} is LongStream but AccumulatorFactoryInfo not found")
           }
         case _ if tpe =:= juDoubleStream =>
           implicit val A: Type[A] = tpe
@@ -279,7 +279,7 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
                 isDoubleStream[A](A, _.upcast[java.util.stream.DoubleStream], accumulatorFactoryInfoExpr)
               )
             case None =>
-              skipped(s"${tpe.prettyPrint} is DoubleStream but AccumulatorFactoryInfo not found")
+              skippedLazily(s"${tpe.prettyPrint} is DoubleStream but AccumulatorFactoryInfo not found")
           }
         case juStream(item) =>
           import item.Underlying as Item
@@ -293,9 +293,9 @@ final class IsCollectionProviderForJavaStream extends StandardMacroExtension { l
                 isStream[A, Item](A, _.upcast[java.util.stream.Stream[Item]], accumulatorFactoryInfoExpr)
               )
             case None =>
-              skipped(s"${tpe.prettyPrint} is Stream[${Item.prettyPrint}] but AccumulatorFactoryInfo not found")
+              skippedLazily(s"${tpe.prettyPrint} is Stream[${Item.prettyPrint}] but AccumulatorFactoryInfo not found")
           }
-        case _ => skipped(s"${tpe.prettyPrint} is not a java.util.stream type")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not a java.util.stream type")
       }
     })
   }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsOptionProviderForJavaOptional.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsOptionProviderForJavaOptional.scala
@@ -160,7 +160,7 @@ final class IsOptionProviderForJavaOptional extends StandardMacroExtension { loa
           implicit val A: Type[A] = tpe
           implicit val OptionalItem: Type[java.util.Optional[Item]] = Optional[Item]
           ProviderResult.Matched(isOption[A, Item](_.upcast[java.util.Optional[Item]], _.upcast[A]))
-        case _ => skipped(s"${tpe.prettyPrint} is not Optional/OptionalInt/OptionalLong/OptionalDouble")
+        case _ => skippedLazily(s"${tpe.prettyPrint} is not Optional/OptionalInt/OptionalLong/OptionalDouble")
       }
     })
   }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaBoolean.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaBoolean.scala
@@ -52,7 +52,7 @@ final class IsValueTypeProviderForJavaBoolean extends StandardMacroExtension { l
 
       override def parse[A](tpe: Type[A]): ProviderResult[IsValueType[A]] =
         if (tpe <:< JBoolean) ProviderResult.Matched(isValueType.asInstanceOf[IsValueType[A]])
-        else skipped(s"${tpe.prettyPrint} is not <: java.lang.Boolean")
+        else skippedLazily(s"${tpe.prettyPrint} is not <: java.lang.Boolean")
     })
   }
 }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaByte.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaByte.scala
@@ -51,7 +51,7 @@ final class IsValueTypeProviderForJavaByte extends StandardMacroExtension { load
 
       override def parse[A](tpe: Type[A]): ProviderResult[IsValueType[A]] =
         if (tpe <:< JByte) ProviderResult.Matched(isValueType.asInstanceOf[IsValueType[A]])
-        else skipped(s"${tpe.prettyPrint} is not <: java.lang.Byte")
+        else skippedLazily(s"${tpe.prettyPrint} is not <: java.lang.Byte")
     })
   }
 }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaCharacter.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaCharacter.scala
@@ -52,7 +52,7 @@ final class IsValueTypeProviderForJavaCharacter extends StandardMacroExtension {
 
       override def parse[A](tpe: Type[A]): ProviderResult[IsValueType[A]] =
         if (tpe <:< JCharacter) ProviderResult.Matched(isValueType.asInstanceOf[IsValueType[A]])
-        else skipped(s"${tpe.prettyPrint} is not <: java.lang.Character")
+        else skippedLazily(s"${tpe.prettyPrint} is not <: java.lang.Character")
     })
   }
 }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaDouble.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaDouble.scala
@@ -52,7 +52,7 @@ final class IsValueTypeProviderForJavaDouble extends StandardMacroExtension { lo
 
       override def parse[A](tpe: Type[A]): ProviderResult[IsValueType[A]] =
         if (tpe <:< JDouble) ProviderResult.Matched(isValueType.asInstanceOf[IsValueType[A]])
-        else skipped(s"${tpe.prettyPrint} is not <: java.lang.Double")
+        else skippedLazily(s"${tpe.prettyPrint} is not <: java.lang.Double")
     })
   }
 }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaFloat.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaFloat.scala
@@ -52,7 +52,7 @@ final class IsValueTypeProviderForJavaFloat extends StandardMacroExtension { loa
 
       override def parse[A](tpe: Type[A]): ProviderResult[IsValueType[A]] =
         if (tpe <:< JFloat) ProviderResult.Matched(isValueType.asInstanceOf[IsValueType[A]])
-        else skipped(s"${tpe.prettyPrint} is not <: java.lang.Float")
+        else skippedLazily(s"${tpe.prettyPrint} is not <: java.lang.Float")
     })
   }
 }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaInteger.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaInteger.scala
@@ -52,7 +52,7 @@ final class IsValueTypeProviderForJavaInteger extends StandardMacroExtension { l
 
       override def parse[A](tpe: Type[A]): ProviderResult[IsValueType[A]] =
         if (tpe <:< JInteger) ProviderResult.Matched(isValueType.asInstanceOf[IsValueType[A]])
-        else skipped(s"${tpe.prettyPrint} is not <: java.lang.Integer")
+        else skippedLazily(s"${tpe.prettyPrint} is not <: java.lang.Integer")
     })
   }
 }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaLong.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaLong.scala
@@ -51,7 +51,7 @@ final class IsValueTypeProviderForJavaLong extends StandardMacroExtension { load
 
       override def parse[A](tpe: Type[A]): ProviderResult[IsValueType[A]] =
         if (tpe <:< JLong) ProviderResult.Matched(isValueType.asInstanceOf[IsValueType[A]])
-        else skipped(s"${tpe.prettyPrint} is not <: java.lang.Long")
+        else skippedLazily(s"${tpe.prettyPrint} is not <: java.lang.Long")
     })
   }
 }

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaShort.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsValueTypeProviderForJavaShort.scala
@@ -52,7 +52,7 @@ final class IsValueTypeProviderForJavaShort extends StandardMacroExtension { loa
 
       override def parse[A](tpe: Type[A]): ProviderResult[IsValueType[A]] =
         if (tpe <:< JShort) ProviderResult.Matched(isValueType.asInstanceOf[IsValueType[A]])
-        else skipped(s"${tpe.prettyPrint} is not <: java.lang.Short")
+        else skippedLazily(s"${tpe.prettyPrint} is not <: java.lang.Short")
     })
   }
 }


### PR DESCRIPTION
The by-name `skipped` perf change in #347 broke **pre-compiled provider extensions** at link time: kindlings' cats-integration threw `NoSuchMethodError: Provider.skipped$(Provider, String)` during macro expansion (caught by [Chimney PR #905 CI](https://github.com/scalalandio/chimney/pull/905)). The MiMa filters' justification was wrong — extensions are ServiceLoader-loaded binaries, not recompiled per Hearth version.

**Fix:** laziness moves to a new name — `skippedLazily(=> String)` on `Provider` and `ProviderResult` (Scala forbids overloading on by-name-ness alone) — and the strict `skipped(String)` signatures are restored under their original descriptors, delegating to the lazy variant. All in-repo providers call `skippedLazily` (perf unchanged); old binaries link against `skipped` and merely build their reason eagerly. Both MiMa filters removed — **MiMa is green without them**.

**Verified:** 1183 + 1311 + sandwich green; the exact failing combination (new Hearth + old pre-compiled kindlings `0.3.0-24-gfc36d68-SNAPSHOT` binary) now passes chimney-cats 312 + 312.

**Lesson recorded** in the roadmap/memory: a `StandardMacroExtension` provider is a binary-compat boundary — trait members its implementations call (`skipped`, `failed`, `name`, `parse`, `mightMatch` defaults) must keep their descriptors.