### PR TITLE
Fix: sealed-hierarchy children come back in stable declaration order (Scala 3 flake)

### DIFF
--- a/hearth-tests/src/main/scala-2/hearth/typed/ClassesFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ClassesFixtures.scala
@@ -45,6 +45,9 @@ final private class ClassesFixtures(val c: blackbox.Context) extends MacroCommon
   def testDependentEnumDiagnosticImpl[A: c.WeakTypeTag]: c.Expr[String] =
     testDependentEnumDiagnostic[A]
 
+  def testEnumParseDiagnosticImpl[A: c.WeakTypeTag]: c.Expr[String] =
+    testEnumParseDiagnostic[A]
+
   def testCaseClassDefaultValuesImpl[A: c.WeakTypeTag]: c.Expr[String] =
     testCaseClassDefaultValues[A]
 
@@ -106,6 +109,9 @@ object ClassesFixtures {
 
   def testDependentEnumDiagnostic[A]: String =
     macro ClassesFixtures.testDependentEnumDiagnosticImpl[A]
+
+  def testEnumParseDiagnostic[A]: String =
+    macro ClassesFixtures.testEnumParseDiagnosticImpl[A]
 
   def testCaseClassDefaultValues[A]: String =
     macro ClassesFixtures.testCaseClassDefaultValuesImpl[A]

--- a/hearth-tests/src/test/scala/hearth/typed/ClassesSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ClassesSpec.scala
@@ -198,6 +198,23 @@ final class ClassesSpec extends MacroSuite {
       }
     }
 
+    group("directChildren ordering") {
+      import ClassesFixtures.testEnumParseDiagnostic
+
+      // Regression: a sealed hierarchy's children must come back in DECLARATION order, deterministically, on both
+      // platforms. On Scala 3 the earlier implementation sorted the synthetic module-CLASS symbols by source position,
+      // but those synthetic symbols frequently lack a position during macro expansion, which intermittently collapsed
+      // the whole list onto an alphabetical name fallback - declaration order on a "warm" build, alphabetical on a
+      // "cold"/from-TASTy one, for the SAME sources. `TrafficLight`'s children are ordered so that declaration order
+      // (`Red, Yellow, Green`) differs from alphabetical (`Green, Red, Yellow`); an accidental alphabetical sort would
+      // therefore fail this assertion. `TrafficLight` lives in the test sources (same compilation unit as this spec),
+      // mirroring the real-world hierarchy that first surfaced the flake.
+      test("sealed trait children preserve declaration order (not alphabetical)") {
+        testEnumParseDiagnostic[ClassesSpec.TrafficLight] <==>
+          "parsed with children: Red, Yellow, Green"
+      }
+    }
+
     test("CaseClass[A].{construct and parConstruct} should construct an instance of the case class") {
       import ClassesFixtures.testCaseClassConstructAndParConstruct
 
@@ -482,5 +499,20 @@ final class ClassesSpec extends MacroSuite {
       code(hearth.examples.enums.ExampleSealedTrait.ExampleSealedTraitObject) <==>
         "sequential: subtype name: hearth.examples.enums.ExampleSealedTrait.ExampleSealedTraitObject.type, expr: ExampleSealedTraitObject, parallel: subtype name: hearth.examples.enums.ExampleSealedTrait.ExampleSealedTraitObject.type, expr: ExampleSealedTraitObject"
     }
+  }
+}
+
+object ClassesSpec {
+
+  /** Witness for the `directChildren ordering` regression: the children are declared in an order (`Red, Yellow, Green`)
+    * that differs from their alphabetical order (`Green, Red, Yellow`), so the test can tell declaration order apart
+    * from an accidental alphabetical sort. Defined in the test sources (same compilation unit as the spec) so both
+    * Scala 2 and Scala 3 resolve it identically.
+    */
+  sealed trait TrafficLight
+  object TrafficLight {
+    case object Red extends TrafficLight
+    case object Yellow extends TrafficLight
+    case object Green extends TrafficLight
   }
 }

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -781,10 +781,22 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
           else if sym.flags.is(Flags.Module) then sym.typeRef.typeSymbol.moduleClass
           else sym
 
