### PR TITLE
Add Type.Lazy: scope-safe deferred Type for per-expansion helper objects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -386,7 +386,18 @@ val mimaSettings = Seq(
     // trait `UntypedTypes#UntypedTypeModule`, part of the MacroCommons cake and implemented ONLY by Hearth's own
     // platform `UntypedType` objects (UntypedTypesScala2/Scala3) - interface and implementation are always evicted
     // together, so no user has a standalone implementation to break. `private[hearth]` besides.
-    exclude[ReversedMissingMethodProblem]("hearth.untyped.UntypedTypes#UntypedTypeModule.cacheBucketKey")
+    exclude[ReversedMissingMethodProblem]("hearth.untyped.UntypedTypes#UntypedTypeModule.cacheBucketKey"),
+    // Type.Lazy support: `withMacroEntryContext`/`macroEntryContextKey` added to the NESTED trait
+    // `Environments#CrossQuotesModule`, implemented ONLY by Hearth's own platform `CrossQuotes` objects
+    // (EnvironmentsScala2/Scala3) - interface and implementations are always evicted together, so no user has a
+    // standalone implementation to break. `private[hearth]` besides.
+    exclude[ReversedMissingMethodProblem]("hearth.Environments#CrossQuotesModule.withMacroEntryContext"),
+    exclude[ReversedMissingMethodProblem]("hearth.Environments#CrossQuotesModule.macroEntryContextKey"),
+    // Type.Lazy: the accessor of the NEW nested `object Lazy` inside `Types#TypeModule` (a Scala-2 trait-nested-module
+    // artifact). TypeModule is part of the MacroCommons cake and implemented ONLY by Hearth's own platform `Type`
+    // objects - interface and implementations are always evicted together, so no user has a standalone implementation
+    // to break.
+    exclude[ReversedMissingMethodProblem]("hearth.typed.Types#TypeModule.Lazy")
   )
 )
 

--- a/hearth-tests/src/main/scala-2/hearth/typed/TypesFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/TypesFixtures.scala
@@ -53,6 +53,8 @@ final private class TypesFixtures(val c: blackbox.Context) extends MacroCommonsS
   def testDecomposeSummonNameImpl[A: c.WeakTypeTag]: c.Expr[String] = testDecomposeSummonName[A]
 
   def testCtorK1FromDiscoveredPartsImpl[A: c.WeakTypeTag]: c.Expr[Data] = testCtorK1FromDiscoveredParts[A]
+
+  def testLazyTypeScopeSafetyImpl: c.Expr[Data] = testLazyTypeScopeSafety
 }
 
 object TypesFixtures {
@@ -100,4 +102,6 @@ object TypesFixtures {
   def testDecomposeSummonName[A]: String = macro TypesFixtures.testDecomposeSummonNameImpl[A]
 
   def testCtorK1FromDiscoveredParts[A]: Data = macro TypesFixtures.testCtorK1FromDiscoveredPartsImpl[A]
+
+  def testLazyTypeScopeSafety: Data = macro TypesFixtures.testLazyTypeScopeSafetyImpl
 }

--- a/hearth-tests/src/main/scala-3/hearth/typed/TypesFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/TypesFixtures.scala
@@ -164,4 +164,8 @@ object TypesFixtures {
   inline def testCtorK1FromDiscoveredParts[A]: Data = ${ testCtorK1FromDiscoveredPartsImpl[A] }
   private def testCtorK1FromDiscoveredPartsImpl[A: Type](using q: Quotes): Expr[Data] =
     new TypesFixtures(q).testCtorK1FromDiscoveredParts[A]
+
+  inline def testLazyTypeScopeSafety: Data = ${ testLazyTypeScopeSafetyImpl }
+  private def testLazyTypeScopeSafetyImpl(using q: Quotes): Expr[Data] =
+    new TypesFixtures(q).testLazyTypeScopeSafety
 }

--- a/hearth-tests/src/main/scala/hearth/typed/TypesFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/TypesFixturesImpl.scala
@@ -777,6 +777,30 @@ trait TypesFixturesImpl { this: MacroCommons =>
     }
   }
 
