### PR TITLE
Document Chimney #899 as a compiler front-end limitation (repro + control) (Do not merge)

### DIFF
--- a/hearth-tests/src/main/scala-2/hearth/typed/CyclicReferenceFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/CyclicReferenceFixtures.scala
@@ -1,0 +1,73 @@
+package hearth
+package typed
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+/** Fixtures for [[CyclicReferenceScala2Spec]] — a Scala-2-only reproduction of the mechanism behind Chimney #899 (`case
+  * class A() { val foo = this.transformInto[B] }` crashing with `CyclicReference: illegal cyclic reference involving
+  * value foo`).
+  *
+  * The essential ingredient is that the reflection of `A` must happen INSIDE an implicit search that runs while an
+  * enclosing `val` of `A` is still being inferred. [[CyclicTC]] plays the role of Chimney's `Transformer`: its implicit
+  * materializer ([[deriveCyclicTC]]) reflects on the source with the very same calls Chimney's product extraction uses
+  * (`Type[A].unsortedMethods` + forcing each return type). When driven through
+  * [[CyclicConvertSyntax.Ops.cyclicConvertInto]] (the `transformInto` analogue), the first reflective access throws a
+  * `scala.reflect.internal.Symbols$CyclicReference`.
+  *
+  * The standalone harness (hearth-repros/repro-899) additionally shows the exception is CATCHABLE: catching it and
+  * letting the implicit search retry makes compilation succeed. This fixture intentionally does NOT catch, so the spec
+  * can pin the observable failure with `compileErrors`.
+  */
+trait CyclicReferenceFixturesImpl { this: MacroCommons =>
+
+  def deriveCyclicTC[A: Type, B: Type]: Expr[CyclicTC[A, B]] = {
+    // Reflect on `A` exactly like Chimney's product extraction: list instance methods and force each return
+    // type. Under the implicit search below this re-enters the still-running completer of the enclosing `val`.
+    val _ = Type[A].unsortedMethods.collect { case oi: Method.OnInstance => (oi: Method) }.map(_.knownReturning)
+    cyclicStub[A, B]
+  }
+
+  /** A do-nothing `CyclicTC[A, B]` value — the derivation's correctness is irrelevant, only its reflection is. */
+  protected def cyclicStub[A: Type, B: Type]: Expr[CyclicTC[A, B]]
+}
+
+/** Type class standing in for Chimney's `Transformer[A, B]`. */
+trait CyclicTC[A, B]
+
+object CyclicTC {
+  // Materializer that REFLECTS on `A` (the #899 trigger).
+  implicit def derive[A, B]: CyclicTC[A, B] = macro CyclicReferenceFixtures.deriveCyclicTCImpl[A, B]
+}
+
+/** Same shape as [[CyclicTC]] but its materializer does NOT reflect on `A` — the control that isolates the reflection
+  * as the cause of the cycle.
+  */
+trait PlainTC[A, B]
+
+object PlainTC {
+  implicit def derive[A, B]: PlainTC[A, B] = macro CyclicReferenceFixtures.derivePlainTCImpl[A, B]
+}
+
+/** `transformInto`-shaped syntax: extension methods whose result type is `B`, driven by an implicit. */
+object CyclicConvertSyntax {
+  implicit class Ops[A](private val a: A) extends AnyVal {
+    def cyclicConvertInto[B](implicit tc: CyclicTC[A, B]): B = null.asInstanceOf[B] // reflecting implicit
+    def plainConvertInto[B](implicit tc: PlainTC[A, B]): B = null.asInstanceOf[B] // non-reflecting control
+  }
+}
+
+final private class CyclicReferenceFixtures(val c: blackbox.Context)
+    extends MacroCommonsScala2
+    with CyclicReferenceFixturesImpl {
+  import c.universe.*
+
+  protected def cyclicStub[A: Type, B: Type]: Expr[CyclicTC[A, B]] =
+    c.Expr[CyclicTC[A, B]](q"null.asInstanceOf[_root_.hearth.typed.CyclicTC[${c.weakTypeOf[A]}, ${c.weakTypeOf[B]}]]")
+
+  def deriveCyclicTCImpl[A: c.WeakTypeTag, B: c.WeakTypeTag]: c.Expr[CyclicTC[A, B]] = deriveCyclicTC[A, B]
+
+  // Control: return a stub WITHOUT reflecting on `A`, so an inferred `val` driven by it compiles cleanly.
+  def derivePlainTCImpl[A: c.WeakTypeTag, B: c.WeakTypeTag]: c.Expr[PlainTC[A, B]] =
+    c.Expr[PlainTC[A, B]](q"null.asInstanceOf[_root_.hearth.typed.PlainTC[${c.weakTypeOf[A]}, ${c.weakTypeOf[B]}]]")
+}

