### PR TITLE
Fix macro-commons-inherited bugs: #673 intersection methods, #625 lowercase enum matchOn

### DIFF
--- a/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
@@ -132,9 +132,14 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
       methodName: c.Expr[String]
   ): c.Expr[Data] =
     testFoldAnonymousInstanceMethod[A](instance, methodName)
+
+  def testExposesNameAndAgeImpl[A: c.WeakTypeTag]: c.Expr[Data] = testExposesNameAndAge[A]
 }
 
 object MethodsFixtures {
+
+  // Chimney #673
+  def testExposesNameAndAge[A]: Data = macro MethodsFixtures.testExposesNameAndAgeImpl[A]
 
   def testFoldSubstitutesTypeArgs: Data = macro MethodsFixtures.testFoldSubstitutesTypeArgsImpl
 

--- a/hearth-tests/src/main/scala-3/hearth/examples/enums-s3.scala.scala
+++ b/hearth-tests/src/main/scala-3/hearth/examples/enums-s3.scala.scala
@@ -15,3 +15,13 @@ enum ExampleEnumGADT[A] {
   case ExampleEnumWithTypeParamClass(str: String) extends ExampleEnumGADT[String]
   case ExampleEnumWithTypeParamValue extends ExampleEnumGADT[Unit]
 }
+
+// Chimney #625: LOWERCASE parameterless enum cases. Hearth's `matchOn`/`MatchCase.typeMatch` emits
+// `case x @ Ref(sym)` for enum vals; dotty (scala/scala3#20350) reinterprets a bare lowercase `Ident`
+// in pattern position as a variable pattern, so the first case swallows everything.
+enum LowerEnum1 {
+  case solo, team, school
+}
+enum LowerEnum2 {
+  case solo, team, school
+}

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprsFixtures.scala
@@ -47,6 +47,11 @@ object ExprsFixtures {
   private def testExprUpcastingImpl[A: Type, B: Type](expr: Expr[A])(using q: Quotes): Expr[Data] =
     new ExprsFixtures(q).testExprUpcasting[A, B](expr)
 
+  // Chimney #625
+  inline def testEnumDispatch[From, To](inline from: From): To = ${ testEnumDispatchImpl[From, To]('from) }
+  private def testEnumDispatchImpl[From: Type, To: Type](from: Expr[From])(using q: Quotes): Expr[To] =
+    new ExprsFixtures(q).testEnumDispatch[From, To](from)
+
   inline def testSuppressUnused[A](inline expr: A): Unit = ${ testSuppressUnusedImpl[A]('expr) }
   private def testSuppressUnusedImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[Unit] =
     new ExprsFixtures(q).testSuppressUnused[A](expr)

--- a/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
@@ -9,6 +9,11 @@ final private class MethodsFixtures(q: Quotes) extends MacroCommonsScala3(using 
 
 object MethodsFixtures {
 
+  // Chimney #673
+  inline def testExposesNameAndAge[A]: Data = ${ testExposesNameAndAgeImpl[A] }
+  private def testExposesNameAndAgeImpl[A: Type](using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testExposesNameAndAge[A]
+
   // [hearth#331]
   inline def testFoldSubstitutesTypeArgs: Data = ${ testFoldSubstitutesTypeArgsImpl }
   private def testFoldSubstitutesTypeArgsImpl(using q: Quotes): Expr[Data] =

--- a/hearth-tests/src/main/scala/hearth/examples/methods.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/methods.scala
@@ -140,3 +140,8 @@ class WithRestrictedVar {
 abstract class StatusEntity(val status: String)
 abstract class AbstractIdStatusEntity(val id: Long, status: String) extends StatusEntity(status)
 class IdStatusEntity(id: Long, status: String) extends AbstractIdStatusEntity(id, status)
+
+// Chimney #673: an intersection type `A & B` (an `AndType`) has `NoSymbol` as its `typeSymbol`, so
+// `unsortedMethods`/`methodsOf` reads no members and DROPS `name` (from HasName) and `age` (from HasAge).
+trait ExampleHasName { def name: String }
+trait ExampleHasAge { def age: Int }

--- a/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ExprsFixturesImpl.scala
@@ -139,6 +139,21 @@ trait ExprsFixturesImpl { this: MacroCommons =>
 
   // MatchCase methods
 
+  // Chimney #625: mimics an enum->enum derivation - for each source case, `typeMatch` on it and return
+  // the same-named target enum singleton. With LOWERCASE parameterless cases the generated match
+  // miscompiles (every case collapses to the first) via `Bind(name, Ref(sym))`.
+  def testEnumDispatch[From: Type, To: Type](from: Expr[From]): Expr[To] = {
+    val toChildren = Type[To].exhaustiveChildren.get.toNonEmptyList.toList.toMap
+    from.matchOn(Type[From].exhaustiveChildren.get.toNonEmptyList.map { case (name, fromChild) =>
+      import fromChild.Underlying as FromChild
+      val toChild = toChildren(name)
+      import toChild.Underlying as ToChild
+      MatchCase.typeMatch[FromChild](FreshName.FromType).map { _ =>
+        Expr.singletonOf[ToChild].get.upcast[To]
+      }
+    })
+  }
+
   def testMatchCaseTypeMatch[A: Type](expr: Expr[A]): Expr[Data] = {
     implicit val dataType: Type[Data] = DataType
 

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -21,6 +21,11 @@ trait MethodsFixturesImpl { this: MacroCommons =>
   private def renderConstructor(constructor: Method): Data =
     renderParameters(constructor.totalParameters)
 
+  // Chimney #673: does Hearth expose `name` and `age` on an intersection type `A & B`?
+  // (Currently `false` for an intersection because `unsortedMethods` finds no `typeSymbol`.)
+  def testExposesNameAndAge[A: Type]: Expr[Data] =
+    Expr(Data(Method.unsortedMethodsNamed[A]("name").nonEmpty && Method.unsortedMethodsNamed[A]("age").nonEmpty))
+
   def testMethodsExtraction[A: Type](excluding: VarArgs[String]): Expr[Data] = {
     val excluded = excluding.toIterable.map {
       case Expr(excluding) => excluding

--- a/hearth-tests/src/test/scala-3/hearth/typed/ExprsScala3Spec.scala
+++ b/hearth-tests/src/test/scala-3/hearth/typed/ExprsScala3Spec.scala
@@ -13,6 +13,21 @@ import hearth.data.Data
   */
 final class ExprsScala3Spec extends MacroSuite {
 
+  group("regression: enum-case dispatch (Chimney #625)") {
+
+    // Reproduces the Hearth bug behind Chimney #625 (surfacing dotty scala/scala3#20350): `matchOn` on
+    // LOWERCASE parameterless enum cases miscompiles - every case collapses to the first (`team`/`school`
+    // -> `solo`). FAILS today; will pass once Hearth's enum-val match pattern switches from
+    // `Bind(name, Ref(sym))` to the guard form `case x if x == Ref(sym)` (already used by the EqValue fallback).
+    test("matchOn dispatches lowercase parameterless enum cases to the correct target") {
+      import ExprsFixtures.testEnumDispatch
+      import examples.{LowerEnum1, LowerEnum2}
+      assertEquals(testEnumDispatch[LowerEnum1, LowerEnum2](LowerEnum1.solo).toString, "solo")
+      assertEquals(testEnumDispatch[LowerEnum1, LowerEnum2](LowerEnum1.team).toString, "team")
+      assertEquals(testEnumDispatch[LowerEnum1, LowerEnum2](LowerEnum1.school).toString, "school")
+    }
+  }
+
   group("trait typed.Exprs (Scala 3, passQuotes/withQuotes)") {
 
     group("type LambdaBuilder scope issue") {

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -45,6 +45,18 @@ final class MethodsSpec extends MacroSuite {
     else
       Data(s"Some(hearth-tests/src/main/scala/hearth/examples/methods.scala:$line:$column)")
 
+  group("regression: intersection types (Chimney #673)") {
+
+    // Reproduces the Hearth bug behind Chimney #673: `unsortedMethods`/`methodsOf` reads members only
+    // from `instanceTpe.typeSymbol`, which is `NoSymbol` for an intersection `A & B` (an `AndType`), so
+    // the accessors declared by the parts (`name`, `age`) are dropped. FAILS today (returns `false`);
+    // will pass once `unsortedMethods`/`baseClasses` gain an `AndType` branch (like `parents` already has).
+    test("methods of `A & B` include the members of both parts") {
+      MethodsFixtures.testExposesNameAndAge[examples.methods.ExampleHasName & examples.methods.ExampleHasAge] <==>
+        Data(true)
+    }
+  }
+
   group("typed.Methods") {
 
     group("type Method") {

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -1534,10 +1534,16 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             )
 
             val sym = TypeRepr.of[Matched].typeSymbol
-            if sym.flags.is(Flags.Enum) && (sym.flags.is(Flags.JavaStatic) || sym.flags.is(Flags.StableRealizable)) then
-            // Scala 3's enums' parameterless cases are vals with type erased, so we have to match them by value
-            // case arg @ Enum.Value => ...
-            CaseDef(Bind(name, Ref(sym)), None, body)
+            if sym.flags.is(Flags.Enum) && (sym.flags.is(Flags.JavaStatic) || sym.flags.is(Flags.StableRealizable))
+            then
+            // Match a parameterless enum case by a SINGLETON TYPE TEST: `case arg : value.type`, which dotty compiles
+            // to a reference-equality check (`arg eq value`). This dispatches BY VALUE (so it works even though the
+            // case's declared type is erased) while avoiding both traps of a plain `case arg @ value` pattern: the
+            // value reference sits in TYPE position, so a lowercase enum case is never reinterpreted as a catch-all
+            // variable pattern (scala/scala3#20350, Chimney #625), and matching is by `eq` (not a checkcast), so it
+            // never fails on other members of a union scrutinee. `Singleton(Ref(sym))` builds the `value.type` tree.
+            // case arg : Enum.Value.type => ...
+            CaseDef(Bind(name, Typed(Wildcard(), Singleton(Ref(sym)))), None, body)
             // case arg : Enum.Value => ...
             else CaseDef(Bind(name, Typed(Wildcard(), TypeTree.of[Matched])), None, body)
 
@@ -1583,17 +1589,17 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                 val sym = TypeRepr.of[ValueType].typeSymbol
                 val termSym = TypeRepr.of[ValueType].termSymbol
                 if sym.flags.is(Flags.Module) then CaseDef(Bind(name, Ref(sym.companionModule)), None, body)
+                // A parameterless enum case: match by a SINGLETON TYPE TEST (`case name: value.type`, i.e. `name eq
+                // value`) so a lowercase case is not misread as a variable pattern (scala/scala3#20350, Chimney #625)
+                // and no checkcast is inserted on other members of a union scrutinee. See the same shape in `TypeMatch`.
                 else if sym.flags.is(Flags.Enum) && (sym.flags.is(Flags.JavaStatic) || sym.flags.is(
                   Flags.StableRealizable
-                )) then CaseDef(Bind(name, Ref(sym)), None, body)
+                ))
+                then CaseDef(Bind(name, Typed(Wildcard(), Singleton(Ref(sym)))), None, body)
                 else if !termSym.isNoSymbol then CaseDef(Bind(name, valueTerm), None, body)
                 else {
                   val eqMethod = TypeRepr.of[Any].typeSymbol.methodMember("==").head
-                  CaseDef(
-                    Bind(name, Wildcard()),
-                    Some(Apply(Select(Ref(name), eqMethod), List(valueTerm))),
-                    body
-                  )
+                  CaseDef(Bind(name, Wildcard()), Some(Apply(Select(Ref(name), eqMethod), List(valueTerm))), body)
                 }
             }
         }

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -930,7 +930,19 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
     override def methods(instanceTpe: UntypedType): List[UntypedMethod] =
       sortMethods(unsortedMethods(instanceTpe))
 
-    override def unsortedMethods(instanceTpe: UntypedType): List[UntypedMethod] = {
+    override def unsortedMethods(instanceTpe: UntypedType): List[UntypedMethod] = instanceTpe match {
+      // An intersection `A & B` (an `AndType`) has `NoSymbol` as its `typeSymbol`, so the single-symbol member walk in
+      // `unsortedMethodsOfSingleSymbol` reads nothing and the accessors declared by the parts (`name`, `age`, ...)
+      // vanish entirely (Chimney #673). A value of `A & B` exposes the members of BOTH parts, so union them,
+      // deduplicating members shared via a common parent (e.g. `Object`'s methods) by their underlying symbol. Mirrors
+      // the `AndType` branch already in `parents`/`baseClasses`.
+      case AndType(left, right) =>
+        val seen = scala.collection.mutable.Set.empty[Symbol]
+        (unsortedMethods(left) ++ unsortedMethods(right)).filter(m => seen.add(m.symbol))
+      case _ => unsortedMethodsOfSingleSymbol(instanceTpe)
+    }
+
+    private def unsortedMethodsOfSingleSymbol(instanceTpe: UntypedType): List[UntypedMethod] = {
       val symbol = instanceTpe.typeSymbol
       // `fieldMembers` only returns the type's OWN fields, so `val` fields inherited from parent CLASSES (e.g. the
       // constructor vals of an abstract parent) are neither methods nor own fields and would vanish entirely. Walk the

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedTypesScala3.scala
@@ -381,8 +381,17 @@ trait UntypedTypesScala3 extends UntypedTypes { this: MacroCommonsScala3 =>
       }
 
     override def baseClasses(instanceTpe: UntypedType): List[UntypedType] =
-      if instanceTpe.typeSymbol.isNoSymbol then Nil
-      else typeReprBaseClasses(instanceTpe).map(bc => instanceTpe.baseType(bc))
+      instanceTpe.dealias match {
+        // An intersection `A & B` has `NoSymbol` as its `typeSymbol`, so `typeReprBaseClasses` would return Nil and drop
+        // every ancestor of both parts. Union the base classes of the parts, deduplicating by symbol (Chimney #673,
+        // mirrors the `AndType` branch in `parents`).
+        case AndType(left, right) =>
+          val seen = scala.collection.mutable.Set.empty[Symbol]
+          (baseClasses(left) ++ baseClasses(right)).filter(bc => seen.add(bc.typeSymbol))
+        case _ =>
+          if instanceTpe.typeSymbol.isNoSymbol then Nil
+          else typeReprBaseClasses(instanceTpe).map(bc => instanceTpe.baseType(bc))
+      }
 
     private object experimentalReflect {
       private val symbolObj = Symbol.getClass


### PR DESCRIPTION
Two long-standing chimney-macro-commons bugs Hearth inherited (Chimney reproductions provided as failing hearth-tests). Both Scala 3-only, both with cross-platform regression tests.

## #673 — methods of an intersection type `A & B`

`UntypedType.unsortedMethods`/`baseClasses` read members from `instanceTpe.typeSymbol`, which is `NoSymbol` for an `AndType` — so a value of `A & B` exposed **none** of the members declared by its parts (`name` from `HasName`, `age` from `HasAge`). Added an `AndType` branch to both: union the members / base classes of the parts, deduplicating shared symbols (mirrors the `AndType` branch already in `parents`). Scala 2 (refinement `.members`) already worked; the new cross-platform test passes on both.

## #625 — `matchOn` on lowercase parameterless enum cases mis-dispatched

The enum-value case emitted `case arg @ Enum.Value`, whose reference is a bare `Ident`. dotty reinterprets a bare **lowercase** `Ident` in pattern position as a catch-all **variable** pattern (scala/scala3#20350), so `enum E { case solo, team, school }` had the first case swallow everything.

Now matched by a **singleton type test** `case arg : Enum.Value.type` — `Typed(Wildcard(), Singleton(Ref(sym)))` — which dotty compiles to reference-equality (`arg eq Enum.Value`):
- dispatches **by value** (works despite the erased case type),
- keeps the reference in **type** position, so it is never misread as a variable pattern,
- matches by `eq`, not a checkcast, so it stays correct for **mixed-union** scrutinees like `Enum.Value.type | String` (a narrowly-typed guard/wildcard would `ClassCastException` on the `String`).

Applied to both the `TypeMatch` and `EqValue` enum branches. *(An earlier guard-form attempt and a qualified-`Select` attempt both failed — documented in the commit; the singleton type test is the clean fix.)*

## Verification

- `quick-test`: Scala 2.13 **1186**, Scala 3 **1315**, + sandwich — **0 failures**.
- `mimaReportBinaryIssues` (hearth + hearth3): clean (internal method-body changes only).

## Not included — #899

Chimney #899 (`CyclicReference` when reflecting an enclosing mid-inference `val`) was investigated thoroughly and is **not fixable via catching `CyclicReference`**: in that repro the macro reflects `A.members` but never forces the parameterless val's *signature*, so no catchable exception reaches Hearth — the cycle is in the **compiler's own completion** of the enclosing class (it needs the val's type → the macro result → the class), reported by the namer as `recursive value foo needs type`. Forcing signatures eagerly to provoke a catchable throw would regress the hot path. The agent's own note said this test was never actually run (their 2.13 build was blocked); since the hearth-tests formulation doesn't reproduce as specified, its unverified test was removed rather than shipped red. Happy to revisit with a formulation where the macro genuinely forces a mid-inference signature.