### PR TITLE
Fix #348: preserve type-position annotations on case-field getter return types

### DIFF
--- a/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-2/hearth/typed/MethodsFixtures.scala
@@ -103,6 +103,9 @@ final private class MethodsFixtures(val c: blackbox.Context) extends MacroCommon
   def testTypeAnnotationsImpl[A: c.WeakTypeTag]: c.Expr[Data] =
     testTypeAnnotations[A]
 
+  def testTypeAnnotationsViaKnownReturningImpl[A: c.WeakTypeTag]: c.Expr[Data] =
+    testTypeAnnotationsViaKnownReturning[A]
+
   def testParameterAnnotationsImpl[A: c.WeakTypeTag](methodName: c.Expr[String]): c.Expr[Data] =
     testParameterAnnotations[A](methodName)
 
@@ -220,6 +223,9 @@ object MethodsFixtures {
 
   def testTypeAnnotations[A]: Data =
     macro MethodsFixtures.testTypeAnnotationsImpl[A]
+
+  def testTypeAnnotationsViaKnownReturning[A]: Data =
+    macro MethodsFixtures.testTypeAnnotationsViaKnownReturningImpl[A]
 
   def testParameterAnnotations[A](methodName: String): Data =
     macro MethodsFixtures.testParameterAnnotationsImpl[A]

--- a/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
+++ b/hearth-tests/src/main/scala-3/hearth/typed/MethodsFixtures.scala
@@ -208,6 +208,10 @@ object MethodsFixtures {
   private def testTypeAnnotationsImpl[A: Type](using q: Quotes): Expr[Data] =
     new MethodsFixtures(q).testTypeAnnotations[A]
 
+  inline def testTypeAnnotationsViaKnownReturning[A]: Data = ${ testTypeAnnotationsViaKnownReturningImpl[A] }
+  private def testTypeAnnotationsViaKnownReturningImpl[A: Type](using q: Quotes): Expr[Data] =
+    new MethodsFixtures(q).testTypeAnnotationsViaKnownReturning[A]
+
   inline def testParameterAnnotations[A](inline methodName: String): Data = ${
     testParameterAnnotationsImpl[A]('methodName)
   }

--- a/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
+++ b/hearth-tests/src/main/scala/hearth/typed/MethodsFixturesImpl.scala
@@ -937,6 +937,28 @@ trait MethodsFixturesImpl { this: MacroCommons =>
     )
   }
 
+  // Issue #348: type-position annotations must ALSO survive the caseFields / knownReturning path (each case-field
+  // GETTER's return type), not only the primaryConstructor.totalParameters path exercised by testTypeAnnotations.
+  def testTypeAnnotationsViaKnownReturning[A: Type]: Expr[Data] = {
+    def annNames(anns: List[Expr_??]): Data = Data.list(anns.map { ann =>
+      if (ann.Underlying =:= Type.of[hearth.examples.methods.ExampleAnnotation2]) Data("ExampleAnnotation2")
+      else if (ann.Underlying =:= Type.of[hearth.examples.methods.ExampleAnnotation]) Data("ExampleAnnotation")
+      else Data(ann.Underlying.plainPrint)
+    }*)
+
+    val fields = CaseClass.parse[A].toOption.toList.flatMap(_.caseFields).flatMap { method =>
+      method.knownReturning.map { rt =>
+        import rt.Underlying as FieldTpe
+        Data.map(
+          "name" -> Data(method.name),
+          "typeAnnotations" -> annNames(Type.typeAnnotations[FieldTpe])
+        )
+      }
+    }
+
+    Expr(Data.list(fields*))
+  }
+
   private def renderParameterAnnotations(parameters: Parameters): Data = {
     val rendered = parameters.flatten.map { case (paramName, param) =>
       val annotations = param.annotations.flatMap { ann =>

--- a/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/MethodsSpec.scala
@@ -2631,6 +2631,20 @@ final class MethodsSpec extends MacroSuite {
         )
       )
     }
+
+    test("type-position annotations survive the caseFields / knownReturning path (#348)") {
+      import MethodsFixtures.testTypeAnnotationsViaKnownReturning
+
+      testTypeAnnotationsViaKnownReturning[examples.methods.WithTypeAnnotations] <==> Data.list(
+        Data.map("name" -> Data("name"), "typeAnnotations" -> Data.list(Data("ExampleAnnotation"))),
+        Data.map("name" -> Data("age"), "typeAnnotations" -> Data.list()),
+        Data.map(
+          "name" -> Data("nickname"),
+          "typeAnnotations" -> Data.list(Data("ExampleAnnotation"), Data("ExampleAnnotation2"))
+        )
+      )
+    }
+
   }
 
   group("methods: parameter annotations") {

--- a/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/untyped/UntypedMethodsScala2.scala
@@ -601,8 +601,19 @@ trait UntypedMethodsScala2 extends UntypedMethods { this: MacroCommonsScala2 =>
           case ExistentialType(_, underlying) => underlying
           case other                          => other
         }
+        // `typeSignatureIn` (as-seen-from applied to the whole NullaryMethodType) DROPS type-position annotations
+        // (`AnnotatedType`, e.g. `String @Ann` on a case-field getter) from the result on Scala 2.13 - see
+        // [hearth#348], where they survive the constructor-parameter path but not this getter/`knownReturning` one.
+        // The raw `typeSignature` keeps them, so recover the annotations from ITS result type and re-apply
+        // `asSeenFrom` to the underlying (preserving prefix/type-param substitution); non-annotated results keep the
+        // instantiated signature's result unchanged.
+        val resultType = untyped.symbol.typeSignature.finalResultType match {
+          case AnnotatedType(annots, underlying) =>
+            internal.annotatedType(annots, underlying.asSeenFrom(instanceTpe, untyped.symbol.owner))
+          case _ => sig.finalResultType
+        }
         // E.g. the case-field accessor of a vararg parameter would otherwise return `scala.<repeated>[A]`.
-        normalizeRepeatedParamType(sig.finalResultType.dealias).as_??
+        normalizeRepeatedParamType(resultType.dealias).as_??
       }
       val returnType: Option[() => ??] =
         if (hasUnresolvedTypeParams) None


### PR DESCRIPTION
## Problem

`Type.typeAnnotations[FieldType]` returned an empty list for a case-class field's type-position annotation (`name: String @Action(...)`) when the field type was obtained via the **`caseFields` / `knownReturning`** path (the case-field getter's return type). Reported in #348.

## Diagnosis

The getter's return type is resolved via `Symbol.typeSignatureIn(instanceTpe)`, whose as-seen-from over the whole `NullaryMethodType` **drops type-position annotations** (`AnnotatedType`, e.g. `String @Ann` → `String`) on Scala 2.13. The raw `typeSignature` retains them.

Key findings (raw-reflection probes on both versions):

- **Version-independent**, not a 2.13.18 regression — `typeSignatureIn` strips the annotation identically on **2.13.16 and 2.13.18**. It was simply never tested.
- The **constructor-parameter path was never broken** — it resolves a *term* symbol, which keeps the annotation, so the existing #306 test passes on both versions. Only the `caseFields`/`knownReturning` route was affected.
- **Scala 3 is unaffected** — `safeMemberType`/`widenByName` preserves `AnnotatedType`.

## Fix

In `UntypedMethodsScala2.resolvedReturnType`, recover the annotations from the raw `typeSignature`'s result type and re-apply `asSeenFrom` to the underlying (preserving prefix/type-param substitution). Non-annotated results are unchanged.

## Tests

Adds a cross-platform regression test exercising the getter/`knownReturning` path (fails before, passes after).

## Known limitation (out of scope)

A type annotation on a **generic type-parameter** field (`value: T @Ann` in `Box[T]`) is still dropped on both paths — a separate, deeper Scala 2 reflection limitation (as-seen-from drops annotations when substituting a type parameter). Not what #348 reports; left as a documented follow-up rather than a risky change to the hot constructor path.

## Verification

| Version | Result |
|---|---|
| 2.13.16 | full suite 1198/0; #306+#348 pass |
| 3.3.8 | full suite 1323/0; #306+#348 pass |
| 2.13.18 | #306+#348 pass |
| scalafmt | clean |

Closes #348.