--- a/hearth-tests/src/test/scala-2/hearth/typed/CyclicReferenceScala2Spec.scala
+++ b/hearth-tests/src/test/scala-2/hearth/typed/CyclicReferenceScala2Spec.scala
@@ -1,0 +1,51 @@
+package hearth
+package typed
+
+/** Scala-2-only reproduction of the mechanism behind Chimney #899 (`case class A() { val foo = this.transformInto[B] }`
+  * failing to compile).
+  *
+  * `Type[A].unsortedMethods` (and forcing member return types) is safe on its own, but when it runs inside an implicit
+  * search that fires while an enclosing `val` of `A` is still being inferred, completing `A`'s member list re-enters
+  * that `val`'s running completer. In a normal file compile that surfaces as
+  * `scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving value foo` (see the real Chimney
+  * control and the standalone harness hearth-repros/repro-899); under the toolbox used by `compileErrors` the typer's
+  * earlier guard fires first and reports `recursive value foo needs type`. Both are the same root cause.
+  *
+  * [[CyclicTC]] plays Chimney's `Transformer[A, B]`: its materializer reflects on the source. [[PlainTC]] is an
+  * identical type class whose materializer does NOT reflect — the control proving the reflection is what turns the
+  * `val` recursive. See [[CyclicReferenceFixtures]].
+  */
+final class CyclicReferenceScala2Spec extends MacroSuite {
+
+  group("regression: reflecting an enclosing mid-inference member (Chimney #899)") {
+
+    test("reflecting `A` from an implicit search makes an inferred `val` of `A` fail as recursive/cyclic") {
+      compileErrors(
+        """
+        import hearth.typed.CyclicConvertSyntax._
+        case class A() { val foo = this.cyclicConvertInto[B] }
+        case class B()
+        """
+      ).check("recursive value foo needs type")
+    }
+
+    test("control: the SAME shape with a non-reflecting materializer compiles (reflection is the cause)") {
+      import hearth.typed.CyclicConvertSyntax.*
+      case class B()
+      case class A() { val foo = this.plainConvertInto[B] } // no explicit type, yet compiles - no reflection
+      A().foo ==> null
+    }
+
+    test("workaround: giving the enclosing member an explicit type avoids the cycle (documented for #899)") {
+      import hearth.typed.CyclicConvertSyntax.*
+      case class B()
+      case class A() { val foo: B = this.cyclicConvertInto[B] } // explicit type -> no re-entry, compiles
+      A().foo ==> null
+    }
+
+    // NOTE (verified empirically): Hearth CANNOT rescue the inferred-`val` case. The compiler's namer detects the
+    // recursive `val` and reports `recursive value foo needs type` BEFORE Hearth ever forces the member's return type,
+    // so no Hearth-level `try/catch` around the reflection (`unsortedMethods`/`knownReturning`) is ever reached - a
+    // catch there does not fire. The user-facing remedy is the explicit type annotation above.
+  }
+}


### PR DESCRIPTION
Adds a Scala-2-only reproduction of the macro-front-end limitation behind Chimney #899:

```scala
case class A() { val foo = this.transformInto[B] }   // Scala 2.13
```

fails to compile because inferring `foo`'s type expands `transformInto`, which resolves an implicit `Transformer[A, B]` whose materializer reflects on `A` — and completing `A`'s member list re-enters the still-running completer of `foo`.

## What's here

- **`CyclicReferenceFixtures`** — `CyclicTC[A, B]`, a `Transformer`-shaped type class whose materializer reflects on the source exactly the way Chimney's product extraction does (`Type[A].unsortedMethods` + forcing each `knownReturning`), plus a non-reflecting `PlainTC[A, B]` control, driven by a `transformInto`-shaped extension method.
- **`CyclicReferenceScala2Spec`** — three tests:
  1. inferred `val foo = this.cyclicConvertInto[B]` → `compileErrors` pins `recursive value foo needs type`;
  2. **control**: the same shape with the non-reflecting materializer **compiles** (proving the reflection is the trigger);
  3. **workaround**: an explicit type on `foo` compiles (the documented #899 remedy).

## Why it's a limitation, not a bug Hearth can fix

Verified empirically (a diagnostic abort placed inside a cycle-catch around `knownReturning` **never fired**): the compiler's namer reports `recursive value foo needs type` for the inferred `val` **before** Hearth forces the member's return type, so no `try/catch` around the reflection is ever reached. An earlier attempt to swallow the cycle in `Method.knownReturning` was reverted for that reason. The remedy is the explicit-type annotation the spec documents.

In a normal file compile (real Chimney, and the standalone harness) the same scenario surfaces as `scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving value foo`; under the toolbox used by `compileErrors` the typer's recursive-`val` guard fires first. Same root cause, both documented in the spec.

## Verification

Scala 2.13 (JDK 24): `CyclicReferenceScala2Spec` 3/3 green on this branch; full `hearthTests/test` → 1196 passed, 0 failed.

Separate from #359 (unrelated review fixes); this is a focused, self-contained addition.