+  // Type.Lazy: the deferred type must behave like an eagerly-initialized one even when its FIRST touch happens
+  // inside an `Expr.splice` (a fresh nested Quotes on Scala 3) and it is then reused OUTSIDE that splice - the
+  // pattern that breaks a plain `lazy val` with "Expression created in a splice was used outside of that splice".
+  def testLazyTypeScopeSafety: Expr[Data] = {
+    val lazyString: Type.Lazy[String] = Type.Lazy(Type.of[String])
+
+    // First touch INSIDE a splice (nested ctx on Scala 3):
+    val innerExpr: Expr[String] = Expr.quote {
+      Expr.splice {
+        Expr(lazyString.value.plainPrint)
+      } + "!"
+    }
+
+    // Reuse OUTSIDE that splice (entry ctx), via the implicit conversion:
+    val outerName: String = (lazyString: Type[String]).plainPrint
+
+    Expr.quote {
+      Data.map(
+        "inner" -> Data(Expr.splice(innerExpr)),
+        "outer" -> Data(Expr.splice(Expr(outerName)))
+      )
+    }
+  }
+
   // types using in fixtures
 
   private val aStringType = Type.of["a"]

--- a/hearth-tests/src/test/scala/hearth/typed/TypesSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/TypesSpec.scala
@@ -1921,6 +1921,18 @@ final class TypesSpec extends MacroSuite {
       }
     }
 
+    group("type Type.Lazy") {
+
+      test("Type.Lazy first touched inside an Expr.splice stays usable outside that splice") {
+        import TypesFixtures.testLazyTypeScopeSafety
+
+        testLazyTypeScopeSafety <==> Data.map(
+          "inner" -> Data("java.lang.String!"),
+          "outer" -> Data("java.lang.String")
+        )
+      }
+    }
+
     group("type TypeCodec") {
 
       test(

--- a/hearth/src/main/scala-2/hearth/EnvironmentsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/EnvironmentsScala2.scala
@@ -208,5 +208,10 @@ trait EnvironmentsScala2 extends Environments { this: MacroCommonsScala2 =>
   object CrossQuotes extends CrossQuotesModule {
 
     override def ctx[CastAs]: CastAs = c.asInstanceOf[CastAs]
+
+    // Scala 2 has a single macro Context: there is no splice scoping, so pinning the entry context is a no-op.
+    override private[hearth] def withMacroEntryContext[A](thunk: => A): A = thunk
+
+    override private[hearth] def macroEntryContextKey: AnyRef = c
   }
 }

--- a/hearth/src/main/scala-3/hearth/EnvironmentsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/EnvironmentsScala3.scala
@@ -209,5 +209,9 @@ trait EnvironmentsScala3 extends Environments { this: MacroCommonsScala3 =>
     override protected def macroEntryCtx: scala.quoted.Quotes = quotes
 
     override def ctx[CastAs]: CastAs = currentCtx.asInstanceOf[CastAs]
+
+    override private[hearth] def withMacroEntryContext[A](thunk: => A): A = withMacroEntryCtx(thunk)
+
+    override private[hearth] def macroEntryContextKey: AnyRef = macroEntryCtx
   }
 }

--- a/hearth/src/main/scala/hearth/Environments.scala
+++ b/hearth/src/main/scala/hearth/Environments.scala
@@ -584,6 +584,24 @@ trait Environments extends EnvironmentCrossQuotesSupport { env: MacroCommons =>
 
     /** `scala.reflect.macros.blackbox.Context` on Scala 2, `scala.quoted.Quotes` on Scala 3. */
     def ctx[CastAs]: CastAs
+
+    /** Runs `thunk` with the MACRO-ENTRY (outermost) context pinned as the active Cross-Quotes context.
+      *
+      * On Scala 3 each `Expr.splice` evaluates its body under a fresh nested `Quotes`; a `Type`/`Expr` created there is
+      * tied to that splice's scope and must not escape it (`-Xcheck-macros` aborts with "Expression created in a splice
+      * was used outside of that splice"). Values created under the ENTRY context, by contrast, are valid throughout the
+      * whole expansion - this is what makes lazily-initialized shared state (see [[Type.Lazy]]) safe regardless of
+      * which splice touches it first. On Scala 2 there is no context scoping and this is just `thunk`.
+      *
+      * @since 0.4.1
+      */
+    private[hearth] def withMacroEntryContext[A](thunk: => A): A
+
+    /** Identity of the macro-entry context, for caches that must not leak values between expansions.
+      *
+      * @since 0.4.1
+      */
+    private[hearth] def macroEntryContextKey: AnyRef
   }
 
   // Lexical-scope (enclosure) inspection for the current macro expansion.

--- a/hearth/src/main/scala/hearth/typed/Types.scala
+++ b/hearth/src/main/scala/hearth/typed/Types.scala
@@ -1043,6 +1043,54 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
       *
       * @since 0.4.1
       */
+    /** A lazily-computed [[Type]] that is SAFE to keep in per-expansion helper objects.
+      *
+      * A plain `lazy val tpe: Type[A] = Type.of[A]` is NOT: its first touch can happen inside an `Expr.splice` (which,
+      * on Scala 3, evaluates under a fresh nested `Quotes`), tying the `Type` - and every expr later built from it - to
+      * that splice's scope; reusing it from a sibling or outer splice then aborts under `-Xcheck-macros` with
+      * "Expression created in a splice was used outside of that splice". Eager `val`s dodge this only by accident of
+      * WHEN the enclosing object initializes - and pay the full materialization cost (a pickled-quote unpickling per
+      * `Type.of` on Scala 3) on every macro expansion, used or not.
+      *
+      * `Type.Lazy` computes its thunk with the MACRO-ENTRY context pinned, so the result is scoped exactly like an
+      * eagerly-initialized `val` (valid throughout the whole expansion, inside any splice), while the cost is only paid
+      * if the type is actually used. The computed value is memoized per macro expansion (re-computed if the holder
+      * outlives the expansion, e.g. when kept in a global object).
+      *
+      * Usage - replace an eager helper `val`:
+      * {{{
+      * val StringType: Type[String]      = Type.of[String]        // eager: costs every expansion
+      * val StringType: Type.Lazy[String] = Type.Lazy(Type.of[String]) // deferred: costs only when used
+      * }}}
+      * Use-sites stay unchanged - a `Type.Lazy[A]` converts to `Type[A]` implicitly (see `lazyTypeToType`).
+      *
+      * Not thread-safe; a macro expansion is single-threaded.
+      *
+      * @since 0.4.1
+      */
+    final class Lazy[A] private[Types] (compute: () => Type[A]) {
+      private var cachedFor: AnyRef = null
+      private var cached: Type[A] = null.asInstanceOf[Type[A]]
+
+      def value: Type[A] = {
+        val key = CrossQuotes.macroEntryContextKey
+        if ((cached == null) || (cachedFor ne key)) {
+          cached = CrossQuotes.withMacroEntryContext(compute())
+          cachedFor = key
+        }
+        cached
+      }
+    }
+    object Lazy {
+
+      /** Creates a [[Lazy]] - `compute` is by-name and will run (at most once per expansion) with the macro-entry
+        * context pinned.
+        *
+        * @since 0.4.1
+        */
+      def apply[A](compute: => Type[A]): Lazy[A] = new Lazy(() => compute)
+    }
+
     final class Cache[F[_]] {
       // (cross-quotes scope token, cheap bucket key) -> entries checked with =:=.
       private val impl =
@@ -1091,6 +1139,14 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
       }
     }
   }
