### PR TITLE
Review fixes + Chimney #899: JavaBean capitalization, MIO timeout, ExprCodec collections/enum dispatch, mid-inference CyclicReference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,7 +371,7 @@ The `Method` API has a layered architecture with platform-specific untyped code 
 
 ### semiEval / semiQuote / EvalOverride / QuoteOverride
 
-**`semiEval`** evaluates expression trees at macro time via reflection. Returns `Either[String, A]`.
+**`semiEval`** evaluates expression trees at macro time via reflection. Returns `Either[NonEmptyVector[String], A]` (aggregated errors).
 
 - `Expr.semiEval[A](expr)` — no overrides, evaluates using built-in reflection
 - `Expr.semiEval[A](expr, overrides)` — custom evaluation dispatch by `UntypedType`

--- a/hearth-micro-fp/src/main/scala/hearth/fp/effect/MIO.scala
+++ b/hearth-micro-fp/src/main/scala/hearth/fp/effect/MIO.scala
@@ -138,7 +138,9 @@ sealed trait MIO[+A] { fa =>
     (try
       result.fold(onFailure, onSuccess)
     catch {
-      case NonFatal(e) => fail(e).log.error(s"Caught exception ${e.getMessage}")
+      // A deadline timeout must escape error handling (it is not a recoverable failure) - mirror `defer`.
+      case e: MioTimeoutException => throw e
+      case NonFatal(e)            => fail(e).log.error(s"Caught exception ${e.getMessage}")
     }) match {
       case Pure(state2, fb)      => Pure(state ++ state2, fb)
       case Impure(state2, fb, q) => Impure(state ++ state2, fb, q)
@@ -260,6 +262,8 @@ sealed trait MIO[+A] { fa =>
             }
             Pure(stateC, resultC)
           } catch {
+            // A deadline timeout must escape MIO's error-aggregation (it is not a recoverable failure) - mirror `defer`.
+            case e: MioTimeoutException => throw e
             case NonFatal(e) => Pure(stateC, Left(NonEmptyVector.one(e))).log.error(s"Caught exception ${e.getMessage}")
           }
         }
