### PR TITLE
Regression tests for #348: typeAnnotations with case-class annotations (cannot reproduce) (Do not merge)

### DIFF
--- a/hearth-tests/src/main/scala/hearth/examples/methods.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/methods.scala
@@ -15,6 +15,15 @@ case class WithTypeAnnotations(
     nickname: String @ExampleAnnotation2(42) @ExampleAnnotation
 )
 
+// A CASE CLASS annotation with a String argument - issue #348's exact shape (`name: String @Action("anonymize")`).
+case class ExampleCaseClassAnnotation(name: String) extends scala.annotation.StaticAnnotation
+
+// Reproduction of issue #348: typeAnnotations came back empty for this shape.
+case class WithCaseClassTypeAnnotation(
+    name: String @ExampleCaseClassAnnotation("anonymize"),
+    age: Int
+)
+
 @ChildAnnotation
 class WithChildAnnotation {
 

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -899,6 +899,8 @@ trait MethodsFixturesImpl { this: MacroCommons =>
     def annNames(anns: List[Expr_??]): Data = Data.list(anns.map { ann =>
       if (ann.Underlying =:= Type.of[hearth.examples.methods.ExampleAnnotation2]) Data("ExampleAnnotation2")
       else if (ann.Underlying =:= Type.of[hearth.examples.methods.ExampleAnnotation]) Data("ExampleAnnotation")
+      else if (ann.Underlying =:= Type.of[hearth.examples.methods.ExampleCaseClassAnnotation])
+        Data("ExampleCaseClassAnnotation")
       else Data(ann.Underlying.plainPrint)
     }*)
 

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -2602,6 +2602,33 @@ final class MethodsSpec extends MacroSuite {
         )
       )
     }
+
+    test("type-position CASE CLASS annotations with arguments are exposed (#348)") {
+      import MethodsFixtures.testTypeAnnotations
+
+      testTypeAnnotations[examples.methods.WithCaseClassTypeAnnotation] <==> Data.map(
+        "own" -> Data.list(),
+        "fields" -> Data.list(
+          Data.map("name" -> Data("name"), "typeAnnotations" -> Data.list(Data("ExampleCaseClassAnnotation"))),
+          Data.map("name" -> Data("age"), "typeAnnotations" -> Data.list())
+        )
+      )
+    }
+
+    test("type-position annotations on SAME-COMPILATION-RUN types are exposed (#348)") {
+      import MethodsFixtures.testTypeAnnotations
+
+      testTypeAnnotations[LocalWithCaseClassTypeAnnotation] <==> Data.map(
+        "own" -> Data.list(),
+        "fields" -> Data.list(
+          Data.map(
+            "name" -> Data("name"),
+            "typeAnnotations" -> Data.list(Data("hearth.typed.LocalCaseClassAnnotation"))
+          ),
+          Data.map("name" -> Data("age"), "typeAnnotations" -> Data.list())
+        )
+      )
+    }
   }
 
   group("methods: parameter annotations") {
@@ -2897,3 +2924,13 @@ final class MethodsSpec extends MacroSuite {
     }
   }
 }
+
+// Issue #348 same-compilation-run reproduction: the annotation AND the annotated class are defined in the SAME
+// compilation unit that expands the macro (unlike `hearth.examples.methods.*`, which is pre-compiled in another
+// module and reaches the macro through unpickling).
+case class LocalCaseClassAnnotation(name: String) extends scala.annotation.StaticAnnotation
+
+case class LocalWithCaseClassTypeAnnotation(
+    name: String @LocalCaseClassAnnotation("anonymize"),
+    age: Int
+)


### PR DESCRIPTION
Attempted to reproduce #348 with the exact reported shape — `case class Action(name: String) extends StaticAnnotation` applied as `name: String @Action(\"anonymize\")`, read via `primaryConstructor.totalParameters` → `Parameter.tpe` → `Type.typeAnnotations` — and it **passes everywhere on current master**:

- Scala 2.13.16 + 3.3.8 (primary) and 2.13.18 + 3.8.4 (`NEWEST_SCALA_TESTS`)
- types pre-compiled in another module (unpickled) **and** types defined in the same compilation unit as the macro expansion

This PR locks both variants in as regression tests (`WithCaseClassTypeAnnotation` in the examples module, `LocalWithCaseClassTypeAnnotation` in the spec file itself). The remaining unknowns are on the reporter's side (hearth snapshot version tested, Scala version, platform) — to be clarified on the issue.