+
+  /** Unwraps a [[Type.Lazy]] wherever a [[Type]] is expected, so converting an eager helper `val` to `Type.Lazy`
+    * requires no use-site changes (implicit `Type` positions still need the value assigned to an `implicit val`,
+    * exactly as with the eager form).
+    *
+    * @since 0.4.1
+    */
+  implicit final def lazyTypeToType[A](lazyType: Type.Lazy[A]): Type[A] = lazyType.value
 
   implicit final class TypeMethods[A](private val tpe: Type[A]) {
 


### PR DESCRIPTION
Downstream macro libraries keep dozens-to-hundreds of eager `val X: Type[T] = Type.of[T]` in per-expansion helper objects — each is a pickled-quote unpickling per expansion on Scala 3, used or not (the Part F pattern: 16 such vals cost hearth itself 1.8%; **Kindlings has 372**). A naive `lazy val` is NOT a safe replacement: first touch inside an `Expr.splice` ties the Type to that splice's scope, and reuse elsewhere aborts under `-Xcheck-macros` (reproduced in Kindlings' CirceScala3Spec when we tried the naive sweep).

**`Type.Lazy(compute)`** evaluates its thunk with the **macro-entry context pinned** (new shared `CrossQuotes.withMacroEntryContext`, delegating to the existing Scala 3 `withMacroEntryCtx`; identity on Scala 2), so the result is scoped exactly like an eagerly-initialized `val` — valid throughout the expansion, inside any splice — while the cost is paid only on use. Memoized per expansion, keyed on entry-context identity so holders in global objects can't leak across expansions. A cake-level implicit conversion `Type.Lazy[A] => Type[A]` keeps use-sites unchanged:

```scala
val StringType: Type[String]      = Type.of[String]             // eager: costs every expansion
val StringType: Type.Lazy[String] = Type.Lazy(Type.of[String])  // deferred: costs only when used
```

Fixture test exercises the exact hazard: first touch inside a quote's splice, reuse outside it, on both platforms. Verified: 1184 + 1312 + sandwich green; MiMa green (3 nested-scope filters: two `private[hearth]` CrossQuotesModule methods + the `Lazy` module accessor).

Unlocks the 372-site sweep in Kindlings (adoption ready to go once a snapshot carries this).