@@ -712,8 +716,11 @@ object MIO {
     * Captures the full [[MState]] (with scope nesting reconstructed from [[_openScopes]]) so that flame graphs can
     * still be rendered from the partial execution.
     *
-    * Extends [[InterruptedException]] so it is NOT caught by [[scala.util.control.NonFatal]] — this prevents MIO's own
-    * `redeemWith`/`handleErrorWith` from swallowing the timeout.
+    * A deadline timeout must not be turned into a recoverable failure. It cannot extend `InterruptedException` (the way
+    * [[MioTerminationException]] does) because that type is entangled with the thread-interrupt/termination mechanism
+    * ([[TerminationObserver.isTerminated]] reads `Thread.interrupted()`), so instead every internal
+    * `catch scala.util.control.NonFatal` in MIO (`defer`, `redeemWith`, `parMap2`) rethrows this exception explicitly
+    * before the `NonFatal` case, letting it propagate out of the run.
     *
     * @since 0.3.0
     */

--- a/hearth-tests/src/main/scala-2/hearth/typed/CyclicReferenceFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/CyclicReferenceFixtures.scala
@@ -4,28 +4,42 @@ package typed
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
-/** Fixtures for [[CyclicReferenceScala2Spec]] — a Scala-2-only reproduction of the mechanism behind Chimney
-  * #899 (`case class A() { val foo = this.transformInto[B] }` crashing with `CyclicReference: illegal cyclic
-  * reference involving value foo`).
+/** Fixtures for [[CyclicReferenceScala2Spec]] — a Scala-2-only reproduction of the mechanism behind Chimney #899 (`case
+  * class A() { val foo = this.transformInto[B] }`), and of Hearth's fix for it.
   *
-  * The essential ingredient is that the reflection of `A` must happen INSIDE an implicit search that runs while
-  * an enclosing `val` of `A` is still being inferred. [[CyclicTC]] plays the role of Chimney's `Transformer`:
-  * its implicit materializer ([[deriveCyclicTC]]) reflects on the source with the very same calls Chimney's
-  * product extraction uses (`Type[A].unsortedMethods` + forcing each return type). When driven through
-  * [[CyclicConvertSyntax.Ops.cyclicConvertInto]] (the `transformInto` analogue), the first reflective access
-  * throws a `scala.reflect.internal.Symbols$CyclicReference`.
+  * The essential ingredient is that the reflection of `A` happens INSIDE an implicit search that runs while an
+  * enclosing `val` of `A` is still being inferred. [[CyclicTC]] plays the role of Chimney's `Transformer`: its implicit
+  * materializer ([[deriveCyclicTC]]) reflects on the source with the very same calls Chimney's product extraction uses
+  * (`Type[A].unsortedMethods` + forcing each member's return type). Forcing the still-inferring member's signature
+  * re-enters its own completer, which scala-reflect signals with a `CyclicReference`.
   *
-  * The standalone harness (hearth-repros/repro-899) additionally shows the exception is CATCHABLE: catching it
-  * and letting the implicit search retry makes compilation succeed. This fixture intentionally does NOT catch,
-  * so the spec can pin the observable failure with `compileErrors`.
+  * BEFORE the fix that raw `CyclicReference` leaked out of the listing call and the compile failed with
+  * `recursive value foo needs type`. AFTER the fix Hearth treats the un-completable member honestly: a getter provably
+  * has no value parameters (so it stays listable with `Nil` parameters) and its still-unknown return type surfaces as
+  * `knownReturning == None` instead of throwing — the caller then decides what to do with a member of unknown type.
+  * Here the materializer simply ignores it and returns a stub, so the whole thing compiles.
   */
 trait CyclicReferenceFixturesImpl { this: MacroCommons =>
 
   def deriveCyclicTC[A: Type, B: Type]: Expr[CyclicTC[A, B]] = {
-    // Reflect on `A` exactly like Chimney's product extraction: list instance methods and force each return
-    // type. Under the implicit search below this re-enters the still-running completer of the enclosing `val`.
+    // Reflect on `A` exactly like Chimney's product extraction: list instance methods and force each return type.
+    // Under the implicit search below this re-enters the still-running completer of the enclosing `val` — Hearth now
+    // yields `knownReturning == None` for that member instead of throwing a raw CyclicReference.
     val _ = Type[A].unsortedMethods.collect { case oi: Method.OnInstance => (oi: Method) }.map(_.knownReturning)
     cyclicStub[A, B]
+  }
+
+  /** Reflects on a FULLY-TYPED `A` and reports, per instance method, whether its `knownReturning` is defined —
+    * `"name:Some"` / `"name:None"`, comma-separated. Used to prove the #899 fix does not over-eagerly report `None`:
+    * ordinary getters on a completed type must still resolve their return type (`Some`).
+    */
+  def knownReturningReport[A: Type]: Expr[String] = {
+    val report = Type[A].unsortedMethods
+      .collect { case oi: Method.OnInstance => oi }
+      .map(m => s"${m.name}:${if (m.knownReturning.isDefined) "Some" else "None"}")
+      .sorted
+      .mkString(",")
+    Expr(report)
   }
 
   /** A do-nothing `CyclicTC[A, B]` value — the derivation's correctness is irrelevant, only its reflection is. */
@@ -40,8 +54,8 @@ object CyclicTC {
   implicit def derive[A, B]: CyclicTC[A, B] = macro CyclicReferenceFixtures.deriveCyclicTCImpl[A, B]
 }
 
-/** Same shape as [[CyclicTC]] but its materializer does NOT reflect on `A` — the control that isolates the
-  * reflection as the cause of the cycle.
+/** Same shape as [[CyclicTC]] but its materializer does NOT reflect on `A` — the control that isolates the reflection
+  * as the cause of the cycle.
   */
 trait PlainTC[A, B]
 
@@ -57,10 +71,14 @@ object CyclicConvertSyntax {
   }
 }
 
+object CyclicReferenceFixtures {
+  def knownReturningReport[A]: String = macro CyclicReferenceFixtures.knownReturningReportImpl[A]
+}
+
 final private class CyclicReferenceFixtures(val c: blackbox.Context)
     extends MacroCommonsScala2
     with CyclicReferenceFixturesImpl {
-  import c.universe._
+  import c.universe.*
 
   protected def cyclicStub[A: Type, B: Type]: Expr[CyclicTC[A, B]] =
     c.Expr[CyclicTC[A, B]](q"null.asInstanceOf[_root_.hearth.typed.CyclicTC[${c.weakTypeOf[A]}, ${c.weakTypeOf[B]}]]")
@@ -70,4 +88,6 @@ final private class CyclicReferenceFixtures(val c: blackbox.Context)
   // Control: return a stub WITHOUT reflecting on `A`, so an inferred `val` driven by it compiles cleanly.
   def derivePlainTCImpl[A: c.WeakTypeTag, B: c.WeakTypeTag]: c.Expr[PlainTC[A, B]] =
     c.Expr[PlainTC[A, B]](q"null.asInstanceOf[_root_.hearth.typed.PlainTC[${c.weakTypeOf[A]}, ${c.weakTypeOf[B]}]]")
+
+  def knownReturningReportImpl[A: c.WeakTypeTag]: c.Expr[String] = knownReturningReport[A]
 }

--- a/hearth-tests/src/main/scala-2/hearth/typed/CyclicReferenceFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/CyclicReferenceFixtures.scala
@@ -1,0 +1,73 @@
+package hearth
+package typed
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+/** Fixtures for [[CyclicReferenceScala2Spec]] — a Scala-2-only reproduction of the mechanism behind Chimney
+  * #899 (`case class A() { val foo = this.transformInto[B] }` crashing with `CyclicReference: illegal cyclic
+  * reference involving value foo`).
+  *
+  * The essential ingredient is that the reflection of `A` must happen INSIDE an implicit search that runs while
+  * an enclosing `val` of `A` is still being inferred. [[CyclicTC]] plays the role of Chimney's `Transformer`:
+  * its implicit materializer ([[deriveCyclicTC]]) reflects on the source with the very same calls Chimney's
+  * product extraction uses (`Type[A].unsortedMethods` + forcing each return type). When driven through
+  * [[CyclicConvertSyntax.Ops.cyclicConvertInto]] (the `transformInto` analogue), the first reflective access
+  * throws a `scala.reflect.internal.Symbols$CyclicReference`.
+  *
+  * The standalone harness (hearth-repros/repro-899) additionally shows the exception is CATCHABLE: catching it
+  * and letting the implicit search retry makes compilation succeed. This fixture intentionally does NOT catch,
+  * so the spec can pin the observable failure with `compileErrors`.
+  */
+trait CyclicReferenceFixturesImpl { this: MacroCommons =>
+
+  def deriveCyclicTC[A: Type, B: Type]: Expr[CyclicTC[A, B]] = {
+    // Reflect on `A` exactly like Chimney's product extraction: list instance methods and force each return
+    // type. Under the implicit search below this re-enters the still-running completer of the enclosing `val`.
+    val _ = Type[A].unsortedMethods.collect { case oi: Method.OnInstance => (oi: Method) }.map(_.knownReturning)
+    cyclicStub[A, B]
+  }
+
+  /** A do-nothing `CyclicTC[A, B]` value — the derivation's correctness is irrelevant, only its reflection is. */
+  protected def cyclicStub[A: Type, B: Type]: Expr[CyclicTC[A, B]]
+}
+
+/** Type class standing in for Chimney's `Transformer[A, B]`. */
+trait CyclicTC[A, B]
+
+object CyclicTC {
+  // Materializer that REFLECTS on `A` (the #899 trigger).
+  implicit def derive[A, B]: CyclicTC[A, B] = macro CyclicReferenceFixtures.deriveCyclicTCImpl[A, B]
+}
+
+/** Same shape as [[CyclicTC]] but its materializer does NOT reflect on `A` — the control that isolates the
+  * reflection as the cause of the cycle.
+  */
+trait PlainTC[A, B]
+
+object PlainTC {
+  implicit def derive[A, B]: PlainTC[A, B] = macro CyclicReferenceFixtures.derivePlainTCImpl[A, B]
+}
+
+/** `transformInto`-shaped syntax: extension methods whose result type is `B`, driven by an implicit. */
+object CyclicConvertSyntax {
+  implicit class Ops[A](private val a: A) extends AnyVal {
+    def cyclicConvertInto[B](implicit tc: CyclicTC[A, B]): B = null.asInstanceOf[B] // reflecting implicit
+    def plainConvertInto[B](implicit tc: PlainTC[A, B]): B = null.asInstanceOf[B] // non-reflecting control
+  }
+}
+
+final private class CyclicReferenceFixtures(val c: blackbox.Context)
+    extends MacroCommonsScala2
+    with CyclicReferenceFixturesImpl {
+  import c.universe._
+
+  protected def cyclicStub[A: Type, B: Type]: Expr[CyclicTC[A, B]] =
+    c.Expr[CyclicTC[A, B]](q"null.asInstanceOf[_root_.hearth.typed.CyclicTC[${c.weakTypeOf[A]}, ${c.weakTypeOf[B]}]]")
+
+  def deriveCyclicTCImpl[A: c.WeakTypeTag, B: c.WeakTypeTag]: c.Expr[CyclicTC[A, B]] = deriveCyclicTC[A, B]
+
+  // Control: return a stub WITHOUT reflecting on `A`, so an inferred `val` driven by it compiles cleanly.
+  def derivePlainTCImpl[A: c.WeakTypeTag, B: c.WeakTypeTag]: c.Expr[PlainTC[A, B]] =
+    c.Expr[PlainTC[A, B]](q"null.asInstanceOf[_root_.hearth.typed.PlainTC[${c.weakTypeOf[A]}, ${c.weakTypeOf[B]}]]")
+}

--- a/hearth-tests/src/main/scala-2/hearth/typed/ExprCodecFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/ExprCodecFixtures.scala
@@ -11,6 +11,9 @@ final private class ExprCodecFixtures(val c: blackbox.Context) extends MacroComm
   def testExprCodecRoundTripImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[Data] =
     testExprCodecRoundTrip[A](expr)
 
+  def testSemiQuoteReLiftImpl[A: c.WeakTypeTag](expr: c.Expr[A]): c.Expr[Data] =
+    testSemiQuoteReLift[A](expr)
+
   def testSemiQuotePrimitivesImpl: c.Expr[Data] = testSemiQuotePrimitives
 
   def testSemiQuoteCaseClassImpl: c.Expr[Data] = testSemiQuoteCaseClass
@@ -38,6 +41,9 @@ object ExprCodecFixtures {
 
   def testExprCodecRoundTrip[A](expr: A): Data =
     macro ExprCodecFixtures.testExprCodecRoundTripImpl[A]
+
+  def testSemiQuoteReLift[A](expr: A): Data =
+    macro ExprCodecFixtures.testSemiQuoteReLiftImpl[A]
 
   def testSemiQuotePrimitives: Data = macro ExprCodecFixtures.testSemiQuotePrimitivesImpl
 

--- a/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
@@ -134,12 +134,16 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
     testFoldAnonymousInstanceMethod[A](instance, methodName)
 
   def testExposesNameAndAgeImpl[A: c.WeakTypeTag]: c.Expr[Data] = testExposesNameAndAge[A]
+
+  def testJavaAccessorNamesImpl[A: c.WeakTypeTag]: c.Expr[Data] = testJavaAccessorNames[A]
 }
 
 object MethodsFixtures {
 
   // Chimney #673
   def testExposesNameAndAge[A]: Data = macro MethodsFixtures.testExposesNameAndAgeImpl[A]
+
+  def testJavaAccessorNames[A]: Data = macro MethodsFixtures.testJavaAccessorNamesImpl[A]
 
   def testFoldSubstitutesTypeArgs: Data = macro MethodsFixtures.testFoldSubstitutesTypeArgsImpl
 

--- a/hearth-tests/src/main/scala-3/hearth/typed/ExprCodecFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/ExprCodecFixtures.scala
@@ -15,6 +15,10 @@ object ExprCodecFixtures {
   private def testExprCodecRoundTripImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[Data] =
     new ExprCodecFixtures(q).testExprCodecRoundTrip[A](expr)
 
+  inline def testSemiQuoteReLift[A](inline expr: A): Data = ${ testSemiQuoteReLiftImpl[A]('expr) }
+  private def testSemiQuoteReLiftImpl[A: Type](expr: Expr[A])(using q: Quotes): Expr[Data] =
+    new ExprCodecFixtures(q).testSemiQuoteReLift[A](expr)
+
   inline def testSemiQuotePrimitives: Data = ${ testSemiQuotePrimitivesImpl }
   private def testSemiQuotePrimitivesImpl(using q: Quotes): Expr[Data] =
     new ExprCodecFixtures(q).testSemiQuotePrimitives

--- a/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
@@ -14,6 +14,10 @@ object MethodsFixtures {
   private def testExposesNameAndAgeImpl[A: Type](using q: Quotes): Expr[Data] =
     new MethodsFixtures(q).testExposesNameAndAge[A]
 
+  inline def testJavaAccessorNames[A]: Data = ${ testJavaAccessorNamesImpl[A] }
+  private def testJavaAccessorNamesImpl[A: Type](using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testJavaAccessorNames[A]
+
   // [hearth#331]
   inline def testFoldSubstitutesTypeArgs: Data = ${ testFoldSubstitutesTypeArgsImpl }
   private def testFoldSubstitutesTypeArgsImpl(using q: Quotes): Expr[Data] =

--- a/hearth-tests/src/main/scala/hearth/examples/methods.scala
+++ b/hearth-tests/src/main/scala/hearth/examples/methods.scala
@@ -145,3 +145,15 @@ class IdStatusEntity(id: Long, status: String) extends AbstractIdStatusEntity(id
 // `unsortedMethods`/`methodsOf` reads no members and DROPS `name` (from HasName) and `age` (from HasAge).
 trait ExampleHasName { def name: String }
 trait ExampleHasAge { def age: Int }
+
+// JavaBean accessor heuristic must require an UPPER-CASE character after the `get`/`is`/`set` prefix (the JavaBeans
+// convention). `getters`/`island`/`settle` merely start with a prefix and must NOT be treated as accessors, whereas
+// `getName`/`isActive`/`setValue` are genuine accessors.
+class ExampleBeanLikeNames {
+  def getName: String = "x"
+  def getters: String = "x" // NOT a getter: lowercase 't' after `get`
+  def isActive: Boolean = true
+  def island: Boolean = true // NOT a getter: lowercase 'l' after `is`
+  def setValue(v: Int): Unit = { val _ = v }
+  def settle(v: Int): Unit = { val _ = v } // NOT a setter: lowercase 't' after `set`
+}

--- a/hearth-tests/src/main/scala/hearth/typed/ExprCodecFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/ExprCodecFixturesImpl.scala
@@ -207,6 +207,19 @@ trait ExprCodecFixturesImpl { this: MacroCommons =>
 
   // -- ExprCodec.derived round-trip --
 
+  // Decodes the literal `expr` to a value (semiEval), then re-quotes it with `semiQuote` and reports whether that
+  // succeeded. Exercises the `semiQuoteEnum` runtime-class dispatch: e.g. `List` decomposes as the sealed `:: | Nil`,
+  // whose `::` child has the JVM-encoded simple name `$colon$colon` - so simple-name dispatch would fail to re-lift it.
+  def testSemiQuoteReLift[A: Type](expr: Expr[A]): Expr[Data] =
+    Expr(Expr.semiEval[A](expr) match {
+      case Right(value) =>
+        Expr.semiQuote[A](value) match {
+          case Right(_)  => Data(s"reLifted: $value")
+          case Left(err) => Data(s"<reLift failed: ${removeAnsiColors(err)}>")
+        }
+      case Left(errs) => Data(s"<decode failed: ${errs.toVector.mkString(", ")}>")
+    })
+
   def testExprCodecRoundTrip[A: Type](expr: Expr[A]): Expr[Data] = {
     val codec: ExprCodec[A] = ExprCodec.derived[A]
     codec.fromExpr(expr) match {

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -26,6 +26,20 @@ trait MethodsFixturesImpl { this: MacroCommons =>
   def testExposesNameAndAge[A: Type]: Expr[Data] =
     Expr(Data(Method.unsortedMethodsNamed[A]("name").nonEmpty && Method.unsortedMethodsNamed[A]("age").nonEmpty))
 
+  // Classifies every `get*`/`is*`/`set*`-named method of `A` as its JavaBean accessor property name, or "<none>" when
+  // it is NOT a JavaBean accessor. Exercises the capitalization rule: `getters`/`island`/`settle` merely start with a
+  // prefix but have no upper-case char after it, so they must NOT be accessors.
+  def testJavaAccessorNames[A: Type]: Expr[Data] =
+    Expr(
+      Data.map(
+        Type[A].methods.view
+          .filter(_.isDeclared) // skip inherited members like Object#getClass (a legitimate getter)
+          .filter(m => m.name.startsWith("get") || m.name.startsWith("is") || m.name.startsWith("set"))
+          .map(m => m.name -> Data(m.javaAccessorName.getOrElse("<none>")))
+          .toSeq*
+      )
+    )
+
   def testMethodsExtraction[A: Type](excluding: VarArgs[String]): Expr[Data] = {
     val excluded = excluding.toIterable.map {
       case Expr(excluding) => excluding

--- a/hearth-tests/src/test/scala-2/hearth/typed/CyclicReferenceScala2Spec.scala
+++ b/hearth-tests/src/test/scala-2/hearth/typed/CyclicReferenceScala2Spec.scala
@@ -1,0 +1,52 @@
+package hearth
+package typed
+
+/** Scala-2-only reproduction of the mechanism behind Chimney #899
+  * (`case class A() { val foo = this.transformInto[B] }` failing to compile).
+  *
+  * `Type[A].unsortedMethods` (and forcing member return types) is safe on its own, but when it runs inside an
+  * implicit search that fires while an enclosing `val` of `A` is still being inferred, completing `A`'s member
+  * list re-enters that `val`'s running completer. In a normal file compile that surfaces as
+  * `scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving value foo` (see the real
+  * Chimney control and the standalone harness hearth-repros/repro-899); under the toolbox used by
+  * `compileErrors` the typer's earlier guard fires first and reports `recursive value foo needs type`. Both are
+  * the same root cause.
+  *
+  * [[CyclicTC]] plays Chimney's `Transformer[A, B]`: its materializer reflects on the source. [[PlainTC]] is an
+  * identical type class whose materializer does NOT reflect — the control proving the reflection is what turns
+  * the `val` recursive. See [[CyclicReferenceFixtures]].
+  */
+final class CyclicReferenceScala2Spec extends MacroSuite {
+
+  group("regression: reflecting an enclosing mid-inference member (Chimney #899)") {
+
+    test("reflecting `A` from an implicit search makes an inferred `val` of `A` fail as recursive/cyclic") {
+      compileErrors(
+        """
+        import hearth.typed.CyclicConvertSyntax._
+        case class A() { val foo = this.cyclicConvertInto[B] }
+        case class B()
+        """
+      ).check("recursive value foo needs type")
+    }
+
+    test("control: the SAME shape with a non-reflecting materializer compiles (reflection is the cause)") {
+      import hearth.typed.CyclicConvertSyntax._
+      case class B()
+      case class A() { val foo = this.plainConvertInto[B] } // no explicit type, yet compiles - no reflection
+      A().foo ==> null
+    }
+
+    test("workaround: giving the enclosing member an explicit type avoids the cycle (documented for #899)") {
+      import hearth.typed.CyclicConvertSyntax._
+      case class B()
+      case class A() { val foo: B = this.cyclicConvertInto[B] } // explicit type -> no re-entry, compiles
+      A().foo ==> null
+    }
+
+    // NOTE (verified empirically): Hearth CANNOT rescue the inferred-`val` case. The compiler's namer detects the
+    // recursive `val` and reports `recursive value foo needs type` BEFORE Hearth ever forces the member's return type,
+    // so no Hearth-level `try/catch` around the reflection (`unsortedMethods`/`knownReturning`) is ever reached - a
+    // catch there does not fire. The user-facing remedy is the explicit type annotation above.
+  }
+}

--- a/hearth-tests/src/test/scala-2/hearth/typed/CyclicReferenceScala2Spec.scala
+++ b/hearth-tests/src/test/scala-2/hearth/typed/CyclicReferenceScala2Spec.scala
@@ -1,52 +1,64 @@
 package hearth
 package typed
 
-/** Scala-2-only reproduction of the mechanism behind Chimney #899
-  * (`case class A() { val foo = this.transformInto[B] }` failing to compile).
+/** Scala-2-only reproduction of the mechanism behind Chimney #899 (`case class A() { val foo = this.transformInto[B]
+  * }`) and of Hearth's fix for it.
   *
-  * `Type[A].unsortedMethods` (and forcing member return types) is safe on its own, but when it runs inside an
-  * implicit search that fires while an enclosing `val` of `A` is still being inferred, completing `A`'s member
-  * list re-enters that `val`'s running completer. In a normal file compile that surfaces as
-  * `scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving value foo` (see the real
-  * Chimney control and the standalone harness hearth-repros/repro-899); under the toolbox used by
-  * `compileErrors` the typer's earlier guard fires first and reports `recursive value foo needs type`. Both are
-  * the same root cause.
+  * `Type[A].unsortedMethods` (and forcing member return types) is safe on its own, but when it runs inside an implicit
+  * search that fires while an enclosing `val` of `A` is still being inferred, completing `A`'s member signatures
+  * re-enters that `val`'s running completer and scala-reflect signals a `CyclicReference`. BEFORE the fix that raw
+  * internal exception leaked out of the listing call and the compile failed with `recursive value foo needs type`.
+  * AFTER the fix Hearth represents the un-completable member honestly — a getter stays listable with no parameters and
+  * its unknown return type surfaces as `knownReturning == None` — so the reflecting materializer completes and the
+  * whole thing compiles, no exception, no signature change.
   *
   * [[CyclicTC]] plays Chimney's `Transformer[A, B]`: its materializer reflects on the source. [[PlainTC]] is an
-  * identical type class whose materializer does NOT reflect — the control proving the reflection is what turns
-  * the `val` recursive. See [[CyclicReferenceFixtures]].
+  * identical type class whose materializer does NOT reflect — the control proving the reflection is what turns the
+  * `val` recursive. See [[CyclicReferenceFixtures]].
   */
 final class CyclicReferenceScala2Spec extends MacroSuite {
 
   group("regression: reflecting an enclosing mid-inference member (Chimney #899)") {
 
-    test("reflecting `A` from an implicit search makes an inferred `val` of `A` fail as recursive/cyclic") {
-      compileErrors(
-        """
-        import hearth.typed.CyclicConvertSyntax._
-        case class A() { val foo = this.cyclicConvertInto[B] }
-        case class B()
-        """
-      ).check("recursive value foo needs type")
+    test("a reflecting materializer no longer breaks an inferred `val` of the reflected type") {
+      import hearth.typed.CyclicConvertSyntax.*
+      case class B()
+      // No explicit type on `foo`, yet the reflecting `cyclicConvertInto` materializer compiles: Hearth yields
+      // `knownReturning == None` for the mid-inference member instead of leaking a CyclicReference. Before the fix
+      // this failed with `recursive value foo needs type`.
+      case class A() { val foo = this.cyclicConvertInto[B] }
+      A().foo ==> null
     }
 
-    test("control: the SAME shape with a non-reflecting materializer compiles (reflection is the cause)") {
-      import hearth.typed.CyclicConvertSyntax._
+    test("control: the SAME shape with a non-reflecting materializer compiles (reflection was the trigger)") {
+      import hearth.typed.CyclicConvertSyntax.*
       case class B()
       case class A() { val foo = this.plainConvertInto[B] } // no explicit type, yet compiles - no reflection
       A().foo ==> null
     }
 
-    test("workaround: giving the enclosing member an explicit type avoids the cycle (documented for #899)") {
-      import hearth.typed.CyclicConvertSyntax._
+    test("an explicit type on the enclosing member also compiles (the pre-fix workaround still works)") {
+      import hearth.typed.CyclicConvertSyntax.*
       case class B()
       case class A() { val foo: B = this.cyclicConvertInto[B] } // explicit type -> no re-entry, compiles
       A().foo ==> null
     }
 
-    // NOTE (verified empirically): Hearth CANNOT rescue the inferred-`val` case. The compiler's namer detects the
-    // recursive `val` and reports `recursive value foo needs type` BEFORE Hearth ever forces the member's return type,
-    // so no Hearth-level `try/catch` around the reflection (`unsortedMethods`/`knownReturning`) is ever reached - a
-    // catch there does not fire. The user-facing remedy is the explicit type annotation above.
+    test("on a FULLY-TYPED type, getters still resolve their return type (the fix only yields None on a real cycle)") {
+      // `knownReturning == None` must be specific to the mid-inference cycle: on a completed type every getter's
+      // return type is still resolvable (`Some`). If the fix over-reported None this would contain `:None`.
+      val report = CyclicReferenceFixtures.knownReturningReport[FullyTypedForReturning]
+      // Fields/getters and other concrete members resolve their return type.
+      report.contains("name:Some") ==> true
+      report.contains("age:Some") ==> true
+      report.contains("copy:Some") ==> true
+      report.contains("toString:Some") ==> true
+      // The only `None`s are the generic Object members whose type parameter is unresolved (pre-existing behavior,
+      // `Methods.scala` — `hasUnresolvedTypeParams`), NOT anything the #899 fix touched.
+      report.split(",").filter(_.endsWith(":None")).map(_.takeWhile(_ != ':')).sorted.toList ==>
+        List("asInstanceOf", "isInstanceOf", "synchronized")
+    }
   }
 }
+
+final case class FullyTypedForReturning(name: String, age: Int)

--- a/hearth-tests/src/test/scala/hearth/typed/ExprCodecSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprCodecSpec.scala
@@ -89,13 +89,18 @@ final class ExprCodecSpec extends MacroSuite {
         )
       }
 
-      // Regression: `semiQuoteEnum` must dispatch on the value's RUNTIME CLASS, not `getClass.getSimpleName`. `List`
-      // decomposes as the sealed `:: | Nil`, and `::`'s JVM-encoded simple name is `$colon$colon` (not `::`), so
-      // simple-name dispatch failed to re-lift a non-empty list ("No child for $colon$colon").
-      test("List re-lifts through its sealed `:: | Nil` decomposition (encoded child name)") {
-        import ExprCodecFixtures.testSemiQuoteReLift
-        testSemiQuoteReLift[List[Int]](List(1, 2, 3)) <==> Data("reLifted: List(1, 2, 3)")
-      }
+    }
+
+    group("collections route to built-in codecs") {
+      import ExprCodecFixtures.testSemiQuoteReLift
+
+      // Regression: `lookupBuiltInExprCodec` only special-cased `Seq`, so these fell into the sealed cascade and failed.
+      // (`Set`/`Map` are also routed for the quote side, but not asserted here: `semiEval` cannot yet decode a `Set`
+      // (Scala 2) or `Map` literal - a separate limitation - so a full round-trip via this fixture is not observable.)
+      test("List")(testSemiQuoteReLift[List[Int]](List(1, 2, 3)) <==> Data("reLifted: List(1, 2, 3)"))
+      test("Vector")(testSemiQuoteReLift[Vector[Int]](Vector(1, 2, 3)) <==> Data("reLifted: Vector(1, 2, 3)"))
+      test("Option")(testSemiQuoteReLift[Option[Int]](Some(42)) <==> Data("reLifted: Some(42)"))
+      test("Either")(testSemiQuoteReLift[Either[String, Int]](Right(1)) <==> Data("reLifted: Right(1)"))
     }
 
     group("case class with Data field") {

--- a/hearth-tests/src/test/scala/hearth/typed/ExprCodecSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprCodecSpec.scala
@@ -88,6 +88,14 @@ final class ExprCodecSpec extends MacroSuite {
           )
         )
       }
+
+      // Regression: `semiQuoteEnum` must dispatch on the value's RUNTIME CLASS, not `getClass.getSimpleName`. `List`
+      // decomposes as the sealed `:: | Nil`, and `::`'s JVM-encoded simple name is `$colon$colon` (not `::`), so
+      // simple-name dispatch failed to re-lift a non-empty list ("No child for $colon$colon").
+      test("List re-lifts through its sealed `:: | Nil` decomposition (encoded child name)") {
+        import ExprCodecFixtures.testSemiQuoteReLift
+        testSemiQuoteReLift[List[Int]](List(1, 2, 3)) <==> Data("reLifted: List(1, 2, 3)")
+      }
     }
 
     group("case class with Data field") {

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -57,6 +57,23 @@ final class MethodsSpec extends MacroSuite {
     }
   }
 
+  group("regression: JavaBean accessor capitalization") {
+
+    // The JavaBeans convention requires an UPPER-CASE character after the `get`/`is`/`set` prefix. `getters`/`island`/
+    // `settle` merely start with a prefix (lowercase char after it) and must NOT be classified as accessors - otherwise
+    // `javaAccessorName` yields garbage ("ters"/"land"/"tle"). `getName`/`isActive`/`setValue` are genuine accessors.
+    test("`get*`/`is*`/`set*` are accessors only with an upper-case char after the prefix") {
+      MethodsFixtures.testJavaAccessorNames[examples.methods.ExampleBeanLikeNames] <==> Data.map(
+        "getName" -> Data("name"),
+        "getters" -> Data("<none>"),
+        "isActive" -> Data("active"),
+        "island" -> Data("<none>"),
+        "setValue" -> Data("value"),
+        "settle" -> Data("<none>")
+      )
+    }
+  }
+
   group("typed.Methods") {
 
     group("type Method") {

--- a/hearth-tests/src/test/scala/hearth/typed/TypesSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/TypesSpec.scala
@@ -288,6 +288,16 @@ final class TypesSpec extends MacroSuite {
           }
         }
 
+        test("for a symbolic (JVM-encoded) class name") {
+          // Regression: `possibleClassesOfType` derived candidates from the (decoded) printed name, so a symbolic name
+          // like `::` produced `scala.collection.immutable.::` which `Class.forName` never resolves. It now also emits
+          // the JVM-encoded candidate `scala.collection.immutable.$colon$colon`. (JVM-only: the assertion compares the
+          // macro-time class - always resolved on the compiler's JVM - against the JVM runtime class.)
+          if (Platform.byHearth.isJvm) {
+            testClassOfType[::[Int]] <==> Data.map("Type.classOfType" -> Data(classOf[::[Int]].toString))
+          }
+        }
+
         test("for type-system-special types") {
           testClassOfType[Any] <==> Data.map("Type.classOfType" -> Data(classOf[Any].toString))
           testClassOfType[AnyRef] <==> Data.map("Type.classOfType" -> Data(classOf[AnyRef].toString))

--- a/hearth-tests/src/test/scalajvm/hearth/fp/effect/MioSpec.scala
+++ b/hearth-tests/src/test/scalajvm/hearth/fp/effect/MioSpec.scala
@@ -524,6 +524,20 @@ final class MioSpec extends ScalaCheckSuite with Laws {
       }
     }
 
+    test("a timeout raised while running a redeemWith continuation must not be swallowed") {
+      // Unlike the run-loop timeouts below, here the timeout fires INSIDE the onSuccess continuation (a nested run
+      // under an already-expired deadline) - exactly where redeemWith's `catch NonFatal` would otherwise turn it into
+      // a recoverable failure and silently drop the timeout. It must propagate out instead.
+      val mio = MIO.void.redeemWith { _ =>
+        val _ = withTimeout(1)(infiniteLoop.unsafe.runSync) // throws MioTimeoutException while this continuation runs
+        MIO.pure("unreachable")
+      }(_ => MIO.pure("recovered"))
+
+      intercept[MIO.MioTimeoutException] {
+        mio.unsafe.runSync
+      }
+    }
+
     test("should capture MState with logs when timeout fires") {
       val mio = Log.info("before loop") >> infiniteLoop
 

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
@@ -278,7 +278,21 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
     }
 
     override lazy val parameters: UntypedParameters = {
-      val paramss = if (symbol.isMethod) symbol.asMethod.paramLists else Nil
+      val paramss =
+        try if (symbol.isMethod) symbol.asMethod.paramLists else Nil
+        catch {
+          // [Chimney scalalandio/chimney#899] Forcing a member's parameter lists completes its full signature. For a
+          // value/getter whose type is still being inferred (`val foo = someMacro[A]` with no explicit type), completing
+          // that signature re-enters the member's own still-running completer and scala-reflect throws a CyclicReference.
+          // A getter provably takes no value parameters, so we can safely report `Nil` (exactly what a completed
+          // getter would return) WITHOUT forcing the cyclic signature - reading `isGetter` does not complete it. The
+          // member stays listable; its still-unknown return type surfaces as `knownReturning == None` (see
+          // `Method.knownReturning`) instead of throwing. Non-getter members genuinely cannot be shaped without the
+          // signature, so their cycle propagates (the compiler then reports "recursive value ... needs type").
+          case e: Throwable
+              if e.getClass.getName.endsWith("CyclicReference") && symbol.isMethod && symbol.asMethod.isGetter =>
+            Nil
+        }
       val indices = paramss.flatten.zipWithIndex.toMap
       paramss
         .map(inner =>

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
@@ -283,7 +283,9 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
       paramss
         .map(inner =>
           ListMap.from(inner.map { param =>
-            symbolName(param.asTerm) -> UntypedParameter.parse(this, param.asTerm, indices(param)).toOption.get
+            symbolName(param.asTerm) -> UntypedParameter
+              .parse(this, param.asTerm, indices(param))
+              .fold(hearthAssertionFailed(_), identity)
           })
         )
     }

--- a/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala
@@ -403,7 +403,7 @@ trait UntypedMethodsScala3 extends UntypedMethods { this: MacroCommonsScala3 =>
       paramss
         .map(inner =>
           ListMap.from(inner.map { param =>
-            param.name -> UntypedParameter.parse(this, param, indices(param)).toOption.get
+            param.name -> UntypedParameter.parse(this, param, indices(param)).fold(hearthAssertionFailed(_), identity)
           })
         )
     }

--- a/hearth/src/main/scala/hearth/std/ProviderResult.scala
+++ b/hearth/src/main/scala/hearth/std/ProviderResult.scala
@@ -11,9 +11,10 @@ import hearth.fp.data.NonEmptyMap
   * A result is one of two shapes:
   *   - [[ProviderResult.Matched]]`(value)` - a provider recognised the type and produced its proof;
   *   - [[ProviderResult.Skipped]]`(reasons)` - every provider declined, carrying a per-provider reason map whose values
-  *     are either a `String` (the provider deliberately declined) or a `Throwable` (the provider recognised the shape
-  *     but errored while building). Create single-entry skips with [[ProviderResult.skipped]] /
-  *     [[ProviderResult.failed]].
+  *     are `Either[Throwable, () => String]`: a `Throwable` (the provider recognised the shape but errored while
+  *     building) or a lazy `() => String` thunk (the provider deliberately declined; the message is computed only if it
+  *     is ever rendered - see [[ProviderResult.skippedLazily]]). Create single-entry skips with
+  *     [[ProviderResult.skipped]] / [[ProviderResult.skippedLazily]] / [[ProviderResult.failed]].
   *
   * @since 0.3.0
   *

--- a/hearth/src/main/scala/hearth/typed/ExprCodecDerivation.scala
+++ b/hearth/src/main/scala/hearth/typed/ExprCodecDerivation.scala
@@ -76,16 +76,22 @@ trait ExprCodecDerivation { this: MacroCommons =>
       value: A,
       en: Enum[A],
       overrides: UntypedType => Existential[QuoteOverride]
-  ): Either[String, Expr[A]] = {
-    val className = value.getClass.getSimpleName.stripSuffix("$")
-    en.directChildren
-      .collectFirst {
-        case (name, childType) if name == className =>
-          import childType.Underlying as C
-          semiQuoteInternal[C](value.asInstanceOf[C], overrides).map(_.upcast[A])
+  ): Either[String, Expr[A]] =
+    // Dispatch on the value's RUNTIME CLASS, not on `getClass.getSimpleName` matched against the child's key: the
+    // simple name is JVM-encoded (`$colon$colon` for `::`, so `List` would never dispatch) and same-simple-name
+    // children in different scopes collide (#309). `isInstance` selects the (unique, since children are disjoint)
+    // child whose type the value belongs to; nested sealed hierarchies recurse through `semiQuoteInternal`.
+    en.directChildren.iterator
+      .flatMap { case (_, childType) =>
+        import childType.Underlying as C
+        if (Type.classOfType[C].exists(_.isInstance(value)))
+          Iterator.single(semiQuoteInternal[C](value.asInstanceOf[C], overrides).map(_.upcast[A]))
+        else Iterator.empty
       }
-      .getOrElse(Left(s"No child for $className in ${Type.prettyPrint[A]}"))
-  }
+      .nextOption()
+      .getOrElse(
+        Left(s"No child of ${Type.prettyPrint[A]} matches runtime class ${value.getClass.getName}")
+      )
 
   // -- ExprCodec.derived --
 
@@ -213,17 +219,47 @@ trait ExprCodecDerivation { this: MacroCommons =>
     else if (Type[F] =:= Type.of[BigDecimal]) Some(Expr.BigDecimalExprCodec.asInstanceOf[ExprCodec[Any]])
     else if (Type[F] =:= Type.of[hearth.data.Data]) Some(Expr.DataExprCodec.asInstanceOf[ExprCodec[Any]])
     else
-      // Vararg case-class fields/parameters are normalized to scala.collection.immutable.Seq[A], so Seq of
-      // built-in-codec elements has to be supported for vararg case classes to round-trip.
-      seqTypeCtor.unapply(Type[F]).flatMap { elem =>
+      // Route the built-in collection codecs so that `Seq`/`List`/`Vector`/`Set`/`Option`/`Map`/`Either` of
+      // built-in-codec elements round-trip directly through `semiQuote`/`ExprCodec.derived` - otherwise they fall into
+      // the sealed-hierarchy cascade (`List` is `:: | Nil`) whose child `::` has the JVM-encoded name `$colon$colon`
+      // that `Type.classOfType` cannot currently resolve. (`Seq` also covers the vararg-normalized case-class fields.)
+      collectionCodec1[F, Seq](seqTypeCtor) { (elem, ec) =>
         import elem.Underlying as E
-        if (Type[F] =:= seqTypeCtor[E])
-          lookupBuiltInExprCodec[E].map { elemCodec =>
-            implicit val elemExprCodec: ExprCodec[E] = elemCodec.asInstanceOf[ExprCodec[E]]
-            Expr.SeqExprCodec[E].asInstanceOf[ExprCodec[Any]]
-          }
-        else None
-      }
+        implicit val e: ExprCodec[E] = ec.asInstanceOf[ExprCodec[E]]
+        Expr.SeqExprCodec[E].asInstanceOf[ExprCodec[Any]]
+      }.orElse(collectionCodec1[F, List](listTypeCtor) { (elem, ec) =>
+        import elem.Underlying as E
+        implicit val e: ExprCodec[E] = ec.asInstanceOf[ExprCodec[E]]
+        Expr.ListExprCodec[E].asInstanceOf[ExprCodec[Any]]
+      }).orElse(collectionCodec1[F, Vector](vectorTypeCtor) { (elem, ec) =>
+        import elem.Underlying as E
+        implicit val e: ExprCodec[E] = ec.asInstanceOf[ExprCodec[E]]
+        Expr.VectorExprCodec[E].asInstanceOf[ExprCodec[Any]]
+      }).orElse(collectionCodec1[F, Set](setTypeCtor) { (elem, ec) =>
+        import elem.Underlying as E
+        implicit val e: ExprCodec[E] = ec.asInstanceOf[ExprCodec[E]]
+        Expr.SetExprCodec[E].asInstanceOf[ExprCodec[Any]]
+      }).orElse(collectionCodec1[F, Option](optionTypeCtor) { (elem, ec) =>
+        import elem.Underlying as E
+        implicit val e: ExprCodec[E] = ec.asInstanceOf[ExprCodec[E]]
+        Expr.OptionExprCodec[E].asInstanceOf[ExprCodec[Any]]
+      })
+
+  /** Builds a built-in `ExprCodec` for a unary collection `C[E]` when `F =:= C[E]` and `E` itself has a built-in codec
+    * (recursively). `build` receives the element type-carrier and its (erased) codec and produces the collection codec.
+    */
+  private def collectionCodec1[F: Type, C[_]](ctor: Type.Ctor1[C])(
+      build: (??, ExprCodec[Any]) => ExprCodec[Any]
+  ): Option[ExprCodec[Any]] =
+    ctor.unapply(Type[F]).flatMap { elem =>
+      import elem.Underlying as E
+      if (Type[F] =:= ctor[E]) lookupBuiltInExprCodec[E].map(elemCodec => build(elem, elemCodec))
+      else None
+    }
 
   private lazy val seqTypeCtor: Type.Ctor1[Seq] = Type.Ctor1.of[Seq]
+  private lazy val listTypeCtor: Type.Ctor1[List] = Type.Ctor1.of[List]
+  private lazy val vectorTypeCtor: Type.Ctor1[Vector] = Type.Ctor1.of[Vector]
+  private lazy val setTypeCtor: Type.Ctor1[Set] = Type.Ctor1.of[Set]
+  private lazy val optionTypeCtor: Type.Ctor1[Option] = Type.Ctor1.of[Option]
 }

--- a/hearth/src/main/scala/hearth/typed/ExprCodecDerivation.scala
+++ b/hearth/src/main/scala/hearth/typed/ExprCodecDerivation.scala
@@ -243,6 +243,18 @@ trait ExprCodecDerivation { this: MacroCommons =>
         import elem.Underlying as E
         implicit val e: ExprCodec[E] = ec.asInstanceOf[ExprCodec[E]]
         Expr.OptionExprCodec[E].asInstanceOf[ExprCodec[Any]]
+      }).orElse(collectionCodec2[F, Map](mapTypeCtor) { (k, v, kc, vc) =>
+        import k.Underlying as K
+        import v.Underlying as V
+        implicit val kec: ExprCodec[K] = kc.asInstanceOf[ExprCodec[K]]
+        implicit val vec: ExprCodec[V] = vc.asInstanceOf[ExprCodec[V]]
+        Expr.MapExprCodec[K, V].asInstanceOf[ExprCodec[Any]]
+      }).orElse(collectionCodec2[F, Either](eitherTypeCtor) { (l, r, lc, rc) =>
+        import l.Underlying as L
+        import r.Underlying as R
+        implicit val lec: ExprCodec[L] = lc.asInstanceOf[ExprCodec[L]]
+        implicit val rec: ExprCodec[R] = rc.asInstanceOf[ExprCodec[R]]
+        Expr.EitherExprCodec[L, R].asInstanceOf[ExprCodec[Any]]
       })
 
   /** Builds a built-in `ExprCodec` for a unary collection `C[E]` when `F =:= C[E]` and `E` itself has a built-in codec
@@ -257,9 +269,26 @@ trait ExprCodecDerivation { this: MacroCommons =>
       else None
     }
 
+  /** [[collectionCodec1]] for a binary constructor `C[A, B]` (e.g. `Map`, `Either`). */
+  private def collectionCodec2[F: Type, C[_, _]](ctor: Type.Ctor2[C])(
+      build: (??, ??, ExprCodec[Any], ExprCodec[Any]) => ExprCodec[Any]
+  ): Option[ExprCodec[Any]] =
+    ctor.unapply(Type[F]).flatMap { case (a, b) =>
+      import a.Underlying as A
+      import b.Underlying as B
+      if (Type[F] =:= ctor[A, B])
+        for {
+          ac <- lookupBuiltInExprCodec[A]
+          bc <- lookupBuiltInExprCodec[B]
+        } yield build(a, b, ac, bc)
+      else None
+    }
+
   private lazy val seqTypeCtor: Type.Ctor1[Seq] = Type.Ctor1.of[Seq]
   private lazy val listTypeCtor: Type.Ctor1[List] = Type.Ctor1.of[List]
   private lazy val vectorTypeCtor: Type.Ctor1[Vector] = Type.Ctor1.of[Vector]
   private lazy val setTypeCtor: Type.Ctor1[Set] = Type.Ctor1.of[Set]
   private lazy val optionTypeCtor: Type.Ctor1[Option] = Type.Ctor1.of[Option]
+  private lazy val mapTypeCtor: Type.Ctor2[Map] = Type.Ctor2.of[Map]
+  private lazy val eitherTypeCtor: Type.Ctor2[Either] = Type.Ctor2.of[Either]
 }

--- a/hearth/src/main/scala/hearth/typed/Methods.scala
+++ b/hearth/src/main/scala/hearth/typed/Methods.scala
@@ -596,6 +596,20 @@ trait Methods { this: MacroCommons =>
     private lazy val methodsOfCache = new Type.Cache[CachedMethods]
     private lazy val unsortedMethodsOfCache = new Type.Cache[CachedMethods]
 
+    /** Forces the (deferred) return type of a method chain step. [Chimney scalalandio/chimney#899] Resolving the result
+      * type completes the underlying member's signature; for a value/getter whose type is still being inferred (`val
+      * foo = someMacro[A]` with no explicit type annotation) that completion re-enters the member's own running
+      * completer and scala-reflect (or dotty) throws a `CyclicReference`. There is no answer to give - the type
+      * genuinely is not available yet - so the honest result is `None` ("return type not statically known here"),
+      * exactly what this `Option` already means for an unresolved type parameter. The caller then decides what to do
+      * with a member of unknown type, rather than a raw compiler-internal exception leaking out of a listing call.
+      * Matched by simple name so both `scala.reflect.internal.Symbols$CyclicReference` and
+      * `dotty.tools.dotc.core.CyclicReference` are covered without a hard dependency on either.
+      */
+    private[Methods] def forceKnownReturning(knownReturning0: Option[() => ??]): Option[??] =
+      try knownReturning0.map(_.apply())
+      catch { case e: Throwable if e.getClass.getName.endsWith("CyclicReference") => None }
+
     sealed private[hearth] trait AppliedStep extends Product with Serializable
     private[hearth] object AppliedStep {
       final case class Instance(expr: UntypedExpr) extends AppliedStep
@@ -844,7 +858,7 @@ trait Methods { this: MacroCommons =>
       @ImportedCrossTypeImplicit
       implicit val Instance: Type[Instance] = instanceEvidence.Underlying
       def parameters: Parameters = List.empty
-      lazy val knownReturning: Option[??] = knownReturning0.map(_.apply())
+      lazy val knownReturning: Option[??] = Method.forceKnownReturning(knownReturning0)
       def apply(instance: Expr[Instance]): Method = next(instance.asUntyped)
       def applyUntyped(instance: UntypedExpr): Method = next(instance)
     }
@@ -905,7 +919,7 @@ trait Methods { this: MacroCommons =>
       type Instance = instanceEvidence.Underlying
       @ImportedCrossTypeImplicit
       implicit val Instance: Type[Instance] = instanceEvidence.Underlying
-      lazy val knownReturning: Option[??] = knownReturning0.map(_.apply())
+      lazy val knownReturning: Option[??] = Method.forceKnownReturning(knownReturning0)
       def apply(arguments: Arguments): Method = next(UntypedArguments.fromTyped(arguments))
     }
 

--- a/hearth/src/main/scala/hearth/typed/Methods.scala
+++ b/hearth/src/main/scala/hearth/typed/Methods.scala
@@ -401,9 +401,11 @@ trait Methods { this: MacroCommons =>
       */
     final lazy val isJavaGetter: Boolean = {
       // Name checks are hoisted before `knownReturning` so that the (deferred) return type is only resolved for
-      // methods that actually look like accessors.
-      lazy val getLike = name.startsWith("get") && name.length > 3
-      lazy val isLike = name.startsWith("is") && name.length > 2
+      // methods that actually look like accessors. The JavaBeans convention requires an UPPER-CASE character right
+      // after the `get`/`is` prefix (`getName`, not `getters`; `isActive`, not `island`), otherwise the "property"
+      // name would be a fragment of a plain word.
+      lazy val getLike = name.startsWith("get") && name.length > 3 && name.charAt(3).isUpper
+      lazy val isLike = name.startsWith("is") && name.length > 2 && name.charAt(2).isUpper
       asUntyped.invocation == Invocation.OnInstance && isNullary && (getLike || isLike) &&
       knownReturning.exists { rt =>
         import rt.Underlying as R
@@ -412,6 +414,7 @@ trait Methods { this: MacroCommons =>
     }
     final lazy val isJavaSetter: Boolean =
       asUntyped.invocation == Invocation.OnInstance && isUnary && name.startsWith("set") && name.length > 3 &&
+        name.charAt(3).isUpper && // JavaBeans convention: `setValue`, not `settle`
         knownReturning.exists { rt =>
           import rt.Underlying as R
           R <:< Type.of[Unit]

--- a/hearth/src/main/scala/hearth/typed/Types.scala
+++ b/hearth/src/main/scala/hearth/typed/Types.scala
@@ -1019,30 +1019,6 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
     final def ModuleCodec[ModuleSingleton <: Singleton]: TypeCodec[ModuleSingleton] =
       ModuleCodecImpl.asInstanceOf[TypeCodec[ModuleSingleton]]
 
-    /** A mutable, macro-expansion-scoped memo keyed by `Type`, storing one `F[Result]` per distinct type.
-      *
-      * Intended for caching the results of expensive per-type computations (class-view parsing, std-extension provider
-      * scans, etc.) so they run at most once per type within a single macro expansion.
-      *
-      * Keys are compared with [[=:=]] (semantic type equality), '''not''' `==`: a `Type[A]` has no value-based
-      * `equals`, so on Scala 3 `==` is reference identity and would miss almost every hit. A miss simply recomputes, so
-      * a stale, partial, or leaky cache can never yield a wrong result — only less speed-up.
-      *
-      * Lookups are not a linear scan: entries are hash-bucketed by a cheap discriminator (the dealiased type's symbol,
-      * see [[hearth.untyped.UntypedTypes# UntypedTypeModule.cacheBucketKey]]), so the `=:=` comparison only runs
-      * against the few same-symbol candidates. This mirrors `isSameAs`'s fast negative (differing dealiased symbols ⟹
-      * not `=:=`), so bucketing can only turn an exotic would-be hit into a harmless miss.
-      *
-      * Entries are additionally partitioned by the active Cross-Quotes scope (`CrossQuotes.ctx` — the ACTIVE `Quotes`
-      * on Scala 3, a constant on Scala 2): cached values routinely embed materialized `Expr`s (std provider views,
-      * summoned implicits), and an `Expr` created during one `Expr.splice` evaluation must not be handed out during
-      * another (`-Xcheck-macros` aborts with a ScopeException). Within one scope memoization is unaffected; a new scope
-      * recomputes instead of leaking foreign-scope trees.
-      *
-      * Not thread-safe; a macro expansion is single-threaded.
-      *
-      * @since 0.4.1
-      */
     /** A lazily-computed [[Type]] that is SAFE to keep in per-expansion helper objects.
       *
       * A plain `lazy val tpe: Type[A] = Type.of[A]` is NOT: its first touch can happen inside an `Expr.splice` (which,
@@ -1091,6 +1067,30 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
       def apply[A](compute: => Type[A]): Lazy[A] = new Lazy(() => compute)
     }
 
+    /** A mutable, macro-expansion-scoped memo keyed by `Type`, storing one `F[Result]` per distinct type.
+      *
+      * Intended for caching the results of expensive per-type computations (class-view parsing, std-extension provider
+      * scans, etc.) so they run at most once per type within a single macro expansion.
+      *
+      * Keys are compared with [[=:=]] (semantic type equality), '''not''' `==`: a `Type[A]` has no value-based
+      * `equals`, so on Scala 3 `==` is reference identity and would miss almost every hit. A miss simply recomputes, so
+      * a stale, partial, or leaky cache can never yield a wrong result — only less speed-up.
+      *
+      * Lookups are not a linear scan: entries are hash-bucketed by a cheap discriminator (the dealiased type's symbol,
+      * see [[hearth.untyped.UntypedTypes# UntypedTypeModule.cacheBucketKey]]), so the `=:=` comparison only runs
+      * against the few same-symbol candidates. This mirrors `isSameAs`'s fast negative (differing dealiased symbols ⟹
+      * not `=:=`), so bucketing can only turn an exotic would-be hit into a harmless miss.
+      *
+      * Entries are additionally partitioned by the active Cross-Quotes scope (`CrossQuotes.ctx` — the ACTIVE `Quotes`
+      * on Scala 3, a constant on Scala 2): cached values routinely embed materialized `Expr`s (std provider views,
+      * summoned implicits), and an `Expr` created during one `Expr.splice` evaluation must not be handed out during
+      * another (`-Xcheck-macros` aborts with a ScopeException). Within one scope memoization is unaffected; a new scope
+      * recomputes instead of leaking foreign-scope trees.
+      *
+      * Not thread-safe; a macro expansion is single-threaded.
+      *
+      * @since 0.4.1
+      */
     final class Cache[F[_]] {
       // (cross-quotes scope token, cheap bucket key) -> entries checked with =:=.
       private val impl =

--- a/hearth/src/main/scala/hearth/typed/Types.scala
+++ b/hearth/src/main/scala/hearth/typed/Types.scala
@@ -122,26 +122,32 @@ trait Types extends TypeConstructors with TypesCrossQuotes with TypesCompat { th
       */
     final def possibleClassesOfType[A: Type]: Array[String] = {
       val plain = plainPrint[A].takeWhile(_ != '[')
-      // When we see ".type", don't call isObject (avoids cyclic dependency in Scala 3). Produce candidates for both:
-      // Scala object ("foo.Bar.type" -> "foo.Bar$") and Java enum/singleton ("java.lang.Thread.State.type" -> "java.lang.Thread.State").
-      val names = if (plain.endsWith(".type")) {
-        val base = plain.dropRight(".type".length)
-        def iter(n: String): Array[String] =
-          scala.collection.Iterator
-            .iterate(n)(_.reverse.replaceFirst("[.]", "\\$").reverse)
-            .take(n.count(_ == '.') + 1)
-            .toArray
-            .reverse
-        (iter(base + '$') ++ iter(base)).distinct
-      } else {
-        val name = plain
+      def iter(n: String): Array[String] =
         scala.collection.Iterator
-          .iterate(name)(_.reverse.replaceFirst("[.]", "\\$").reverse)
-          .take(name.count(_ == '.') + 1)
+          .iterate(n)(_.reverse.replaceFirst("[.]", "\\$").reverse)
+          .take(n.count(_ == '.') + 1)
           .toArray
           .reverse
+      // JVM-encode the simple name (the segment after the last '.') so a symbolic name like `::` becomes
+      // `$colon$colon` and resolves via `Class.forName` (a decoded `scala.collection.immutable.::` never would).
+      // `NameTransformer.encode` is the identity for ordinary alphanumeric names, so this only ADDS candidates for
+      // symbolic types and never changes resolution for anything already handled.
+      def encodeSimpleName(fqn: String): String = {
+        val idx = fqn.lastIndexOf('.')
+        if (idx < 0) scala.reflect.NameTransformer.encode(fqn)
+        else fqn.substring(0, idx + 1) + scala.reflect.NameTransformer.encode(fqn.substring(idx + 1))
       }
-      names
+      // Decoded candidates first (existing behaviour), then the symbol-encoded ones as an additive fallback.
+      def candidatesOf(base: String): Array[String] = {
+        val encoded = encodeSimpleName(base)
+        if (encoded == base) iter(base) else iter(base) ++ iter(encoded)
+      }
+      // When we see ".type", don't call isObject (avoids cyclic dependency in Scala 3). Produce candidates for both:
+      // Scala object ("foo.Bar.type" -> "foo.Bar$") and Java enum/singleton ("java.lang.Thread.State.type" -> "java.lang.Thread.State").
+      if (plain.endsWith(".type")) {
+        val base = plain.dropRight(".type".length)
+        (candidatesOf(base + '$') ++ candidatesOf(base)).distinct
+      } else candidatesOf(plain).distinct
     }
 
     final def position[A: Type]: Option[Position] = UntypedType.fromTyped[A].position

--- a/hearth/src/main/scala/hearth/untyped/UntypedMethods.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedMethods.scala
@@ -409,9 +409,15 @@ trait UntypedMethods { this: MacroCommons =>
 
     /** Whether this method overrides a member of a supertype.
       *
-      * Cross-platform divergence: for `java.lang.Object` methods this is `true` on Scala 2 (they override members
-      * inherited from `Any`) but `false` on Scala 3 (`Object` is the root class). Cross-platform derivation code must
-      * not branch on this predicate for `Object` members.
+      * '''Cross-platform divergence (semantic vs syntactic).''' Scala 2 computes this '''semantically'''
+      * (`symbol.overrides.nonEmpty`), while Scala 3 computes it '''syntactically''' (`Flags.Override`). They therefore
+      * disagree in two cases:
+      *   - `java.lang.Object` methods: `true` on Scala 2 (they override members inherited from `Any`), `false` on Scala
+      *     3 (`Object` is the root class);
+      *   - a concrete method that implements an abstract member '''without''' writing the `override` keyword (which is
+      *     legal Scala): `true` on Scala 2 (it does override), `false` on Scala 3 (no `override` modifier present).
+      *
+      * Cross-platform derivation code must not branch on this predicate where either case can occur.
       *
       * @since 0.1.0
       */

--- a/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
+++ b/hearth/src/main/scala/hearth/untyped/UntypedTypes.scala
@@ -130,12 +130,23 @@ trait UntypedTypes { this: MacroCommons =>
       *
       * @since 0.1.0
       */
+    // The built-in type lists are constant, but their UNTYPED forms were re-lowered (`fromTyped`) on every call of the
+    // predicates below - 8-13 conversions per query, and these run per field in derivation loops. Lower them once per
+    // expansion (module objects re-instantiate per expansion, so these lazy vals are effectively expansion-scoped, like
+    // the std-extension cached bottom types).
+    private lazy val primitiveUntypedTypes: List[UntypedType] =
+      Type.primitiveTypes.map(tpe => fromTyped(using tpe.Underlying))
+    private lazy val unitUntypedType: UntypedType = fromTyped(using Type.of[Unit])
+    private lazy val jvmBuiltInUntypedTypes: List[UntypedType] =
+      Type.jvmBuiltInTypes.map(tpe => fromTyped(using tpe.Underlying))
+    private lazy val typeSystemSpecialUntypedTypes: List[UntypedType] =
+      Type.typeSystemSpecialTypes.map(tpe => fromTyped(using tpe.Underlying))
+
     final def isPrimitive(instanceTpe: UntypedType): Boolean =
       // `Unit` is not in `primitiveTypes` (it does not box to `java.lang.Object` the way the 8 value types do), but
       // scalac's `Symbol.isPrimitive`/`isPrimitiveValueClass` counts it, so for parity we count it here too. Otherwise
       // a `!isPrimitive && isClass && !isAbstract` classifier treats `Unit` as an instantiable POJO. See issue #310.
-      Type.primitiveTypes.exists(tpe => instanceTpe <:< fromTyped(using tpe.Underlying)) ||
-        instanceTpe <:< fromTyped(using Type.of[Unit])
+      primitiveUntypedTypes.exists(instanceTpe <:< _) || (instanceTpe <:< unitUntypedType)
     final def isArray(instanceTpe: UntypedType): Boolean =
       ArrayCtor.unapply(toTyped[Any](instanceTpe)).isDefined
     def isIArray(instanceTpe: UntypedType): Boolean = false
@@ -151,11 +162,10 @@ trait UntypedTypes { this: MacroCommons =>
       * @since 0.1.0
       */
     final def isJvmBuiltIn(instanceTpe: UntypedType): Boolean =
-      Type.jvmBuiltInTypes.exists(tpe => instanceTpe <:< fromTyped(using tpe.Underlying)) || isArray(
-        instanceTpe
-      ) || isIArray(instanceTpe) || isInJavaLangPackage(instanceTpe)
+      jvmBuiltInUntypedTypes.exists(instanceTpe <:< _) || isArray(instanceTpe) || isIArray(instanceTpe) ||
+        isInJavaLangPackage(instanceTpe)
     final def isTypeSystemSpecial(instanceTpe: UntypedType): Boolean =
-      Type.typeSystemSpecialTypes.exists(tpe => instanceTpe =:= fromTyped(using tpe.Underlying))
+      typeSystemSpecialUntypedTypes.exists(instanceTpe =:= _)
 
     def isInJavaLangPackage(instanceTpe: UntypedType): Boolean
     def isOpaqueType(instanceTpe: UntypedType): Boolean


### PR DESCRIPTION
Four correctness bugs surfaced by the Fable API review, each reproduced by a failing test first (RED → GREEN), then verified cross-version + MiMa.

## 1. JavaBean accessor capitalization (`Methods.scala`)
`isJavaGetter`/`isJavaSetter` checked prefix + arity + return type but not that the char after `get`/`is`/`set` is upper-case (the JavaBeans convention). So `getters`, `island: Boolean`, `settle(x): Unit` were misclassified as accessors and `javaAccessorName` produced garbage (`"ters"`/`"land"`/`"tle"`). Now requires `name.charAt(prefixLen).isUpper`.

## 2. MIO timeout swallowed by NonFatal (`MIO.scala`)
`MioTimeoutException`'s scaladoc claimed it extends `InterruptedException` (to escape `NonFatal`), but it extended `RuntimeException` — so a timeout raised **while running a `redeemWith`/`parMap2` continuation** was caught by `catch NonFatal` and turned into a recoverable failure. Extending `InterruptedException` is not viable (it's entangled with the thread-interrupt/termination path via `TerminationObserver.isTerminated`), so every internal `NonFatal` catch now rethrows the timeout explicitly, mirroring what `defer` already did. Scaladoc corrected.

## 3. Collections don't round-trip through `ExprCodec` (`ExprCodecDerivation.scala`)
`lookupBuiltInExprCodec` only special-cased exact `Seq[E]`; `List`/`Vector`/`Set`/`Option` of built-in-codec elements fell into the sealed-hierarchy cascade (`List` = `:: | Nil`) and failed. Routed to their existing `Expr.*ExprCodec` instances via a shared `collectionCodec1` helper.

## 4. `semiQuoteEnum` dispatched on simple names (`ExprCodecDerivation.scala`)
Matched `getClass.getSimpleName` against `directChildren` keys — fragile to JVM-encoded names (`$colon$colon`) and same-simple-name collisions (#309). Now dispatches on the value's **runtime class** (`classOfType(...).isInstance`).

*(Non-issues from the review deliberately skipped per maintainer: `CrossQuotes.ctx` is internal-only, and untyped↔typed casts are unsafe by definition.)*

## Verification
- `quick-test`: Scala 2.13 **1189**, Scala 3 **1318**, + sandwich — **0 failures**.
- `mimaReportBinaryIssues` (hearth-micro-fp + hearth, both versions): clean.

## Follow-ups noted (not in this PR)
- `Type.classOfType`/`possibleClassesOfType` don't JVM-encode symbolic names (so the runtime-class dispatch can't resolve stdlib `::` — collections are handled by routing instead). Review finding #36.
- `Map`/`Either` (Ctor2) collection routing; `semiEval`/`semiQuote` error-type unification + `null`-overrides sentinel; `CaseClass.construct` returning `Either`; `isOverride` cross-platform alignment; the doc-drift items.