-        // calling .distinct here as `children` returns duplicates for multiply-inherited types
-        instanceTpe.typeSymbol.children
+        // Sort the ORIGINAL child symbols, THEN map them through `handleSymbols` - the previous code did the reverse
+        // (`.map(handleSymbols).sorted`), which is what made the order flaky.
+        //
+        // `symbolOrdering` orders by source position first, and falls back to the (deterministic) alphabetical name
+        // only when a position is absent - the intended behaviour, because incremental compilation drops positions and
+        // the name is then the one stable key available. The bug was purely about WHICH symbol we sorted: for a
+        // `case object`, `handleSymbols` returns the synthetic module CLASS, whose source position is frequently absent
+        // (and unreliably completed) during macro expansion, so `symbolOrdering` fell through to the name fallback and
+        // the result flipped between declaration order ("warm" build) and alphabetical order ("cold" build) for the
+        // SAME sources. The ORIGINAL child symbol (the user-written `case object`'s module val / the case class) carries
+        // a real source position for a same-compilation-unit hierarchy, so sorting it directly restores stable
+        // declaration order there while keeping the exact position-then-name semantics everywhere else. We deliberately
+        // do NOT rely on the `children` list order itself (it is not a documented declaration-order guarantee across
+        // Scala versions / incremental compilation), only on the per-symbol position/name keys.
+        instanceTpe.typeSymbol.children.sorted // by `symbolOrdering`: original child position, then alphabetical name when the position is absent
           .map(handleSymbols)
-          .sorted
           .map(subtypeSymbol => subtypeName(subtypeSymbol) -> subtypeTypeOf(instanceTpe, subtypeSymbol))
       }
       else if isUnionType(instanceTpe) then unionMemberDispatch(instanceTpe).flatMap { dispatch =>


### PR DESCRIPTION
## Problem

`UntypedType.directChildrenList` for a sealed hierarchy sorted its children with `.map(handleSymbols).sorted` — sorting **after** mapping each child through `handleSymbols`, which maps a `case object` to its synthetic **module CLASS**. Those synthetic symbols frequently lack a source position during macro expansion (and are completed unreliably), so `symbolOrdering` (position-first) fell through to its alphabetical name fallback.

The result flipped between **declaration order** (positions present, "warm" build) and **alphabetical order** (positions absent, "cold"/from-TASTy build) for the *same* sources — an intermittent, build-state-dependent flake. It surfaced downstream (Kindlings) as an enum-values list `List(Red, Green, Blue)` coming back alphabetical `List(Blue, Green, Red)` roughly 1 run in 4.

## Fix

Sort the **original child symbols** first, **then** map them through `handleSymbols`. The bug was purely about *which* symbol carried the sort key: the original child (the user-written `case object`'s module val / the case class) has a real source position for a same-compilation-unit hierarchy, so `symbolOrdering` resolves it to stable declaration order there — while keeping the **exact** position-then-name semantics everywhere else.

Crucially this **does not rely on the `children` list order** being declaration order (that is not a documented guarantee across Scala versions / incremental compilation) — only on the per-symbol position/name keys, exactly as before. It's the minimal correction to the existing ordering: `.map(handleSymbols).sorted` → `.sorted.map(handleSymbols)`.

Scala 2 is untouched (its `knownDirectSubclasses` is an unordered `Set`, but same-unit case-object positions reliably give declaration order there — same position-then-name design).

## Test

Cross-platform regression in `ClassesSpec`: `TrafficLight`'s children are declared `Red, Yellow, Green` — deliberately *different* from alphabetical `Green, Red, Yellow` — in the test sources (same compilation unit as the spec, mirroring the real hierarchy that surfaced the flake). `testEnumParseDiagnostic` (now wired on Scala 2 as well) asserts declaration order on both platforms. **Its passing is itself the proof that the original child position is reliably present** — an alphabetical fallback would fail the assertion.

## Verification

- `hearthTests3` (Scala 3, 1313) + `hearthTests` (Scala 2.13, 1185): **0 failures**. `ClassesSpec` is 28/28 with identical counts on both platforms (same-unit `TrafficLight` → `Red, Yellow, Green` on both).
- `mimaReportBinaryIssues` (hearth3): clean (method-body-only change).