### PR TITLE
Bump MiMa baseline to 0.4.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -280,7 +280,7 @@ val publishSettings = Seq(
 )
 
 // The last released version we check binary compatibility against. Bump this on every release.
-val mimaPreviousVersion = "0.4.0"
+val mimaPreviousVersion = "0.4.1"
 
 val mimaSettings = Seq(
   mimaPreviousArtifacts := {


### PR DESCRIPTION
Now that **0.4.1** is published, bump `mimaPreviousVersion` so binary compatibility is checked against it — the next release is gated against the current public API.

Verified locally: `mimaReportBinaryIssues` green for hearth-micro-fp, hearth-better-printers, hearth, hearth-munit across Scala 2.13 + 3 (JVM).