### PR TITLE
Add IsCollectionOf.sizeHintForBuilder: safe per-provider builder pre-allocation

### DIFF
--- a/hearth/src/main/scala-3/hearth/std/extensions/IsCollectionProviderForIArray.scala
+++ b/hearth/src/main/scala-3/hearth/std/extensions/IsCollectionProviderForIArray.scala
@@ -41,6 +41,9 @@ final class IsCollectionProviderForIArray extends StandardMacroExtension { loade
         Existential[IsCollectionOf[A, *], Item](new IsCollectionOf[A, Item] {
           // We will use Array as the collection type, we need to adjust how we convert the collection to Iterable.
           override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = toIterableExpr(value)
+          override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+            Expr.splice(value).asInstanceOf[IArray[Item]].length
+          })
           override def foreach(value: Expr[A])(f: Expr[Item] => Expr[Unit]): Expr[Unit] = Expr.quote {
             val arr = Expr.splice(value).asInstanceOf[IArray[Item]]
             var i = 0

--- a/hearth/src/main/scala/hearth/std/StdExtensions.scala
+++ b/hearth/src/main/scala/hearth/std/StdExtensions.scala
@@ -475,6 +475,28 @@ trait StdExtensions { this: MacroCommons =>
       }
     }
 
+    /** Emits an expression computing the collection's size for pre-allocating a builder (`Builder.sizeHint`), or `None`
+      * when no SAFE size expression exists.
+      *
+      * The contract: the returned expression must be cheap (O(1)-ish) and, critically, '''must not traverse or consume
+      * the collection''' - a single-pass source (an iterator, an enumeration, a Java stream) must return `None` (the
+      * default), because any size probe next to the actual traversal would consume it. The expression may evaluate to a
+      * negative value at runtime when the size is unknown (e.g. `knownSize` of a `List`); callers are expected to guard
+      * with `if (size >= 0)` before calling `sizeHint`.
+      *
+      * Consumers building a target collection element-by-element should use this to avoid builder regrowth: an
+      * un-hinted `ArrayBuilder`, for instance, regrows log(n) times and pays one more array copy in `result()`.
+      *
+      * @since 0.4.1
+      *
+      * @param value
+      *   the collection expression to (safely) measure
+      * @return
+      *   `Some` of an `Expr[Int]` evaluating to the size (or a negative value for unknown-at-runtime), `None` when no
+      *   safe size expression exists (single-pass sources)
+      */
+    def sizeHintForBuilder(value: Expr[CollA]): Option[Expr[Int]] = None
+
     /** If this collection is actually a map, returns its map proof (whose `Pair` is this `Item`); `None` for a plain
       * collection. Lets a caller that already holds an `IsCollectionOf` discover map-ness without a second
       * `IsCollection.parse` and without an erasure-unsound `isInstanceOf[IsMapOf[?, ?]]`.

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForArray.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForArray.scala
@@ -40,6 +40,9 @@ final class IsCollectionProviderForArray extends StandardMacroExtension { loader
         Existential[IsCollectionOf[A, *], Item](new IsCollectionOf[A, Item] {
           // We will use Array as the collection type, we need to adjust how we convert the collection to Iterable.
           override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = toIterableExpr(value)
+          override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+            Expr.splice(value).asInstanceOf[Array[Item]].length
+          })
           override def foreach(value: Expr[A])(f: Expr[Item] => Expr[Unit]): Expr[Unit] = Expr.quote {
             val arr = Expr.splice(value).asInstanceOf[Array[Item]]
             var i = 0

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaCollection.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaCollection.scala
@@ -31,6 +31,10 @@ final class IsCollectionProviderForScalaCollection extends StandardMacroExtensio
         Existential[IsCollectionOf[A, *], Item](new IsCollectionOf[A, Item] {
           // We're just upcasting the collection to Iterable, to avoid things like type constructor extraction from generic F[A].
           override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = value.asInstanceOf[Expr[Iterable[Item]]]
+          // knownSize is O(1) and safe on multi-pass collections; -1 at runtime (e.g. List) means unknown.
+          override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+            Expr.splice(value.asInstanceOf[Expr[Iterable[Item]]]).knownSize
+          })
           // Standard scala collections have no smart constructors, so we just return the collection itself.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
@@ -60,6 +64,10 @@ final class IsCollectionProviderForScalaCollection extends StandardMacroExtensio
         Existential[IsCollectionOf[A, *], Pair](new IsMapOf[A, Pair] {
           // We're just upcasting the collection to Iterable, to avoid things like type constructor extraction from generic F[A].
           override def asIterable(value: Expr[A]): Expr[Iterable[Pair]] = value.asInstanceOf[Expr[Iterable[Pair]]]
+          // knownSize is O(1) and safe on multi-pass collections; -1 at runtime means unknown.
+          override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+            Expr.splice(value.asInstanceOf[Expr[Iterable[Pair]]]).knownSize
+          })
           // Standard scala collections have no smart constructors, so we just return the collection itself.
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaOption.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForScalaOption.scala
@@ -39,6 +39,10 @@ final class IsCollectionProviderForScalaOption extends StandardMacroExtension { 
           override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = Expr.quote {
             Expr.splice(toOption(value)).toList
           }
+          // `scala.Some` fully qualified: the provider shadows `Some` with its `Type.Ctor1.of[scala.Some]` above.
+          override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = scala.Some(Expr.quote {
+            if (Expr.splice(toOption(value)).isDefined) 1 else 0
+          })
           // CtorResult is List[Item] so the smart constructor can validate element count.
           override type CtorResult = List[Item]
           implicit override val CtorResult: Type[CtorResult] = listItemType

--- a/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForString.scala
+++ b/hearth/src/main/scala/hearth/std/extensions/IsCollectionProviderForString.scala
@@ -28,6 +28,9 @@ final class IsCollectionProviderForString extends StandardMacroExtension { loade
           override def asIterable(value: Expr[A]): Expr[Iterable[Char]] = Expr.quote {
             new scala.collection.immutable.WrappedString(Expr.splice(value).asInstanceOf[String])
           }
+          override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+            Expr.splice(value).asInstanceOf[String].length
+          })
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
           override def factory: Expr[scala.collection.Factory[Char, CtorResult]] = Expr.quote {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaBitSet.scala
@@ -34,6 +34,9 @@ final class IsCollectionProviderForJavaBitSet extends StandardMacroExtension { l
               else Some(currentValue, bitSet.nextSetBit(currentValue + 1))
             }
           }
+          override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+            Expr.splice(value).asInstanceOf[java.util.BitSet].cardinality()
+          })
           override def foreach(value: Expr[A])(f: Expr[Int] => Expr[Unit]): Expr[Unit] = Expr.quote {
             val bitSet = Expr.splice(value).asInstanceOf[java.util.BitSet]
             var i = bitSet.nextSetBit(0)

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaCollection.scala
@@ -63,6 +63,9 @@ final class IsCollectionProviderForJavaCollection extends StandardMacroExtension
           override def asIterable(value: Expr[A]): Expr[Iterable[Item]] = Expr.quote {
             scala.jdk.javaapi.CollectionConverters.asScala(Expr.splice(value).iterator()).to(Iterable)
           }
+          override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+            Expr.splice(value).size()
+          })
           override def foreach(value: Expr[A])(f: Expr[Item] => Expr[Unit]): Expr[Unit] = Expr.quote {
             val it = Expr.splice(value).iterator()
             while (it.hasNext()) {
@@ -119,6 +122,9 @@ final class IsCollectionProviderForJavaCollection extends StandardMacroExtension
               )
               .to(Iterable)
           }
+          override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+            Expr.splice(value).asInstanceOf[java.util.Set[Item]].size()
+          })
           override type CtorResult = A
           implicit override val CtorResult: Type[CtorResult] = A
           override def factory: Expr[scala.collection.Factory[Item, CtorResult]] =

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaDictionary.scala
@@ -48,6 +48,9 @@ final class IsCollectionProviderForJavaDictionary extends StandardMacroExtension
               .map(key => (key, dict.get(key)))
               .to(Iterable)
           }
+          override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+            Expr.splice(value).asInstanceOf[java.util.Dictionary[Key, Value]].size()
+          })
           override def foreach(value: Expr[A])(f: Expr[Pair] => Expr[Unit]): Expr[Unit] = Expr.quote {
             val dict: java.util.Dictionary[Key, Value] =
               Expr.splice(value).asInstanceOf[java.util.Dictionary[Key, Value]]
@@ -140,6 +143,9 @@ final class IsCollectionProviderForJavaDictionary extends StandardMacroExtension
             // We will use scala.jdk.javaapi.CollectionConverters.asScala to convert the dictionary to Iterable.
             override def asIterable(value: Expr[java.util.Properties]): Expr[Iterable[(String, String)]] =
               asScalaExpr(value)
+            override def sizeHintForBuilder(value: Expr[java.util.Properties]): Option[Expr[Int]] = Some(Expr.quote {
+              Expr.splice(value).size()
+            })
             override def foreach(value: Expr[java.util.Properties])(
                 f: Expr[(String, String)] => Expr[Unit]
             ): Expr[Unit] = Expr.quote {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaMap.scala
@@ -71,6 +71,9 @@ final class IsCollectionProviderForJavaMap extends StandardMacroExtension { load
               )
               .to(Iterable)
           }
+          override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+            Expr.splice(value).asInstanceOf[java.util.Map[Key0, Value0]].size()
+          })
           override def foreach(value: Expr[A])(f: Expr[Pair] => Expr[Unit]): Expr[Unit] = Expr.quote {
             val it = Expr.splice(value).asInstanceOf[java.util.Map[Key0, Value0]].entrySet().iterator()
             while (it.hasNext()) {
@@ -137,6 +140,9 @@ final class IsCollectionProviderForJavaMap extends StandardMacroExtension { load
           override def asIterable(value: Expr[A]): Expr[Iterable[Pair]] = Expr.quote {
             scala.jdk.javaapi.CollectionConverters.asScala(Expr.splice(value).entrySet().iterator()).to(Iterable)
           }
+          override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+            Expr.splice(value).size()
+          })
           override def foreach(value: Expr[A])(f: Expr[Pair] => Expr[Unit]): Expr[Unit] = Expr.quote {
             val it = Expr.splice(value).entrySet().iterator()
             while (it.hasNext()) {

--- a/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaOptional.scala
+++ b/hearth/src/main/scalajvm/hearth/std/extensions/IsCollectionProviderForJavaOptional.scala
@@ -40,6 +40,9 @@ final class IsCollectionProviderForJavaOptional extends StandardMacroExtension {
             val opt = Expr.splice(toOptional(value))
             if (opt.isPresent) List(opt.get()) else Nil
           }
+          override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+            if (Expr.splice(toOptional(value)).isPresent) 1 else 0
+          })
           override def foreach(value: Expr[A])(f: Expr[Item] => Expr[Unit]): Expr[Unit] = Expr.quote {
             val opt = Expr.splice(toOptional(value))
             if (opt.isPresent) {


### PR DESCRIPTION
Follow-up to the runtime-parity work ([chimney#906](https://github.com/scalalandio/chimney/pull/906)): consumers building a target collection element-by-element want `Builder.sizeHint`, but obtaining a size generically means a second traversal — which **consumes single-pass sources** (java Iterator/Enumeration sources came out empty, java streams threw `already operated upon` on chimney's CI). The provider is the one who knows whether a non-consuming size expression exists, so:

```scala
def sizeHintForBuilder(value: Expr[CollA]): Option[Expr[Int]] = None
```

- **Default `None`** = no safe size — single-pass providers (scala `Iterator`, java `Iterator`/`Enumeration`/`Stream`) inherit it, making misuse impossible by construction.
- **Overridden by all 13 multi-pass provider shapes**: `Array`/`IArray` (`length`), scala collections (`knownSize` — may evaluate to `-1` at runtime, callers guard with `>= 0`), `String` (`length`), scala `Option`/java `Optional` (0/1), java `Collection`/`Set`/`Map`/`Dictionary`/`Properties` (`size()`), java `BitSet` (`cardinality()`).
- Compiles to a **default interface method** — binary-compatible for extensions built against older Hearth (MiMa green, zero filters; same pattern as `mightMatch`).

Verified: 1183 + 1311 + sandwich green, MiMa green. Chimney will adopt it in the foreach+builder encoding once a snapshot carries it.