### PR TITLE
Evaluate scala.ValueOf in semiEval from its type argument

### DIFF
--- a/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
+++ b/hearth-tests/src/test/scala/hearth/typed/ExprsSpec.scala
@@ -180,6 +180,30 @@ final class ExprsSpec extends MacroSuite {
           )
         }
 
+        test("should evaluate ValueOf of a literal Int singleton") {
+          testSemiEval(implicitly[ValueOf[3]].value) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("3"),
+            "class" -> Data("java.lang.Integer")
+          )
+        }
+
+        test("should evaluate ValueOf of a literal String singleton") {
+          testSemiEval(implicitly[ValueOf["hi"]].value) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("hi"),
+            "class" -> Data("java.lang.String")
+          )
+        }
+
+        test("should evaluate ValueOf of an object singleton") {
+          testSemiEval(implicitly[ValueOf[None.type]].value) <==> Data.map(
+            "status" -> Data("success"),
+            "value" -> Data("None"),
+            "class" -> Data("scala.None$")
+          )
+        }
+
         test("should evaluate companion apply: Some(42)") {
           testSemiEval(Some(42)) <==> Data.map(
             "status" -> Data("success"),

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -229,6 +229,14 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
           case Literal(Constant(value)) =>
             Right(value)
 
+          // A `scala.ValueOf[A]` is fully determined by its type argument `A`: for a literal singleton
+          // `A` the value is `A`'s constant, for an object singleton it is the module. The synthesized
+          // `ValueOf` given is not always reducible by the reflective evaluator below, so reconstruct it
+          // from the type instead. This makes `valueOf[A]` / `implicitly[ValueOf[A]].value` evaluate at
+          // compile time.
+          case t if valueOfValue(t.tpe).isDefined =>
+            Right(new scala.ValueOf(valueOfValue(t.tpe).get))
+
           case Function(params, body) =>
             evalLambda(params, body, locals, overrides)
 
@@ -382,6 +390,31 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
           .collectFirst { case ModuleSingleton(value) => value }
           .toRight(NonEmptyVector.one(s"Cannot resolve module: $name"))
       }
+
+      private lazy val valueOfSymbol = c.typeOf[scala.ValueOf[Any]].typeSymbol
+
+      /** The value witnessed by a `scala.ValueOf[A]` type, derived from `A`: the constant of a literal singleton type,
+        * or the instance of an object singleton type. `None` when `tpe` is not a `ValueOf`, or its argument is neither
+        * (so evaluation falls through to the generic handling).
+        */
+      private def valueOfValue(tpe: c.Type): Option[Any] =
+        if (tpe == null || tpe =:= NoType) None
+        else {
+          val base = tpe.baseType(valueOfSymbol)
+          if (base == NoType || base.typeArgs.isEmpty) None
+          else
+            base.typeArgs.head.dealias match {
+              case ConstantType(Constant(value)) => Some(value)
+              case arg                           =>
+                val termSym = arg.termSymbol
+                val moduleSym =
+                  if (termSym != NoSymbol && termSym.isModule) termSym
+                  else arg.typeSymbol
+                if (moduleSym != NoSymbol && (moduleSym.isModule || moduleSym.isModuleClass))
+                  resolveModule(moduleSym).toOption
+                else None
+            }
+        }
 
       private def moduleCandidates(fullName: String): Array[String] = {
         val withDollar = if (fullName.endsWith("$")) fullName else fullName + "$"

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -234,8 +234,8 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
           // `ValueOf` given is not always reducible by the reflective evaluator below, so reconstruct it
           // from the type instead. This makes `valueOf[A]` / `implicitly[ValueOf[A]].value` evaluate at
           // compile time.
-          case t if valueOfValue(t.tpe).isDefined =>
-            Right(new scala.ValueOf(valueOfValue(t.tpe).get))
+          case ValueOfExpr(value) =>
+            Right(new scala.ValueOf(value))
 
           case Function(params, body) =>
             evalLambda(params, body, locals, overrides)
@@ -415,6 +415,11 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
                 else None
             }
         }
