### PR TITLE
Docs: shipped-state compile ratio + runtime-parity verification

### DIFF
--- a/docs/contributing/compile-time-perf-roadmap.md
+++ b/docs/contributing/compile-time-perf-roadmap.md
@@ -35,7 +35,13 @@ compile, old design as 1.0×):
 | pre-optimization (Hearth as-migrated) | ~3.0× | ~2.0× |
 | after the optimizations so far | ~1.7× | ~1.5× |
 | **after PR #347 (perf9, measured 2026-07-10)** | **1.30×** | **1.27×** |
+| **shipped state (#347+#349+#350 + chimney#905, 2026-07-10)** | **1.22×** | **~1.3×** (flat) |
 | goal | → 1.0× | → 1.0× |
+
+Shipped-state row: premig 115s/74s vs merged `2.0.0-development` @ `0.4.0-45-g8dcd069-SNAPSHOT`
+140s/98s, best of 3. The #350 quote-tax and Part E/F cuts are Scala-3-side (pickled quotes and the
+inherited-field walk do not exist on Scala 2), so the Scala 2 number staying flat is expected — its
+remaining gap is a separate investigation.
 
 The 2026-07-10 measurement: `chimney` module `clean` + `Test/compile`, best of 3 (spread was ±3s —
 tight), sbt-reported compile seconds, `CI=true` (no scalafmt), Temurin 25 — premig (macro-commons,

--- a/docs/contributing/compile-time-perf-roadmap.md
+++ b/docs/contributing/compile-time-perf-roadmap.md
@@ -348,6 +348,19 @@ conversion ~7%, Chimney `Configurations` ~8% (Chimney-side), `summonImplicit` ~6
 meaningful cuts need the *Chimney-side* adoptions (methodGetter → `unsortedMethodsNamed`,
 `TypeCache` → `Type.Cache`) after a Hearth release/snapshot carrying PR #347.
 
+## Runtime verification (2026-07-10) — the generated code is not slower
+
+The compile-time work above must not cost runtime: the full Chimney JMH suite (identical benchmark
+sources) was run against the last pre-Hearth macro-commons commit on the same JVM. Result: **0
+regressions, 8 significant improvements** (`BasicLarge` 1.31×, `BasicSimple` 1.22×,
+`eitherTransformChimney` 1.25×, ...), rest within error bars — after fixing the ONE real regression
+the sweep found (chimney#906): the Hearth-migration `foreach`+builder collection encoding had lost
+`Iterator.to(factory)`'s `knownSize` pre-allocation, putting `Array` targets at 0.55× (builder
+regrowth + an extra `result()` copy). Fixed with a `sizeHint` plus routing Array sources through the
+mapped-iterator encoding (0.99× — statistical parity; non-array sources keep foreach+builder, which
+measures faster for them). Lesson for Hearth-based codegen: collection-building encodings must
+preserve size hints, and `javap` on a benchmark class shows the whole derivation — cheap to audit.
+
 ## Sequencing & measurement
 
 Biggest-bang order when credits/time are tight:


### PR DESCRIPTION
Two measurement records for the perf roadmap: the shipped-state end-to-end compile ratio (**1.22× Scala 3** — down from 1.30× before #350/module-init cuts; ~1.3× flat on Scala 2.13, which none of the recent Scala-3-side cuts touch), and the runtime JMH sweep vs pre-Hearth macro-commons (**0 regressions, 8 improvements** after [chimney#906](https://github.com/scalalandio/chimney/pull/906) fixed the one real finding — Array targets at 0.55× from a lost size hint, now 0.99× parity).