### PR TITLE
Perf: cut the quote-unpickling tax (Ctor.apply fast path, defn bottom symbols, cached bottom Types)

### DIFF
--- a/hearth/src/main/scala/hearth/std/StdExtensions.scala
+++ b/hearth/src/main/scala/hearth/std/StdExtensions.scala
@@ -8,6 +8,13 @@ import scala.collection.immutable.ListMap
 
 trait StdExtensions { this: MacroCommons =>
 
+  // Cached across all shape companions of one cake: on Scala 3 each `Type.of[X]` call unpickles a quoted type
+  // literal, and `isBottomType` used to pay two of them per `parse` call. Cake-level (not on the nested
+  // `ProvidedCompanion` trait) so that trait's compiled interface stays untouched - see the note above
+  // `bottomTypeSkipReason` / issue #319.
+  private lazy val stdExtensionsCachedNullType: Type[Null] = Type.of[Null]
+  private lazy val stdExtensionsCachedNothingType: Type[Nothing] = Type.of[Nothing]
+
   /** Base trait for companion objects that aggregate results from registered providers.
     *
     * Provides common infrastructure: a mutable list of providers, `registerProvider`, abstract `parse`, concrete
@@ -119,7 +126,7 @@ trait StdExtensions { this: MacroCommons =>
       * @since 0.3.0
       */
     final protected def isBottomType[A: Type]: Boolean =
-      Type[A] <:< Type.of[Null] || Type[A] <:< Type.of[Nothing]
+      Type[A] <:< stdExtensionsCachedNullType || Type[A] <:< stdExtensionsCachedNothingType
     // A `def` (not a `val`): a new trait `val`/`var` adds an abstract accessor to the compiled interface, breaking
     // binary compatibility; a `final def` compiles to a provided default method and does not. See issue #319.
     final protected def bottomTypeSkipReason: String =

--- a/project/TypeConstructorsGen.scala
+++ b/project/TypeConstructorsGen.scala
@@ -445,9 +445,11 @@ object TypeConstructorsGen {
     sb ++= s"            fastPathHktSymbol != null && fastPathHktSymbol.asInstanceOf[quotes.reflect.Symbol].isClassDef\n"
     sb ++= s"          }\n"
     // Bottom types conform to everything, so the base-classes negative must never fire for them.
+    // `defn` classes, NOT `TypeRepr.of[Nothing]`: the latter unpickles a quoted type literal (measurable per
+    // Ctor instance per expansion), the former is a free reference to a preloaded symbol.
     sb ++= s"          private lazy val fastPathBottomSymbols: (AnyRef, AnyRef) = {\n"
     sb ++= s"            given quotes: scala.quoted.Quotes = CrossQuotes.ctx\n"
-    sb ++= s"            (quotes.reflect.TypeRepr.of[Nothing].typeSymbol, quotes.reflect.TypeRepr.of[Null].typeSymbol)\n"
+    sb ++= s"            (quotes.reflect.defn.NothingClass, quotes.reflect.defn.NullClass)\n"
     sb ++= s"          }\n"
 
     // asUntyped
@@ -464,6 +466,17 @@ object TypeConstructorsGen {
       val name = p(i)
       sb ++= s"            given scala.quoted.Type[$name] = Type[$name].asInstanceOf[scala.quoted.Type[$name]]\n"
     }
+    // Fast path (perf): for a class/trait-headed constructor, `TypeRepr.of[HKT].appliedTo(args)` builds the exact
+    // same type as the quoted literal below without unpickling a pickled quote on every call (the tag reads are
+    // free). Alias/lambda heads keep the quote so the literal's surface form (e.g. the alias name) is preserved.
+    val applyFastArgs = (0 until n).map(i => s"quotes.reflect.TypeRepr.of[${p(i)}]").mkString(", ")
+    sb ++= s"            if (fastPathHktIsClass) {\n"
+    sb ++= s"              return quotes.reflect.TypeRepr\n"
+    sb ++= s"                .of[HKT]\n"
+    sb ++= s"                .appliedTo(List($applyFastArgs))\n"
+    sb ++= s"                .asType\n"
+    sb ++= s"                .asInstanceOf[Type[HKT[${allParams(n)}]]]\n"
+    sb ++= s"            }\n"
     sb ++= s"            scala.quoted.Type.of[HKT[${allParams(n)}]].asInstanceOf[Type[HKT[${allParams(n)}]]]\n"
     sb ++= s"          }\n"
 


### PR DESCRIPTION
Profiling the dense Chimney derivation load showed **29.9% of macro samples inside `PickledQuotes`/`TastyString`** — every evaluation of a quoted `Type.of[...]` literal unpickles a pickled tree. Three mechanical cuts:

1. **Generated `Ctor.Bounded.apply` fast path**: class/trait-headed constructors build the applied type via `TypeRepr.of[HKT].appliedTo(args)` (free tag reads — the same construction `FromUntypedImpl.apply` already used) instead of unpickling a `Type.of[HKT[...]]` quote per call. Alias/lambda heads keep the quote so the literal's surface form is preserved.
2. **`fastPathBottomSymbols`** uses `defn.NothingClass`/`defn.NullClass` instead of `TypeRepr.of[Nothing]/[Null]` (each unpickled a quoted literal per Ctor instance per expansion).
3. **`StdExtensions.isBottomType`** unpickled `Type.of[Null]` + `Type.of[Nothing]` on **every** shape-companion `parse` call; both are now cake-level lazy vals (kept off the nested `ProvidedCompanion` trait per the #319 binary-compat note).

## Measured (dense load, JFR)
| | before | after |
|---|---|---|
| `Ctor.apply` (all arities) | 3.3% | **0.4%** |
| `fastPathBottomSymbols` init | 1.3% | **0.2%** |
| macro share | 20.6% | **19.1%** |
| absolute macro samples | 3874 | **2894 (−25%)** |

Chimney's `ChimneyType.*` factories ride on `Ctor.apply`, so downstreams get this for free. Verified: 1183 + 1311 + sandwich green (incl. the BoundedCtor parity specs guarding `apply`/`unapply` equivalence), MiMa green, no new filters.