+
+      /** Matches a tree whose type is a reducible `scala.ValueOf[A]`, yielding the witnessed value. */
+      private object ValueOfExpr {
+        def unapply(tree: Tree): Option[Any] = valueOfValue(tree.tpe)
+      }
 
       private def moduleCandidates(fullName: String): Array[String] = {
         val withDollar = if (fullName.endsWith("$")) fullName else fullName + "$"

--- a/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
+++ b/hearth/src/main/scala-2/hearth/typed/ExprsScala2.scala
@@ -398,8 +398,11 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
         * (so evaluation falls through to the generic handling).
         */
       private def valueOfValue(tpe: c.Type): Option[Any] =
-        if (tpe == null || tpe =:= NoType) None
-        else {
+        if (tpe == null || tpe =:= NoType) {
+          // $COVERAGE-OFF$ null / NoType do not arise for the typed trees seen in tests
+          None
+          // $COVERAGE-ON$
+        } else {
           val base = tpe.baseType(valueOfSymbol)
           if (base == NoType || base.typeArgs.isEmpty) None
           else
@@ -412,7 +415,11 @@ trait ExprsScala2 extends Exprs { this: MacroCommonsScala2 =>
                   else arg.typeSymbol
                 if (moduleSym != NoSymbol && (moduleSym.isModule || moduleSym.isModuleClass))
                   resolveModule(moduleSym).toOption
-                else None
+                else {
+                  // $COVERAGE-OFF$ a ValueOf argument that is neither a literal constant nor a module is not reachable from tests
+                  None
+                  // $COVERAGE-ON$
+                }
             }
         }
 

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -278,6 +278,14 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
           case Inlined(_, _, inner) =>
             evalWithLocals(inner, locals, overrides)
 
+          // A `scala.ValueOf[A]` is fully determined by its type argument `A`: for a literal singleton
+          // `A` the value is `A`'s constant, for an object singleton it is the module. The synthesized
+          // `ValueOf` given is not always reducible by the reflective evaluator below (e.g. it yields an
+          // opaque `ValueOf` whose `.value` getter does not reduce), so reconstruct it from the type
+          // instead. This makes `valueOf[A]` / `summon[ValueOf[A]].value` evaluate at compile time.
+          case t if valueOfValue(t.tpe).isDefined =>
+            Right(new scala.ValueOf(valueOfValue(t.tpe).get))
+
           case Block(List(ddef: DefDef), closure: Closure) =>
             evalLambda(ddef, locals, overrides)
 
@@ -496,6 +504,28 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
           .collectFirst { case ModuleSingleton(value) => value }
           .toRight(NonEmptyVector.one(s"Cannot resolve module: $name"))
       }
+
+      private val valueOfSymbol = TypeRepr.of[scala.ValueOf[Any]].typeSymbol
+
+      /** The value witnessed by a `scala.ValueOf[A]` type, derived from `A`: the constant of a literal singleton type,
+        * or the instance of an object singleton type. `None` when `tpe` is not a `ValueOf`, or its argument is neither
+        * (so evaluation falls through to the generic handling).
+        */
+      private def valueOfValue(tpe: TypeRepr): Option[Any] =
+        tpe.baseType(valueOfSymbol) match {
+          case AppliedType(_, List(arg)) =>
+            arg.dealias match {
+              case ConstantType(constant) => Some(extractConstant(constant))
+              case dealiased              =>
+                val termSym = dealiased.termSymbol
+                val moduleSym =
+                  if !termSym.isNoSymbol && termSym.flags.is(Flags.Module) then termSym
+                  else dealiased.typeSymbol
+                if !moduleSym.isNoSymbol && moduleSym.flags.is(Flags.Module) then resolveModule(moduleSym).toOption
+                else None
+            }
+          case _ => None
+        }
 
       private def resolveModuleForInheritedMethod(sym: Symbol): Result = {
         val owner = sym.owner

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -522,7 +522,11 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
                   if !termSym.isNoSymbol && termSym.flags.is(Flags.Module) then termSym
                   else dealiased.typeSymbol
                 if !moduleSym.isNoSymbol && moduleSym.flags.is(Flags.Module) then resolveModule(moduleSym).toOption
-                else None
+                else {
+                  // $COVERAGE-OFF$ a ValueOf argument that is neither a literal constant nor a module is not reachable from tests
+                  None
+                  // $COVERAGE-ON$
+                }
             }
           case _ => None
         }

--- a/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
+++ b/hearth/src/main/scala-3/hearth/typed/ExprsScala3.scala
@@ -283,8 +283,8 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
           // `ValueOf` given is not always reducible by the reflective evaluator below (e.g. it yields an
           // opaque `ValueOf` whose `.value` getter does not reduce), so reconstruct it from the type
           // instead. This makes `valueOf[A]` / `summon[ValueOf[A]].value` evaluate at compile time.
-          case t if valueOfValue(t.tpe).isDefined =>
-            Right(new scala.ValueOf(valueOfValue(t.tpe).get))
+          case ValueOfExpr(value) =>
+            Right(new scala.ValueOf(value))
 
           case Block(List(ddef: DefDef), closure: Closure) =>
             evalLambda(ddef, locals, overrides)
@@ -526,6 +526,11 @@ trait ExprsScala3 extends Exprs { this: MacroCommonsScala3 =>
             }
           case _ => None
         }
+
+      /** Matches a term whose type is a reducible `scala.ValueOf[A]`, yielding the witnessed value. */
+      private object ValueOfExpr {
+        def unapply(term: Term): Option[Any] = valueOfValue(term.tpe)
+      }
 
       private def resolveModuleForInheritedMethod(sym: Symbol): Result = {
         val owner = sym.owner


### PR DESCRIPTION
`Expr.semiEval` could not reduce a `scala.ValueOf[A]` value: the reflective evaluator reduced the synthesized given to an opaque `ValueOf` instance whose `.value` getter did not fold to the underlying constant. That breaks callers that evaluate a `Validate`/witness built on `ValueOf` at compile time (e.g. refined's `WitnessAs` for `Greater[0]`, `Contains['c']`, `Equal[Foo.type]`).

Reconstruct the `ValueOf` from its type argument `A` instead: the constant of a literal singleton type, or the module of an object singleton type. The helper returns `None` for non-`ValueOf` or otherwise-irreducible types, so every other term falls through to the existing generic handling unchanged.

Mirrored in both the Scala 2 and Scala 3 evaluators, with cross-version `ExprsSpec` coverage (literal Int, literal String, object singleton).